### PR TITLE
Used kotlin duration

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialOfferRequestResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialOfferRequestResolver.kt
@@ -20,7 +20,7 @@ import io.ktor.http.*
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import java.io.Serializable
-import java.time.Duration
+import kotlin.time.Duration
 
 /**
  * A Credential Offer.
@@ -80,7 +80,9 @@ sealed interface Grants : java.io.Serializable {
         val issuerState: String? = null,
     ) : Grants {
         init {
-            require(!(issuerState?.isBlank() ?: false)) { "issuerState cannot be blank" }
+            issuerState?.let {
+                require(issuerState.isNotBlank()) { "issuerState cannot be blank" }
+            }
         }
     }
 
@@ -90,10 +92,11 @@ sealed interface Grants : java.io.Serializable {
     data class PreAuthorizedCode(
         val preAuthorizedCode: String,
         val pinRequired: Boolean = false,
-        val interval: Duration = Duration.ofSeconds(5L),
+        val interval: Duration,
     ) : Grants {
         init {
             require(preAuthorizedCode.isNotBlank()) { "preAuthorizedCode cannot be blank" }
+            require(interval.isPositive()) { "interval cannot be negative or zero" }
         }
     }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/credentialoffer/DefaultCredentialOfferRequestResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/credentialoffer/DefaultCredentialOfferRequestResolver.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.*
-import java.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * A default implementation for [CredentialOfferRequestResolver].
@@ -93,7 +93,7 @@ internal class DefaultCredentialOfferRequestResolver(
                     Grants.PreAuthorizedCode(
                         it.preAuthorizedCode,
                         it.pinRequired ?: false,
-                        it.interval?.let { interval -> Duration.ofSeconds(interval) } ?: Duration.ofSeconds(5L),
+                        it.interval?.seconds ?: 5.seconds,
                     )
                 }
 


### PR DESCRIPTION
This PR
Uses Kotlin's `Duration` instead of Java's `Duration`.

This leverages a nice DSL, where we can say `5.seconds`