### PR TITLE
Add locations to authorization_details

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/AuthorizeIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/AuthorizeIssuanceImpl.kt
@@ -25,7 +25,12 @@ internal class AuthorizeIssuanceImpl(
 ) : AuthorizeIssuance {
 
     private val authServerClient: AuthorizationServerClient =
-        AuthorizationServerClient(credentialOffer.authorizationServerMetadata, config, ktorHttpClientFactory)
+        AuthorizationServerClient(
+            credentialOffer.credentialIssuerIdentifier,
+            credentialOffer.authorizationServerMetadata,
+            config,
+            ktorHttpClientFactory,
+        )
 
     override suspend fun prepareAuthorizationRequest(): Result<AuthorizationRequestPrepared> = runCatching {
         val (scopes, configurationIds) = scopesAndCredentialConfigurationIds()


### PR DESCRIPTION
This PR adds the attribute `locations` to an `authorization_details` object in case the credential issuer is not the authorization server. That is, in case the credential issuer uses an external authorization server.

Closes #200 