### PR TITLE
Reorganize OAUTH2 & Credential Issuer HTTP clients

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
@@ -92,13 +92,18 @@ interface Issuer : AuthorizeIssuance, RequestIssuance, QueryForDeferredCredentia
                 ktorHttpClientFactory,
                 dPoPJwtFactory,
             )
+            val responseEncryptionSpec =
+                responseEncryptionSpec(credentialOffer, config, responseEncryptionSpecFactory).getOrThrow()
             val requestIssuance = RequestIssuanceImpl(
                 credentialOffer,
                 config,
                 issuanceServerClient,
-                responseEncryptionSpecFactory,
-            ).getOrThrow()
-            val queryForDeferredCredential = QueryForDeferredCredentialImpl(issuanceServerClient)
+                responseEncryptionSpec,
+            )
+            val queryForDeferredCredential = QueryForDeferredCredentialImpl(
+                issuanceServerClient,
+                responseEncryptionSpec,
+            )
             val notifyIssuer = NotifyIssuerImpl(issuanceServerClient)
 
             object :

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
@@ -17,6 +17,7 @@ package eu.europa.ec.eudi.openid4vci
 
 import eu.europa.ec.eudi.openid4vci.internal.*
 import eu.europa.ec.eudi.openid4vci.internal.RequestIssuanceImpl
+import eu.europa.ec.eudi.openid4vci.internal.http.IssuanceServerClient
 import io.ktor.client.*
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/AuthorizeIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/AuthorizeIssuanceImpl.kt
@@ -18,6 +18,14 @@ package eu.europa.ec.eudi.openid4vci.internal
 import com.nimbusds.oauth2.sdk.id.State
 import eu.europa.ec.eudi.openid4vci.*
 import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.*
