### PR TITLE
Make credential offer available from Issuer

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
@@ -25,6 +25,8 @@ import kotlinx.coroutines.coroutineScope
 
 interface Issuer : AuthorizeIssuance, RequestIssuance, QueryForDeferredCredential, NotifyIssuer {
 
+    val credentialOffer: CredentialOffer
+
     companion object {
 
         /**
@@ -112,7 +114,10 @@ interface Issuer : AuthorizeIssuance, RequestIssuance, QueryForDeferredCredentia
                 AuthorizeIssuance by authorizeIssuance,
                 RequestIssuance by requestIssuance,
                 QueryForDeferredCredential by queryForDeferredCredential,
-                NotifyIssuer by notifyIssuer {}
+                NotifyIssuer by notifyIssuer {
+                override val credentialOffer: CredentialOffer
+                    get() = credentialOffer
+            }
         }
 
         /**

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingAuthorizationFlow.kt
@@ -46,9 +46,7 @@ fun main(): Unit = runBlocking {
     val authorizedRequest = authorizeRequestWithAuthCodeUseCase(issuer, actingUser)
     authorizationLog("Authorization retrieved: $authorizedRequest")
 
-    val offerCredentialConfIds = listOf(PID_SdJwtVC_config_id, PID_MsoMdoc_config_id, MDL_config_id).map {
-        CredentialConfigurationIdentifier(it)
-    }
+    val offerCredentialConfIds = issuer.credentialOffer.credentialConfigurationIdentifiers
 
     val credentials = when (authorizedRequest) {
         is AuthorizedRequest.NoProofRequired -> offerCredentialConfIds.map { credentialId ->


### PR DESCRIPTION
This PR is a small improvement in ergonomics.

Adds to `Issuer` interface a public property for accessing the credential offer for which the Issuer was created.

Closes #216 