### PR TITLE
Add missing check of the state returned by auth. server

### DIFF
--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceAuthorizationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceAuthorizationTest.kt
@@ -135,8 +135,9 @@ class IssuanceAuthorizationTest {
             with(issuer) {
                 val authRequestPrepared = prepareAuthorizationRequest().getOrThrow().also { println(it) }
                 val authorizationCode = UUID.randomUUID().toString()
+                val serverState = authRequestPrepared.state // dummy don't use it
                 authRequestPrepared
-                    .authorizeWithAuthorizationCode(AuthorizationCode(authorizationCode))
+                    .authorizeWithAuthorizationCode(AuthorizationCode(authorizationCode), serverState)
                     .also { println(it) }
             }
         }
@@ -218,8 +219,9 @@ class IssuanceAuthorizationTest {
             with(issuer) {
                 val authRequestPrepared = prepareAuthorizationRequest().getOrThrow().also { println(it) }
                 val authorizationCode = UUID.randomUUID().toString()
+                val serverState = authRequestPrepared.state
                 authRequestPrepared
-                    .authorizeWithAuthorizationCode(AuthorizationCode(authorizationCode))
+                    .authorizeWithAuthorizationCode(AuthorizationCode(authorizationCode), serverState)
                     .also { println(it) }
             }
         }
@@ -457,8 +459,10 @@ class IssuanceAuthorizationTest {
             ).getOrThrow()
 
             with(issuer) {
-                val authorizedRequest = prepareAuthorizationRequest().getOrThrow()
-                    .authorizeWithAuthorizationCode(AuthorizationCode("auth-code"))
+                val prepareAuthorizationRequest = prepareAuthorizationRequest().getOrThrow()
+                val serverState = prepareAuthorizationRequest.state
+                val authorizedRequest = prepareAuthorizationRequest
+                    .authorizeWithAuthorizationCode(AuthorizationCode("auth-code"), serverState)
                     .getOrThrow()
 
                 assertTrue("Token endpoint provides c_nonce but authorized request is not ProofRequired") {
@@ -515,8 +519,10 @@ class IssuanceAuthorizationTest {
             ).getOrThrow()
 
             with(issuer) {
-                val authorizedRequest = prepareAuthorizationRequest().getOrThrow()
-                    .authorizeWithAuthorizationCode(AuthorizationCode("auth-code"))
+                val authorizationRequestPrepared = prepareAuthorizationRequest().getOrThrow()
+                val serverState = authorizationRequestPrepared.state
+                val authorizedRequest = authorizationRequestPrepared
+                    .authorizeWithAuthorizationCode(AuthorizationCode("auth-code"), serverState)
                     .getOrThrow()
 
                 assertTrue("Offer does not require proofs but authorized request is ProofRequired instead of NoProofRequired") {
@@ -559,8 +565,10 @@ class IssuanceAuthorizationTest {
             ).getOrThrow()
 
             with(issuer) {
-                val authorizedRequest = prepareAuthorizationRequest().getOrThrow()
-                    .authorizeWithAuthorizationCode(AuthorizationCode("auth-code"))
+                val authorizationRequestPrepared = prepareAuthorizationRequest().getOrThrow()
+                val serverState = authorizationRequestPrepared.state
+                val authorizedRequest = authorizationRequestPrepared
+                    .authorizeWithAuthorizationCode(AuthorizationCode("auth-code"), serverState)
                     .getOrThrow()
 
                 assertTrue("Expected authorized request to be of type NoProofRequired but is ProofRequired") {
@@ -648,8 +656,9 @@ class IssuanceAuthorizationTest {
             with(issuer) {
                 val parPlaced = prepareAuthorizationRequest().getOrThrow()
                 val authorizationCode = UUID.randomUUID().toString()
+                val serverState = parPlaced.state
                 parPlaced
-                    .authorizeWithAuthorizationCode(AuthorizationCode(authorizationCode))
+                    .authorizeWithAuthorizationCode(AuthorizationCode(authorizationCode), serverState)
                     .fold(
                         onSuccess = {
                             fail("Exception expected to be thrown")

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
@@ -86,7 +86,8 @@ suspend fun authorizeRequestForCredentialOffer(
     val authorizedRequest = with(issuer) {
         val authRequestPrepared = prepareAuthorizationRequest().getOrThrow()
         val authorizationCode = UUID.randomUUID().toString()
-        authRequestPrepared.authorizeWithAuthorizationCode(AuthorizationCode(authorizationCode)).getOrThrow()
+        val serverState = authRequestPrepared.state
+        authRequestPrepared.authorizeWithAuthorizationCode(AuthorizationCode(authorizationCode), serverState).getOrThrow()
     }
     return Triple(offer, authorizedRequest, issuer)
 }


### PR DESCRIPTION
This PR closes #205 

- Adds missing check of the `state` returned by the authorization server, during auth. code flow.
- Allows the wallet to provide a `state` to be included in the authorization request. If not provided, a random value will be used

Unfortunately, this PR introduces a small breaking change to the library public facade.

In particular the method `authorizeWithAuthorizationCode` which was accepting a single parameter (`authorizationCode`), now will have an additional `serverState`. 

So, wallet after user authorization (on the auth. server side), must provide the `authorization_code` & the `state`
returned by the server.

```kotlin

 suspend fun AuthorizationRequestPrepared.authorizeWithAuthorizationCode(
        authorizationCode: AuthorizationCode,
        serverState: String,
    ): Result<AuthorizedRequest>
```