+import eu.europa.ec.eudi.openid4vci.internal.http.AuthorizationServerClient
+
+internal data class TokenResponse(
+    val accessToken: AccessToken,
+    val refreshToken: RefreshToken?,
+    val cNonce: CNonce?,
+    val authorizationDetails: Map<CredentialConfigurationIdentifier, List<CredentialIdentifier>> = emptyMap(),
+)
 
 internal class AuthorizeIssuanceImpl(
     private val credentialOffer: CredentialOffer,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialIssuanceRequest.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialIssuanceRequest.kt
@@ -13,13 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package eu.europa.ec.eudi.openid4vci.internal.formats
+package eu.europa.ec.eudi.openid4vci.internal
 
 import eu.europa.ec.eudi.openid4vci.*
 import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.InvalidIssuanceRequest
-import eu.europa.ec.eudi.openid4vci.internal.Proof
-import eu.europa.ec.eudi.openid4vci.internal.ensure
-import eu.europa.ec.eudi.openid4vci.internal.ensureNotNull
 
 internal sealed interface CredentialType {
     data class MsoMdocDocType(val doctype: String, val claimSet: MsoMdocClaimSet?) : CredentialType

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/DefaultCredentialIssuerMetadataResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/DefaultCredentialIssuerMetadataResolver.kt
@@ -20,7 +20,7 @@ import eu.europa.ec.eudi.openid4vci.CredentialIssuerMetadata
 import eu.europa.ec.eudi.openid4vci.CredentialIssuerMetadataError
 import eu.europa.ec.eudi.openid4vci.CredentialIssuerMetadataResolver
 import eu.europa.ec.eudi.openid4vci.CredentialIssuerMetadataValidationError.InvalidCredentialIssuerId
-import eu.europa.ec.eudi.openid4vci.internal.formats.CredentialIssuerMetadataJsonParser
+import eu.europa.ec.eudi.openid4vci.internal.http.CredentialIssuerMetadataJsonParser
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/IssuanceServerClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/IssuanceServerClient.kt
@@ -24,7 +24,6 @@ import com.nimbusds.jwt.proc.DefaultJWTProcessor
 import eu.europa.ec.eudi.openid4vci.*
 import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.*
 import eu.europa.ec.eudi.openid4vci.internal.formats.CredentialIssuanceRequest
-import eu.europa.ec.eudi.openid4vci.internal.formats.DeferredRequestJsonMapper
 import eu.europa.ec.eudi.openid4vci.internal.formats.IssuanceRequestJsonMapper
 import io.ktor.client.call.*
 import io.ktor.client.request.*
@@ -171,7 +170,7 @@ internal class IssuanceServerClient(
         ensureNotNull(issuerMetadata.deferredCredentialEndpoint) { IssuerDoesNotSupportDeferredIssuance }
         ktorHttpClientFactory().use { client ->
             val url = issuerMetadata.deferredCredentialEndpoint.value.value
-            val request = DeferredRequestJsonMapper.asJson(deferredCredential, responseEncryptionSpec)
+            val request = IssuanceRequestJsonMapper.asJson(deferredCredential, responseEncryptionSpec)
             val response = client.post(url) {
                 bearerOrDPoPAuth(dPoPJwtFactory, url, Htm.POST, accessToken)
                 contentType(ContentType.Application.Json)

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/NotifyIssuerImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/NotifyIssuerImpl.kt
@@ -16,6 +16,7 @@
 package eu.europa.ec.eudi.openid4vci.internal
 
 import eu.europa.ec.eudi.openid4vci.*
+import eu.europa.ec.eudi.openid4vci.internal.http.IssuanceServerClient
 
 internal class NotifyIssuerImpl(
     private val issuanceServerClient: IssuanceServerClient,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/QueryForDeferredCredentialImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/QueryForDeferredCredentialImpl.kt
@@ -16,6 +16,7 @@
 package eu.europa.ec.eudi.openid4vci.internal
 
 import eu.europa.ec.eudi.openid4vci.*
+import eu.europa.ec.eudi.openid4vci.internal.http.IssuanceServerClient
 
 internal class QueryForDeferredCredentialImpl(
     private val issuanceServerClient: IssuanceServerClient,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/QueryForDeferredCredentialImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/QueryForDeferredCredentialImpl.kt
@@ -19,10 +19,11 @@ import eu.europa.ec.eudi.openid4vci.*
 
 internal class QueryForDeferredCredentialImpl(
     private val issuanceServerClient: IssuanceServerClient,
+    private val responseEncryptionSpec: IssuanceResponseEncryptionSpec?,
 ) : QueryForDeferredCredential {
 
     override suspend fun AuthorizedRequest.queryForDeferredCredential(
         deferredCredential: IssuedCredential.Deferred,
     ): Result<DeferredCredentialQueryOutcome> =
-        issuanceServerClient.placeDeferredCredentialRequest(accessToken, deferredCredential.transactionId)
+        issuanceServerClient.placeDeferredCredentialRequest(accessToken, deferredCredential, responseEncryptionSpec)
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -17,6 +17,7 @@ package eu.europa.ec.eudi.openid4vci.internal
 
 import eu.europa.ec.eudi.openid4vci.*
 import eu.europa.ec.eudi.openid4vci.internal.formats.CredentialIssuanceRequest
+import eu.europa.ec.eudi.openid4vci.internal.http.IssuanceServerClient
 
 internal class RequestIssuanceImpl(
     private val credentialOffer: CredentialOffer,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -19,7 +19,7 @@ import eu.europa.ec.eudi.openid4vci.*
 import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.ResponseEncryptionError.*
 import eu.europa.ec.eudi.openid4vci.internal.formats.CredentialIssuanceRequest
 
-internal class RequestIssuanceImpl private constructor(
+internal class RequestIssuanceImpl(
     private val credentialOffer: CredentialOffer,
     private val config: OpenId4VCIConfig,
     private val issuanceServerClient: IssuanceServerClient,
@@ -169,81 +169,6 @@ internal class RequestIssuanceImpl private constructor(
                     onFailure = { handleIssuanceFailure(it) },
                 )
             }
-        }
-    }
-
-    companion object {
-        operator fun invoke(
-            credentialOffer: CredentialOffer,
-            config: OpenId4VCIConfig,
-            issuanceServerClient: IssuanceServerClient,
-            responseEncryptionSpecFactory: ResponseEncryptionSpecFactory,
-        ): Result<RequestIssuanceImpl> = runCatching {
-            val responseEncryptionSpec =
-                responseEncryptionSpec(credentialOffer, config, responseEncryptionSpecFactory).getOrThrow()
-            RequestIssuanceImpl(credentialOffer, config, issuanceServerClient, responseEncryptionSpec)
-        }
-    }
-}
-
-private fun responseEncryptionSpec(
-    credentialOffer: CredentialOffer,
-    config: OpenId4VCIConfig,
-    responseEncryptionSpecFactory: ResponseEncryptionSpecFactory,
-): Result<IssuanceResponseEncryptionSpec?> = runCatching {
-    fun IssuanceResponseEncryptionSpec.validate(
-        supportedAlgorithmsAndMethods: SupportedEncryptionAlgorithmsAndMethods,
-    ) {
-        ensure(algorithm in supportedAlgorithmsAndMethods.algorithms) {
-            ResponseEncryptionAlgorithmNotSupportedByIssuer
-        }
-        ensure(encryptionMethod in supportedAlgorithmsAndMethods.encryptionMethods) {
-            ResponseEncryptionMethodNotSupportedByIssuer
-        }
-    }
-
-    when (val encryption = credentialOffer.credentialIssuerMetadata.credentialResponseEncryption) {
-        CredentialResponseEncryption.NotSupported ->
-            // Issuance server does not support Credential Response encryption.
-            // In case Wallet requires Credential Response encryption, fail.
-            when (config.credentialResponseEncryptionPolicy) {
-                CredentialResponseEncryptionPolicy.SUPPORTED -> null
-                CredentialResponseEncryptionPolicy.REQUIRED -> throw ResponseEncryptionRequiredByWalletButNotSupportedByIssuer
-            }
-
-        is CredentialResponseEncryption.SupportedNotRequired -> {
-            // Issuance server supports but does not require Credential Response encryption.
-            // Fail in case Wallet requires Credential Response encryption but no crypto material can be generated,
-            // or in case algorithm/method supported by Wallet is not supported by issuance server.
-            val supportedAlgorithmsAndMethods = encryption.encryptionAlgorithmsAndMethods
-            val maybeSpec = runCatching {
-                responseEncryptionSpecFactory(supportedAlgorithmsAndMethods, config.keyGenerationConfig)
-                    ?.apply {
-                        validate(supportedAlgorithmsAndMethods)
-                    }
-            }.getOrNull()
-
-            when (config.credentialResponseEncryptionPolicy) {
-                CredentialResponseEncryptionPolicy.SUPPORTED -> maybeSpec
-
-                CredentialResponseEncryptionPolicy.REQUIRED -> {
-                    ensureNotNull(maybeSpec) {
-                        WalletRequiresCredentialResponseEncryptionButNoCryptoMaterialCanBeGenerated
-                    }
-                }
-            }
-        }
-
-        is CredentialResponseEncryption.Required -> {
-            // Issuance server requires Credential Response encryption.
-            // Fail in case Wallet does not support Credential Response encryption or,
-            // algorithms/methods supported by Wallet are not supported by issuance server.
-            val supportedAlgorithmsAndMethods = encryption.encryptionAlgorithmsAndMethods
-            val maybeSpec = responseEncryptionSpecFactory(supportedAlgorithmsAndMethods, config.keyGenerationConfig)
-                ?.apply {
-                    validate(supportedAlgorithmsAndMethods)
-                }
-            ensureNotNull(maybeSpec) { IssuerExpectsResponseEncryptionCryptoMaterialButNotProvided }
         }
     }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -16,7 +16,6 @@
 package eu.europa.ec.eudi.openid4vci.internal
 
 import eu.europa.ec.eudi.openid4vci.*
-import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.ResponseEncryptionError.*
 import eu.europa.ec.eudi.openid4vci.internal.formats.CredentialIssuanceRequest
 
 internal class RequestIssuanceImpl(
@@ -25,6 +24,7 @@ internal class RequestIssuanceImpl(
     private val issuanceServerClient: IssuanceServerClient,
     private val responseEncryptionSpec: IssuanceResponseEncryptionSpec?,
 ) : RequestIssuance {
+
     override suspend fun AuthorizedRequest.NoProofRequired.requestSingle(
         requestPayload: IssuanceRequestPayload,
     ): Result<SubmittedRequest> = runCatching {
@@ -49,7 +49,7 @@ internal class RequestIssuanceImpl(
             val credentialRequests = credentialsMetadata.map {
                 singleRequest(it, null, credentialIdentifiers)
             }
-            CredentialIssuanceRequest.BatchRequest(credentialRequests)
+            CredentialIssuanceRequest.BatchRequest(credentialRequests, responseEncryptionSpec)
         }
     }
 
@@ -60,7 +60,7 @@ internal class RequestIssuanceImpl(
             val credentialRequests = credentialsMetadata.map { (requestPayload, proofSigner) ->
                 singleRequest(requestPayload, proofFactory(proofSigner, cNonce), credentialIdentifiers)
             }
-            CredentialIssuanceRequest.BatchRequest(credentialRequests)
+            CredentialIssuanceRequest.BatchRequest(credentialRequests, responseEncryptionSpec)
         }
     }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -16,8 +16,21 @@
 package eu.europa.ec.eudi.openid4vci.internal
 
 import eu.europa.ec.eudi.openid4vci.*
-import eu.europa.ec.eudi.openid4vci.internal.formats.CredentialIssuanceRequest
 import eu.europa.ec.eudi.openid4vci.internal.http.IssuanceServerClient
+
+/**
+ * Models a response of the issuer to a successful issuance request.
+ *
+ * @param credentials The outcome of the issuance request.
+ * if the issuance request was a batch request, it will contain
+ * the results of each issuance request.
+ * If it was a single issuance request list will contain only one result.
+ * @param cNonce Nonce information sent back from the issuance server.
+ */
+internal data class CredentialIssuanceResponse(
+    val credentials: List<IssuedCredential>,
+    val cNonce: CNonce?,
+)
 
 internal class RequestIssuanceImpl(
     private val credentialOffer: CredentialOffer,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/ResponseEncryption.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/ResponseEncryption.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.openid4vci.internal
+
+import eu.europa.ec.eudi.openid4vci.*
+import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.ResponseEncryptionError.*
+
+internal fun responseEncryptionSpec(
+    credentialOffer: CredentialOffer,
+    config: OpenId4VCIConfig,
+    responseEncryptionSpecFactory: ResponseEncryptionSpecFactory,
+): Result<IssuanceResponseEncryptionSpec?> = runCatching {
+    fun IssuanceResponseEncryptionSpec.validate(
+        supportedAlgorithmsAndMethods: SupportedEncryptionAlgorithmsAndMethods,
+    ) {
+        ensure(algorithm in supportedAlgorithmsAndMethods.algorithms) {
+            ResponseEncryptionAlgorithmNotSupportedByIssuer
+        }
+        ensure(encryptionMethod in supportedAlgorithmsAndMethods.encryptionMethods) {
+            ResponseEncryptionMethodNotSupportedByIssuer
+        }
+    }
+
+    when (val encryption = credentialOffer.credentialIssuerMetadata.credentialResponseEncryption) {
+        CredentialResponseEncryption.NotSupported ->
+            // Issuance server does not support Credential Response encryption.
+            // In case Wallet requires Credential Response encryption, fail.
+            when (config.credentialResponseEncryptionPolicy) {
+                CredentialResponseEncryptionPolicy.SUPPORTED -> null
+                CredentialResponseEncryptionPolicy.REQUIRED -> throw ResponseEncryptionRequiredByWalletButNotSupportedByIssuer
+            }
+
+        is CredentialResponseEncryption.SupportedNotRequired -> {
+            // Issuance server supports but does not require Credential Response encryption.
+            // Fail in case Wallet requires Credential Response encryption but no crypto material can be generated,
+            // or in case algorithm/method supported by Wallet is not supported by issuance server.
+            val supportedAlgorithmsAndMethods = encryption.encryptionAlgorithmsAndMethods
+            val maybeSpec = runCatching {
+                responseEncryptionSpecFactory(supportedAlgorithmsAndMethods, config.keyGenerationConfig)
+                    ?.apply {
+                        validate(supportedAlgorithmsAndMethods)
+                    }
+            }.getOrNull()
+
+            when (config.credentialResponseEncryptionPolicy) {
+                CredentialResponseEncryptionPolicy.SUPPORTED -> maybeSpec
+
+                CredentialResponseEncryptionPolicy.REQUIRED -> {
+                    ensureNotNull(maybeSpec) {
+                        WalletRequiresCredentialResponseEncryptionButNoCryptoMaterialCanBeGenerated
+                    }
+                }
+            }
+        }
+
+        is CredentialResponseEncryption.Required -> {
+            // Issuance server requires Credential Response encryption.
+            // Fail in case Wallet does not support Credential Response encryption or,
+            // algorithms/methods supported by Wallet are not supported by issuance server.
+            val supportedAlgorithmsAndMethods = encryption.encryptionAlgorithmsAndMethods
+            val maybeSpec = responseEncryptionSpecFactory(supportedAlgorithmsAndMethods, config.keyGenerationConfig)
+                ?.apply { validate(supportedAlgorithmsAndMethods) }
+            ensureNotNull(maybeSpec) { IssuerExpectsResponseEncryptionCryptoMaterialButNotProvided }
+        }
+    }
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/formats/CredentialIssuanceRequest.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/formats/CredentialIssuanceRequest.kt
@@ -34,6 +34,8 @@ internal sealed interface CredentialType {
  */
 internal sealed interface CredentialIssuanceRequest {
 
+    val encryption: IssuanceResponseEncryptionSpec?
+
     /**
      * Models an issuance request for a batch of credentials
      *
@@ -43,6 +45,7 @@ internal sealed interface CredentialIssuanceRequest {
      */
     data class BatchRequest(
         val credentialRequests: List<SingleRequest>,
+        override val encryption: IssuanceResponseEncryptionSpec?,
     ) : CredentialIssuanceRequest
 
     /**
@@ -50,7 +53,6 @@ internal sealed interface CredentialIssuanceRequest {
      */
     sealed interface SingleRequest : CredentialIssuanceRequest {
         val proof: Proof?
-        val encryption: IssuanceResponseEncryptionSpec?
     }
 
     /**

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/formats/IssuanceRequestJsonMapper.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/formats/IssuanceRequestJsonMapper.kt
@@ -15,10 +15,7 @@
  */
 package eu.europa.ec.eudi.openid4vci.internal.formats
 
-import eu.europa.ec.eudi.openid4vci.FORMAT_MSO_MDOC
-import eu.europa.ec.eudi.openid4vci.FORMAT_SD_JWT_VC
-import eu.europa.ec.eudi.openid4vci.FORMAT_W3C_SIGNED_JWT
-import eu.europa.ec.eudi.openid4vci.IssuanceResponseEncryptionSpec
+import eu.europa.ec.eudi.openid4vci.*
 import eu.europa.ec.eudi.openid4vci.internal.Proof
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -91,7 +88,7 @@ private fun transferObjectOfSingle(
     }
 }
 
-private fun IssuanceResponseEncryptionSpec.transferObject(): CredentialResponseEncryptionSpecTO {
+internal fun IssuanceResponseEncryptionSpec.transferObject(): CredentialResponseEncryptionSpecTO {
     val credentialEncryptionJwk = Json.parseToJsonElement(jwk.toPublicJWK().toString()).jsonObject
     val credentialResponseEncryptionAlg = algorithm.toString()
     val credentialResponseEncryptionMethod = encryptionMethod.toString()
@@ -133,5 +130,23 @@ internal data class SingleCredentialTO(
 ) {
     init {
         require(format != null || credentialIdentifier != null) { "Either format or credentialIdentifier must be set" }
+    }
+}
+
+@Serializable
+internal data class DeferredIssuanceRequestTO(
+    @SerialName("transaction_id") val transactionId: String,
+    @SerialName("credential_response_encryption") val credentialResponseEncryptionSpec: CredentialResponseEncryptionSpecTO? = null,
+)
+
+internal object DeferredRequestJsonMapper {
+
+    fun asJson(
+        deferredCredential: IssuedCredential.Deferred,
+        responseEncryptionSpec: IssuanceResponseEncryptionSpec?,
+    ): DeferredIssuanceRequestTO {
+        val transactionId = deferredCredential.transactionId.value
+        val credentialResponseEncryptionSpecTO = responseEncryptionSpec?.run { transferObject() }
+        return DeferredIssuanceRequestTO(transactionId, credentialResponseEncryptionSpecTO)
     }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialIssuerMetadataJsonParser.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialIssuerMetadataJsonParser.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package eu.europa.ec.eudi.openid4vci.internal.formats
+package eu.europa.ec.eudi.openid4vci.internal.http
 
 import com.nimbusds.jose.EncryptionMethod
 import com.nimbusds.jose.JWEAlgorithm

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/IssuanceRequestJsonMapper.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/IssuanceRequestJsonMapper.kt
@@ -18,10 +18,11 @@ package eu.europa.ec.eudi.openid4vci.internal.http
 import com.nimbusds.jwt.JWTClaimsSet
 import eu.europa.ec.eudi.openid4vci.*
 import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.*
+import eu.europa.ec.eudi.openid4vci.internal.*
+import eu.europa.ec.eudi.openid4vci.internal.CredentialIssuanceRequest
+import eu.europa.ec.eudi.openid4vci.internal.CredentialType
 import eu.europa.ec.eudi.openid4vci.internal.Proof
 import eu.europa.ec.eudi.openid4vci.internal.ensure
-import eu.europa.ec.eudi.openid4vci.internal.formats.CredentialIssuanceRequest
-import eu.europa.ec.eudi.openid4vci.internal.formats.CredentialType
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.*

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/IssuanceRequestJsonMapper.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/IssuanceRequestJsonMapper.kt
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package eu.europa.ec.eudi.openid4vci.internal.formats
+package eu.europa.ec.eudi.openid4vci.internal.http
 
 import com.nimbusds.jwt.JWTClaimsSet
 import eu.europa.ec.eudi.openid4vci.*
 import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.*
-import eu.europa.ec.eudi.openid4vci.internal.CredentialIssuanceResponse
 import eu.europa.ec.eudi.openid4vci.internal.Proof
 import eu.europa.ec.eudi.openid4vci.internal.ensure
+import eu.europa.ec.eudi.openid4vci.internal.formats.CredentialIssuanceRequest
+import eu.europa.ec.eudi.openid4vci.internal.formats.CredentialType
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.*

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/IssuanceServerClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/IssuanceServerClient.kt
@@ -94,7 +94,7 @@ internal class IssuanceServerClient(
             if (response.status.isSuccess()) {
                 responsePossiblyEncrypted(
                     response,
-                    request.encryption,
+                    null, // Replace with responseEncryptionSpec value as soon VCI spec decide on this
                     fromTransferObject = { it.toDomain() },
                     transferObjectFromJwtClaims = { BatchCredentialResponseSuccessTO.from(it) },
                 )
@@ -128,7 +128,7 @@ internal class IssuanceServerClient(
             if (response.status.isSuccess()) {
                 responsePossiblyEncrypted<DeferredIssuanceSuccessResponseTO, DeferredCredentialQueryOutcome.Issued>(
                     response,
-                    responseEncryptionSpec,
+                    null, // Replace with responseEncryptionSpec value as soon VCI spec decide on this
                     fromTransferObject = { it.toDomain() },
                     transferObjectFromJwtClaims = { DeferredIssuanceSuccessResponseTO.from(it) },
                 )

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/IssuanceServerClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/IssuanceServerClient.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package eu.europa.ec.eudi.openid4vci.internal
+package eu.europa.ec.eudi.openid4vci.internal.http
 
 import com.nimbusds.jose.jwk.JWKSet
 import com.nimbusds.jose.jwk.source.ImmutableJWKSet
@@ -23,6 +23,10 @@ import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.proc.DefaultJWTProcessor
 import eu.europa.ec.eudi.openid4vci.*
 import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.*
+import eu.europa.ec.eudi.openid4vci.internal.DPoPJwtFactory
+import eu.europa.ec.eudi.openid4vci.internal.Htm
+import eu.europa.ec.eudi.openid4vci.internal.bearerOrDPoPAuth
+import eu.europa.ec.eudi.openid4vci.internal.ensureNotNull
 import eu.europa.ec.eudi.openid4vci.internal.formats.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/IssuanceServerClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/IssuanceServerClient.kt
@@ -23,29 +23,16 @@ import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.proc.DefaultJWTProcessor
 import eu.europa.ec.eudi.openid4vci.*
 import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.*
+import eu.europa.ec.eudi.openid4vci.internal.*
+import eu.europa.ec.eudi.openid4vci.internal.CredentialIssuanceRequest
 import eu.europa.ec.eudi.openid4vci.internal.DPoPJwtFactory
 import eu.europa.ec.eudi.openid4vci.internal.Htm
 import eu.europa.ec.eudi.openid4vci.internal.bearerOrDPoPAuth
 import eu.europa.ec.eudi.openid4vci.internal.ensureNotNull
-import eu.europa.ec.eudi.openid4vci.internal.formats.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
-
-/**
- * Models a response of the issuer to a successful issuance request.
- *
- * @param credentials The outcome of the issuance request.
- * if the issuance request was a batch request, it will contain
- * the results of each issuance request.
- * If it was a single issuance request list will contain only one result.
- * @param cNonce Nonce information sent back from the issuance server.
- */
-internal data class CredentialIssuanceResponse(
-    val credentials: List<IssuedCredential>,
-    val cNonce: CNonce?,
-)
 
 internal class IssuanceServerClient(
     private val issuerMetadata: CredentialIssuerMetadata,

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceAuthorizationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceAuthorizationTest.kt
@@ -15,9 +15,9 @@
  */
 package eu.europa.ec.eudi.openid4vci
 
-import eu.europa.ec.eudi.openid4vci.internal.AccessTokenRequestResponseTO
-import eu.europa.ec.eudi.openid4vci.internal.PushedAuthorizationRequestResponse
-import eu.europa.ec.eudi.openid4vci.internal.TokenEndpointForm
+import eu.europa.ec.eudi.openid4vci.internal.http.PushedAuthorizationRequestResponseTO
+import eu.europa.ec.eudi.openid4vci.internal.http.TokenEndpointForm
+import eu.europa.ec.eudi.openid4vci.internal.http.TokenResponseTO
 import io.ktor.client.engine.mock.*
 import io.ktor.client.request.forms.*
 import io.ktor.http.*
@@ -381,7 +381,7 @@ class IssuanceAuthorizationTest {
                     responseBuilder = {
                         respond(
                             content = Json.encodeToString(
-                                AccessTokenRequestResponseTO.Success(
+                                TokenResponseTO.Success(
                                     accessToken = UUID.randomUUID().toString(),
                                     expiresIn = 3600,
                                     cNonce = "dfghhj34wpCJp",
@@ -436,7 +436,7 @@ class IssuanceAuthorizationTest {
                     responseBuilder = {
                         respond(
                             content = Json.encodeToString(
-                                AccessTokenRequestResponseTO.Success(
+                                TokenResponseTO.Success(
                                     accessToken = UUID.randomUUID().toString(),
                                     expiresIn = 3600,
                                     cNonce = "dfghhj34wpCJp",
@@ -483,7 +483,7 @@ class IssuanceAuthorizationTest {
                     responseBuilder = {
                         respond(
                             content = Json.encodeToString(
-                                AccessTokenRequestResponseTO.Success(
+                                TokenResponseTO.Success(
                                     accessToken = UUID.randomUUID().toString(),
                                     expiresIn = 3600,
                                     cNonce = "dfghhj34wpCJp",
@@ -543,7 +543,7 @@ class IssuanceAuthorizationTest {
                     responseBuilder = {
                         respond(
                             content = Json.encodeToString(
-                                AccessTokenRequestResponseTO.Success(
+                                TokenResponseTO.Success(
                                     accessToken = UUID.randomUUID().toString(),
                                     expiresIn = 3600,
                                 ),
@@ -588,7 +588,7 @@ class IssuanceAuthorizationTest {
                     responseBuilder = {
                         respond(
                             content = Json.encodeToString(
-                                PushedAuthorizationRequestResponse.Failure(
+                                PushedAuthorizationRequestResponseTO.Failure(
                                     "invalid_request",
                                     "The redirect_uri is not valid for the given client",
                                 ),
@@ -634,7 +634,7 @@ class IssuanceAuthorizationTest {
                     responseBuilder = {
                         respond(
                             content = Json.encodeToString(
-                                AccessTokenRequestResponseTO.Failure(
+                                TokenResponseTO.Failure(
                                     error = "unauthorized_client",
                                 ),
                             ),
@@ -684,7 +684,7 @@ class IssuanceAuthorizationTest {
                     responseBuilder = {
                         respond(
                             content = Json.encodeToString(
-                                AccessTokenRequestResponseTO.Failure(
+                                TokenResponseTO.Failure(
                                     error = "unauthorized_client",
                                 ),
                             ),

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceBatchRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceBatchRequestTest.kt
@@ -15,8 +15,8 @@
  */
 package eu.europa.ec.eudi.openid4vci
 
-import eu.europa.ec.eudi.openid4vci.internal.BatchIssuanceSuccessResponse
-import eu.europa.ec.eudi.openid4vci.internal.CertificateIssuanceResponse
+import eu.europa.ec.eudi.openid4vci.internal.BatchIssuanceSuccessResponseTO
+import eu.europa.ec.eudi.openid4vci.internal.IssuanceResponseTO
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
 import io.ktor.http.content.*
@@ -42,15 +42,15 @@ class IssuanceBatchRequestTest {
                     if (textContent.text.contains("\"proof\":")) {
                         respond(
                             content = Json.encodeToString(
-                                BatchIssuanceSuccessResponse(
+                                BatchIssuanceSuccessResponseTO(
                                     credentialResponses = listOf(
-                                        CertificateIssuanceResponse(
+                                        IssuanceResponseTO(
                                             credential = "issued_credential_content_mso_mdoc",
                                         ),
-                                        CertificateIssuanceResponse(
+                                        IssuanceResponseTO(
                                             credential = "issued_credential_content_sd_jwt_vc",
                                         ),
-                                        CertificateIssuanceResponse(
+                                        IssuanceResponseTO(
                                             credential = "issued_credential_content_jwt_vc_json",
                                         ),
                                     ),

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceBatchRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceBatchRequestTest.kt
@@ -15,8 +15,8 @@
  */
 package eu.europa.ec.eudi.openid4vci
 
-import eu.europa.ec.eudi.openid4vci.internal.formats.BatchCredentialResponseSuccessTO
-import eu.europa.ec.eudi.openid4vci.internal.formats.IssuanceResponseTO
+import eu.europa.ec.eudi.openid4vci.internal.http.BatchCredentialResponseSuccessTO
+import eu.europa.ec.eudi.openid4vci.internal.http.IssuanceResponseTO
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
 import io.ktor.http.content.*

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceBatchRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceBatchRequestTest.kt
@@ -15,8 +15,8 @@
  */
 package eu.europa.ec.eudi.openid4vci
 
-import eu.europa.ec.eudi.openid4vci.internal.BatchIssuanceSuccessResponseTO
-import eu.europa.ec.eudi.openid4vci.internal.IssuanceResponseTO
+import eu.europa.ec.eudi.openid4vci.internal.formats.BatchCredentialResponseSuccessTO
+import eu.europa.ec.eudi.openid4vci.internal.formats.IssuanceResponseTO
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
 import io.ktor.http.content.*
@@ -42,7 +42,7 @@ class IssuanceBatchRequestTest {
                     if (textContent.text.contains("\"proof\":")) {
                         respond(
                             content = Json.encodeToString(
-                                BatchIssuanceSuccessResponseTO(
+                                BatchCredentialResponseSuccessTO(
                                     credentialResponses = listOf(
                                         IssuanceResponseTO(
                                             credential = "issued_credential_content_mso_mdoc",

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceDeferredRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceDeferredRequestTest.kt
@@ -15,8 +15,8 @@
  */
 package eu.europa.ec.eudi.openid4vci
 
-import eu.europa.ec.eudi.openid4vci.internal.formats.CredentialRequestTO
-import eu.europa.ec.eudi.openid4vci.internal.formats.DeferredRequestTO
+import eu.europa.ec.eudi.openid4vci.internal.http.CredentialRequestTO
+import eu.europa.ec.eudi.openid4vci.internal.http.DeferredRequestTO
 import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
 import io.ktor.http.*

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceDeferredRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceDeferredRequestTest.kt
@@ -15,7 +15,7 @@
  */
 package eu.europa.ec.eudi.openid4vci
 
-import eu.europa.ec.eudi.openid4vci.internal.DeferredIssuanceRequestTO
+import eu.europa.ec.eudi.openid4vci.internal.formats.DeferredIssuanceRequestTO
 import eu.europa.ec.eudi.openid4vci.internal.formats.SingleCredentialTO
 import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceDeferredRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceDeferredRequestTest.kt
@@ -15,8 +15,8 @@
  */
 package eu.europa.ec.eudi.openid4vci
 
-import eu.europa.ec.eudi.openid4vci.internal.formats.DeferredIssuanceRequestTO
-import eu.europa.ec.eudi.openid4vci.internal.formats.SingleCredentialTO
+import eu.europa.ec.eudi.openid4vci.internal.formats.CredentialRequestTO
+import eu.europa.ec.eudi.openid4vci.internal.formats.DeferredRequestTO
 import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
 import io.ktor.http.*
@@ -301,7 +301,7 @@ class IssuanceDeferredRequestTest {
 
     private fun respondToCredentialIssuanceRequest(
         call: MockRequestHandleScope,
-        issuanceRequest: SingleCredentialTO?,
+        issuanceRequest: CredentialRequestTO?,
     ): HttpResponseData =
         if (issuanceRequest == null) {
             call.respond(
@@ -346,16 +346,16 @@ class IssuanceDeferredRequestTest {
             )
         }
 
-    private fun asDeferredIssuanceRequest(bodyStr: String): DeferredIssuanceRequestTO? =
+    private fun asDeferredIssuanceRequest(bodyStr: String): DeferredRequestTO? =
         try {
-            Json.decodeFromString<DeferredIssuanceRequestTO>(bodyStr)
+            Json.decodeFromString<DeferredRequestTO>(bodyStr)
         } catch (ex: Exception) {
             null
         }
 
-    private fun asIssuanceRequest(bodyStr: String): SingleCredentialTO? =
+    private fun asIssuanceRequest(bodyStr: String): CredentialRequestTO? =
         try {
-            Json.decodeFromString<SingleCredentialTO>(bodyStr)
+            Json.decodeFromString<CredentialRequestTO>(bodyStr)
         } catch (ex: Exception) {
             null
         }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceEncryptedResponsesTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceEncryptedResponsesTest.kt
@@ -29,7 +29,7 @@ import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
 import com.nimbusds.jwt.EncryptedJWT
 import com.nimbusds.jwt.JWTClaimsSet
 import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.ResponseEncryptionError.*
-import eu.europa.ec.eudi.openid4vci.internal.formats.CredentialRequestTO
+import eu.europa.ec.eudi.openid4vci.internal.http.CredentialRequestTO
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
 import io.ktor.http.content.*

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceEncryptedResponsesTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceEncryptedResponsesTest.kt
@@ -29,7 +29,7 @@ import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
 import com.nimbusds.jwt.EncryptedJWT
 import com.nimbusds.jwt.JWTClaimsSet
 import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.ResponseEncryptionError.*
-import eu.europa.ec.eudi.openid4vci.internal.formats.SingleCredentialTO
+import eu.europa.ec.eudi.openid4vci.internal.formats.CredentialRequestTO
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
 import io.ktor.http.content.*
@@ -164,9 +164,9 @@ class IssuanceEncryptedResponsesTest {
                 singleIssuanceRequestMocker(
                     requestValidator = {
                         val textContent = it.body as TextContent
-                        val issuanceRequestTO = Json.decodeFromString<SingleCredentialTO>(textContent.text)
+                        val issuanceRequestTO = Json.decodeFromString<CredentialRequestTO>(textContent.text)
                         assertTrue("No encryption parameters expected to be sent") {
-                            issuanceRequestTO.credentialResponseEncryptionSpec == null
+                            issuanceRequestTO.credentialResponseEncryption == null
                         }
                     },
                 ),
@@ -201,9 +201,9 @@ class IssuanceEncryptedResponsesTest {
                 singleIssuanceRequestMocker(
                     requestValidator = {
                         val textContent = it.body as TextContent
-                        val issuanceRequestTO = Json.decodeFromString<SingleCredentialTO>(textContent.text)
+                        val issuanceRequestTO = Json.decodeFromString<CredentialRequestTO>(textContent.text)
                         assertTrue("Encryption parameters were expected to be sent but was not.") {
-                            issuanceRequestTO.credentialResponseEncryptionSpec != null
+                            issuanceRequestTO.credentialResponseEncryption != null
                         }
                     },
                 ),
@@ -238,9 +238,9 @@ class IssuanceEncryptedResponsesTest {
                 singleIssuanceRequestMocker(
                     requestValidator = {
                         val textContent = it.body as TextContent
-                        val issuanceRequestTO = Json.decodeFromString<SingleCredentialTO>(textContent.text)
+                        val issuanceRequestTO = Json.decodeFromString<CredentialRequestTO>(textContent.text)
                         assertTrue("Encryption parameters were expected to be sent but was not.") {
-                            issuanceRequestTO.credentialResponseEncryptionSpec == null
+                            issuanceRequestTO.credentialResponseEncryption == null
                         }
                     },
                 ),
@@ -271,10 +271,10 @@ class IssuanceEncryptedResponsesTest {
                     responseBuilder = {
                         val textContent = it?.body as TextContent
                         if (textContent.text.contains("\"proof\":")) {
-                            val issuanceRequestTO = Json.decodeFromString<SingleCredentialTO>(textContent.text)
-                            val jwk = JWK.parse(issuanceRequestTO.credentialResponseEncryptionSpec?.jwk.toString())
-                            val alg = JWEAlgorithm.parse(issuanceRequestTO.credentialResponseEncryptionSpec?.encryptionAlgorithm)
-                            val enc = EncryptionMethod.parse(issuanceRequestTO.credentialResponseEncryptionSpec?.encryptionMethod)
+                            val issuanceRequestTO = Json.decodeFromString<CredentialRequestTO>(textContent.text)
+                            val jwk = JWK.parse(issuanceRequestTO.credentialResponseEncryption?.jwk.toString())
+                            val alg = JWEAlgorithm.parse(issuanceRequestTO.credentialResponseEncryption?.encryptionAlgorithm)
+                            val enc = EncryptionMethod.parse(issuanceRequestTO.credentialResponseEncryption?.encryptionMethod)
                             respond(
                                 content = encryptedResponse(jwk, alg, enc).getOrThrow(),
                                 status = HttpStatusCode.OK,
@@ -311,16 +311,16 @@ class IssuanceEncryptedResponsesTest {
 
                         val textContent = it.body as TextContent
                         val issuanceRequestTO = assertDoesNotThrow("Wrong credential request type") {
-                            Json.decodeFromString<SingleCredentialTO>(textContent.text)
+                            Json.decodeFromString<CredentialRequestTO>(textContent.text)
                         }
                         assertTrue("Missing response encryption JWK") {
-                            issuanceRequestTO.credentialResponseEncryptionSpec?.jwk != null
+                            issuanceRequestTO.credentialResponseEncryption?.jwk != null
                         }
                         assertTrue("Missing response encryption algorithm") {
-                            issuanceRequestTO.credentialResponseEncryptionSpec?.encryptionAlgorithm != null
+                            issuanceRequestTO.credentialResponseEncryption?.encryptionAlgorithm != null
                         }
                         assertTrue("Missing response encryption method") {
-                            issuanceRequestTO.credentialResponseEncryptionSpec?.encryptionMethod != null
+                            issuanceRequestTO.credentialResponseEncryption?.encryptionMethod != null
                         }
                     },
                 ),

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceNotificationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceNotificationTest.kt
@@ -15,8 +15,8 @@
  */
 package eu.europa.ec.eudi.openid4vci
 
+import eu.europa.ec.eudi.openid4vci.internal.NotificationEventTO
 import eu.europa.ec.eudi.openid4vci.internal.NotificationTO
-import eu.europa.ec.eudi.openid4vci.internal.NotifiedEvent
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
 import io.ktor.http.content.*
@@ -59,7 +59,7 @@ class IssuanceNotificationTest {
                     val textContent = it.body as TextContent
                     val notificationTO = Json.decodeFromString<NotificationTO>(textContent.text)
                     assertTrue("Not expected event type") {
-                        notificationTO.event == NotifiedEvent.CREDENTIAL_ACCEPTED
+                        notificationTO.event == NotificationEventTO.CREDENTIAL_ACCEPTED
                     }
                 },
             ),

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceNotificationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceNotificationTest.kt
@@ -15,8 +15,8 @@
  */
 package eu.europa.ec.eudi.openid4vci
 
-import eu.europa.ec.eudi.openid4vci.internal.formats.NotificationEventTO
-import eu.europa.ec.eudi.openid4vci.internal.formats.NotificationTO
+import eu.europa.ec.eudi.openid4vci.internal.http.NotificationEventTO
+import eu.europa.ec.eudi.openid4vci.internal.http.NotificationTO
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
 import io.ktor.http.content.*

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceNotificationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceNotificationTest.kt
@@ -15,8 +15,8 @@
  */
 package eu.europa.ec.eudi.openid4vci
 
-import eu.europa.ec.eudi.openid4vci.internal.NotificationEventTO
-import eu.europa.ec.eudi.openid4vci.internal.NotificationTO
+import eu.europa.ec.eudi.openid4vci.internal.formats.NotificationEventTO
+import eu.europa.ec.eudi.openid4vci.internal.formats.NotificationTO
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
 import io.ktor.http.content.*

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
@@ -16,7 +16,7 @@
 package eu.europa.ec.eudi.openid4vci
 
 import eu.europa.ec.eudi.openid4vci.internal.Proof
-import eu.europa.ec.eudi.openid4vci.internal.formats.CredentialRequestTO
+import eu.europa.ec.eudi.openid4vci.internal.http.CredentialRequestTO
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
 import io.ktor.http.content.*

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
@@ -16,7 +16,7 @@
 package eu.europa.ec.eudi.openid4vci
 
 import eu.europa.ec.eudi.openid4vci.internal.Proof
-import eu.europa.ec.eudi.openid4vci.internal.formats.SingleCredentialTO
+import eu.europa.ec.eudi.openid4vci.internal.formats.CredentialRequestTO
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
 import io.ktor.http.content.*
@@ -64,7 +64,7 @@ class IssuanceSingleRequestTest {
                     }
 
                     val textContent = it.body as TextContent
-                    val issuanceRequestTO = Json.decodeFromString<SingleCredentialTO>(textContent.text)
+                    val issuanceRequestTO = Json.decodeFromString<CredentialRequestTO>(textContent.text)
                     assertThat(
                         "Wrong credential request type",
                         issuanceRequestTO.format != null && issuanceRequestTO.format == FORMAT_MSO_MDOC,
@@ -237,7 +237,7 @@ class IssuanceSingleRequestTest {
                 credential = credential,
                 requestValidator = {
                     val textContent = it.body as TextContent
-                    val issuanceRequest = Json.decodeFromString<SingleCredentialTO>(textContent.text)
+                    val issuanceRequest = Json.decodeFromString<CredentialRequestTO>(textContent.text)
                     issuanceRequest.proof?.let {
                         assertIs<Proof.Jwt>(issuanceRequest.proof)
                     }
@@ -409,7 +409,7 @@ class IssuanceSingleRequestTest {
                 credential = "credential",
                 requestValidator = {
                     val textContent = it.body as TextContent
-                    val issuanceRequestTO = Json.decodeFromString<SingleCredentialTO>(textContent.text)
+                    val issuanceRequestTO = Json.decodeFromString<CredentialRequestTO>(textContent.text)
                     assertThat(
                         "Expected identifier based issuance request but credential_identifier is null",
                         issuanceRequestTO.credentialIdentifier != null,
@@ -450,10 +450,10 @@ class IssuanceSingleRequestTest {
                 credential = "credential",
                 requestValidator = {
                     val textContent = it.body as TextContent
-                    val issuanceRequestTO = Json.decodeFromString<SingleCredentialTO>(textContent.text)
+                    val issuanceRequestTO = Json.decodeFromString<CredentialRequestTO>(textContent.text)
                     assertThat(
                         "Expected identifier based issuance request but credential_identifier is null",
-                        issuanceRequestTO.credentialResponseEncryptionSpec != null,
+                        issuanceRequestTO.credentialResponseEncryption != null,
                     )
                 },
             ),
@@ -492,7 +492,7 @@ class IssuanceSingleRequestTest {
                 credential = "credential",
                 requestValidator = {
                     val textContent = it.body as TextContent
-                    val issuanceRequestTO = Json.decodeFromString<SingleCredentialTO>(textContent.text)
+                    val issuanceRequestTO = Json.decodeFromString<CredentialRequestTO>(textContent.text)
                     assertThat(
                         "Expected identifier based issuance request but credential_identifier is null",
                         issuanceRequestTO.credentialIdentifier != null,
@@ -536,7 +536,7 @@ class IssuanceSingleRequestTest {
                 credential = "credential",
                 requestValidator = {
                     val textContent = it.body as TextContent
-                    val issuanceRequestTO = Json.decodeFromString<SingleCredentialTO>(textContent.text)
+                    val issuanceRequestTO = Json.decodeFromString<CredentialRequestTO>(textContent.text)
                     assertThat(
                         "Expected identifier based issuance request but credential_identifier is null",
                         issuanceRequestTO.credentialIdentifier != null,

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/RequestMockers.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/RequestMockers.kt
@@ -16,8 +16,8 @@
 package eu.europa.ec.eudi.openid4vci
 
 import eu.europa.ec.eudi.openid4vci.EncryptedResponses.*
-import eu.europa.ec.eudi.openid4vci.internal.AccessTokenRequestResponseTO
-import eu.europa.ec.eudi.openid4vci.internal.PushedAuthorizationRequestResponse
+import eu.europa.ec.eudi.openid4vci.internal.http.PushedAuthorizationRequestResponseTO
+import eu.europa.ec.eudi.openid4vci.internal.http.TokenResponseTO
 import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
 import io.ktor.http.*
@@ -83,7 +83,7 @@ internal fun parPostMocker(validator: (request: HttpRequestData) -> Unit = {}): 
         responseBuilder = {
             respond(
                 content = Json.encodeToString(
-                    PushedAuthorizationRequestResponse.Success(
+                    PushedAuthorizationRequestResponseTO.Success(
                         "org:example:oauth:request_uri:6esc_11ACC5bwc014ltc14eY22c",
                         3600,
                     ),
@@ -103,7 +103,7 @@ internal fun tokenPostMocker(validator: (request: HttpRequestData) -> Unit = {})
         responseBuilder = {
             respond(
                 content = Json.encodeToString(
-                    AccessTokenRequestResponseTO.Success(
+                    TokenResponseTO.Success(
                         accessToken = UUID.randomUUID().toString(),
                         expiresIn = 3600,
                     ),
@@ -126,7 +126,7 @@ internal fun tokenPostMockerWithAuthDetails(
         responseBuilder = {
             respond(
                 content = Json.encodeToString(
-                    AccessTokenRequestResponseTO.Success(
+                    TokenResponseTO.Success(
                         accessToken = UUID.randomUUID().toString(),
                         expiresIn = 3600,
                         authorizationDetails = authorizationDetails(configurationIds),


### PR DESCRIPTION
Closes #213

This PR re-factors the HTTP clients for placing calls towards the OAUTH2 / OIDC and Credential Issuer servers.

A new package `.internal.http` was added and clients were moved there.
Also in this package Transfer objects (for JSON) were moved