### PR TITLE
Add findByFormat() & findScopeForMsoMdoc()

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialIssuerMetadataResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialIssuerMetadataResolver.kt
@@ -60,6 +60,10 @@ data class CredentialIssuerMetadata(
         require(credentialsSupported.isNotEmpty()) { "credentialsSupported must not be empty" }
     }
 
+    inline fun <reified T : CredentialSupported> findByFormat(predicate: (T) -> Boolean): Map<CredentialIdentifier, T> {
+        return credentialsSupported.mapNotNull { (k, v) -> if (v is T && predicate(v)) k to v else null }.toMap()
+    }
+
     /**
      * The display properties of the Credential Issuer.
      */

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/formats/MsoMdoc.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/formats/MsoMdoc.kt
@@ -29,6 +29,9 @@ import kotlinx.serialization.*
 import kotlinx.serialization.json.*
 import java.util.*
 
+fun CredentialIssuerMetadata.findScopeForMsoMdoc(docType: String): String? =
+    findByFormat<MsoMdoc.Model.CredentialSupported> { it.docType == docType }.values.firstOrNull()?.scope
+
 internal data object MsoMdoc : Format<MsoMdoc.Model.CredentialSupported, MsoMdoc.Model.CredentialIssuanceRequest> {
 
     const val FORMAT = "mso_mdoc"


### PR DESCRIPTION
This PR 

- Adds a way to query CredentialIssuerMetadata for a specific format 

- Adds a method to query for the scope of an MSO_MDOC given its doctype