### PR TITLE
Improve Proof Types Supported

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
@@ -57,12 +57,11 @@ enum class ProofType : Serializable {
     LDP_VP,
 }
 
-@JvmInline
-value class CurveIdentifier(val value: Int)
-
 sealed interface ProofTypeMeta : Serializable {
     data class Jwt(val algorithms: List<JWSAlgorithm>) : ProofTypeMeta
-    data class Cwt(val algorithms: List<Int>, val curves: List<CurveIdentifier>) : ProofTypeMeta
+    data object Cwt : ProofTypeMeta {
+        private fun readResolve(): Any = Cwt
+    }
     data object LdpVp : ProofTypeMeta {
         private fun readResolve(): Any = LdpVp
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
@@ -58,10 +58,16 @@ enum class ProofType : Serializable {
 }
 
 sealed interface ProofTypeMeta : Serializable {
-    data class Jwt(val algorithms: List<JWSAlgorithm>) : ProofTypeMeta
+    data class Jwt(val algorithms: List<JWSAlgorithm>) : ProofTypeMeta {
+        init {
+            require(algorithms.isNotEmpty()) { "Supported algorithms in case of JWT cannot be empty" }
+        }
+    }
+
     data object Cwt : ProofTypeMeta {
         private fun readResolve(): Any = Cwt
     }
+
     data object LdpVp : ProofTypeMeta {
         private fun readResolve(): Any = LdpVp
     }
@@ -77,6 +83,7 @@ fun ProofTypeMeta.type(): ProofType = when (this) {
 value class ProofTypesSupported private constructor(val values: Set<ProofTypeMeta>) {
 
     operator fun get(type: ProofType): ProofTypeMeta? = values.firstOrNull { it.type() == type }
+
     companion object {
         val Empty: ProofTypesSupported = ProofTypesSupported(emptySet())
         operator fun invoke(values: Set<ProofTypeMeta>): ProofTypesSupported {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
@@ -58,7 +58,7 @@ enum class ProofType : Serializable {
 }
 
 @JvmInline
-value class CurveIdentifier(val value : Int)
+value class CurveIdentifier(val value: Int)
 
 sealed interface ProofTypeMeta : Serializable {
     data class Jwt(val algorithms: List<JWSAlgorithm>) : ProofTypeMeta

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
@@ -57,9 +57,12 @@ enum class ProofType : Serializable {
     LDP_VP,
 }
 
+@JvmInline
+value class CurveIdentifier(val value : Int)
+
 sealed interface ProofTypeMeta : Serializable {
     data class Jwt(val algorithms: List<JWSAlgorithm>) : ProofTypeMeta
-    data class Cwt(val algorithms: List<Int>, val curves: List<Int>) : ProofTypeMeta
+    data class Cwt(val algorithms: List<Int>, val curves: List<CurveIdentifier>) : ProofTypeMeta
     data object LdpVp : ProofTypeMeta {
         private fun readResolve(): Any = LdpVp
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
@@ -57,6 +57,35 @@ enum class ProofType : Serializable {
     LDP_VP,
 }
 
+sealed interface ProofTypeMeta : Serializable {
+    data class Jwt(val algorithms: List<JWSAlgorithm>) : ProofTypeMeta
+    data class Cwt(val algorithms: List<Int>, val curves: List<Int>) : ProofTypeMeta
+    data object LdpVp : ProofTypeMeta {
+        private fun readResolve(): Any = LdpVp
+    }
+}
+
+fun ProofTypeMeta.type(): ProofType = when (this) {
+    is ProofTypeMeta.Jwt -> ProofType.JWT
+    is ProofTypeMeta.Cwt -> ProofType.CWT
+    is ProofTypeMeta.LdpVp -> ProofType.LDP_VP
+}
+
+@JvmInline
+value class ProofTypesSupported private constructor(val values: Set<ProofTypeMeta>) {
+
+    operator fun get(type: ProofType): ProofTypeMeta? = values.firstOrNull { it.type() == type }
+    companion object {
+        val Empty: ProofTypesSupported = ProofTypesSupported(emptySet())
+        operator fun invoke(values: Set<ProofTypeMeta>): ProofTypesSupported {
+            require(values.groupBy(ProofTypeMeta::type).all { (_, instances) -> instances.size == 1 }) {
+                "Multiple instance of the same proof type are not allowed"
+            }
+            return ProofTypesSupported(values)
+        }
+    }
+}
+
 typealias CssColor = String
 
 /**
@@ -87,7 +116,7 @@ sealed interface CredentialConfiguration : Serializable {
     val scope: String?
     val cryptographicBindingMethodsSupported: List<CryptographicBindingMethod>
     val credentialSigningAlgorithmsSupported: List<String>
-    val proofTypesSupported: Map<ProofType, List<JWSAlgorithm>>
+    val proofTypesSupported: ProofTypesSupported
     val display: List<Display>
 }
 
@@ -122,7 +151,7 @@ data class MsoMdocCredential(
     override val scope: String? = null,
     override val cryptographicBindingMethodsSupported: List<CryptographicBindingMethod> = emptyList(),
     override val credentialSigningAlgorithmsSupported: List<String> = emptyList(),
-    override val proofTypesSupported: Map<ProofType, List<JWSAlgorithm>> = emptyMap(),
+    override val proofTypesSupported: ProofTypesSupported = ProofTypesSupported.Empty,
     override val display: List<Display> = emptyList(),
     val docType: String,
     val claims: MsoMdocClaims = emptyMap(),
@@ -133,7 +162,7 @@ data class SdJwtVcCredential(
     override val scope: String? = null,
     override val cryptographicBindingMethodsSupported: List<CryptographicBindingMethod> = emptyList(),
     override val credentialSigningAlgorithmsSupported: List<String> = emptyList(),
-    override val proofTypesSupported: Map<ProofType, List<JWSAlgorithm>> = emptyMap(),
+    override val proofTypesSupported: ProofTypesSupported = ProofTypesSupported.Empty,
     override val display: List<Display> = emptyList(),
     val type: String,
     val claims: Map<ClaimName, Claim?>?,
@@ -152,7 +181,7 @@ data class W3CJsonLdDataIntegrityCredential(
     override val scope: String? = null,
     override val cryptographicBindingMethodsSupported: List<CryptographicBindingMethod> = emptyList(),
     override val credentialSigningAlgorithmsSupported: List<String> = emptyList(),
-    override val proofTypesSupported: Map<ProofType, List<JWSAlgorithm>> = emptyMap(),
+    override val proofTypesSupported: ProofTypesSupported = ProofTypesSupported.Empty,
     override val display: List<Display> = emptyList(),
     val context: List<String> = emptyList(),
     val type: List<String> = emptyList(),
@@ -167,7 +196,7 @@ data class W3CJsonLdSignedJwtCredential(
     override val scope: String? = null,
     override val cryptographicBindingMethodsSupported: List<CryptographicBindingMethod> = emptyList(),
     override val credentialSigningAlgorithmsSupported: List<String> = emptyList(),
-    override val proofTypesSupported: Map<ProofType, List<JWSAlgorithm>> = emptyMap(),
+    override val proofTypesSupported: ProofTypesSupported = ProofTypesSupported.Empty,
     override val display: List<Display> = emptyList(),
     val context: List<String> = emptyList(),
     val credentialDefinition: W3CJsonLdCredentialDefinition,
@@ -181,7 +210,7 @@ data class W3CSignedJwtCredential(
     override val scope: String? = null,
     override val cryptographicBindingMethodsSupported: List<CryptographicBindingMethod> = emptyList(),
     override val credentialSigningAlgorithmsSupported: List<String> = emptyList(),
-    override val proofTypesSupported: Map<ProofType, List<JWSAlgorithm>> = emptyMap(),
+    override val proofTypesSupported: ProofTypesSupported = ProofTypesSupported.Empty,
     override val display: List<Display> = emptyList(),
     val credentialDefinition: CredentialDefinition,
     val order: List<ClaimName> = emptyList(),

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/AuthorizeIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/AuthorizeIssuanceImpl.kt
@@ -134,7 +134,8 @@ internal fun TxCode.validate(txCode: String?) {
 
 internal fun authorizedRequest(offer: CredentialOffer, tokenResponse: TokenResponse): AuthorizedRequest {
     val offerRequiresProofs = offer.credentialConfigurationIdentifiers.any {
-        !offer.credentialIssuerMetadata.credentialConfigurationsSupported[it]?.proofTypesSupported.isNullOrEmpty()
+        val credentialConfiguration = offer.credentialIssuerMetadata.credentialConfigurationsSupported[it]
+        credentialConfiguration != null && credentialConfiguration.proofTypesSupported.values.isNotEmpty()
     }
     val (accessToken, refreshToken, cNonce, authorizationDetails) = tokenResponse
     return when {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProofBuilder.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProofBuilder.kt
@@ -68,10 +68,11 @@ internal sealed interface ProofBuilder {
                 "No credential specification provided"
             }
             val proofTypesSupported = spec.proofTypesSupported
-            ensure(ProofType.JWT in proofTypesSupported.keys) {
+            val jwtProofTypeMeta = proofTypesSupported.values.filterIsInstance<ProofTypeMeta.Jwt>().firstOrNull()
+            ensureNotNull(jwtProofTypeMeta) {
                 CredentialIssuanceError.ProofGenerationError.ProofTypeNotSupported
             }
-            val proofTypeSigningAlgorithmsSupported = proofTypesSupported[ProofType.JWT].orEmpty()
+            val proofTypeSigningAlgorithmsSupported = jwtProofTypeMeta.algorithms
             ensure(proofSigner.getAlgorithm() in proofTypeSigningAlgorithmsSupported) {
                 CredentialIssuanceError.ProofGenerationError.ProofTypeSigningAlgorithmNotSupported
             }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -165,7 +165,7 @@ internal class RequestIssuanceImpl(
             is Proof.Cwt -> ProofType.CWT
             is Proof.LdpVp -> ProofType.LDP_VP
         }
-        require(proofType in credentialSupported.proofTypesSupported.keys) {
+        requireNotNull(credentialSupported.proofTypesSupported[proofType]) {
             "Provided proof type $proofType is not one of supported [${credentialSupported.proofTypesSupported}]."
         }
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialIssuerMetadataJsonParser.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialIssuerMetadataJsonParser.kt
@@ -64,8 +64,6 @@ private sealed interface CredentialSupportedTO {
 @Serializable
 private data class ProofSigningAlgorithmsSupportedTO(
     @SerialName("proof_signing_alg_values_supported") val algorithms: List<String> = emptyList(),
-    @SerialName("proof_alg_values_supported") val cwtAlgorithms: List<Int> = emptyList(),
-    @SerialName("proof_crv_values_supported") val cwtCurves: List<Int> = emptyList(),
 )
 
 /**
@@ -527,6 +525,7 @@ private fun proofTypeMeta(type: String, meta: ProofSigningAlgorithmsSupportedTO)
         "jwt" -> ProofTypeMeta.Jwt(
             algorithms = meta.algorithms.map { JWSAlgorithm.parse(it) },
         )
+
         "cwt" -> ProofTypeMeta.Cwt
         "ldp_vp" -> ProofTypeMeta.LdpVp
         else -> error("Unknown Proof Type '$type'")

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialIssuerMetadataJsonParser.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialIssuerMetadataJsonParser.kt
@@ -524,8 +524,13 @@ private fun Map<String, ProofSigningAlgorithmsSupportedTO>?.toProofTypes(): Proo
 
 private fun proofTypeMeta(type: String, meta: ProofSigningAlgorithmsSupportedTO): ProofTypeMeta =
     when (type) {
-        "jwt" -> ProofTypeMeta.Jwt(algorithms = meta.algorithms.map { JWSAlgorithm.parse(it) })
-        "cwt" -> ProofTypeMeta.Cwt(algorithms = meta.cwtAlgorithms, curves = meta.cwtCurves)
+        "jwt" -> ProofTypeMeta.Jwt(
+            algorithms = meta.algorithms.map { JWSAlgorithm.parse(it) }
+        )
+        "cwt" -> ProofTypeMeta.Cwt(
+            algorithms = meta.cwtAlgorithms,
+            curves = meta.cwtCurves.map { CurveIdentifier(it) }
+        )
         "ldp_vp" -> ProofTypeMeta.LdpVp
         else -> error("Unknown Proof Type '$type'")
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialIssuerMetadataJsonParser.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialIssuerMetadataJsonParser.kt
@@ -527,10 +527,7 @@ private fun proofTypeMeta(type: String, meta: ProofSigningAlgorithmsSupportedTO)
         "jwt" -> ProofTypeMeta.Jwt(
             algorithms = meta.algorithms.map { JWSAlgorithm.parse(it) },
         )
-        "cwt" -> ProofTypeMeta.Cwt(
-            algorithms = meta.cwtAlgorithms,
-            curves = meta.cwtCurves.map { CurveIdentifier(it) },
-        )
+        "cwt" -> ProofTypeMeta.Cwt
         "ldp_vp" -> ProofTypeMeta.LdpVp
         else -> error("Unknown Proof Type '$type'")
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialIssuerMetadataJsonParser.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialIssuerMetadataJsonParser.kt
@@ -525,11 +525,11 @@ private fun Map<String, ProofSigningAlgorithmsSupportedTO>?.toProofTypes(): Proo
 private fun proofTypeMeta(type: String, meta: ProofSigningAlgorithmsSupportedTO): ProofTypeMeta =
     when (type) {
         "jwt" -> ProofTypeMeta.Jwt(
-            algorithms = meta.algorithms.map { JWSAlgorithm.parse(it) }
+            algorithms = meta.algorithms.map { JWSAlgorithm.parse(it) },
         )
         "cwt" -> ProofTypeMeta.Cwt(
             algorithms = meta.cwtAlgorithms,
-            curves = meta.cwtCurves.map { CurveIdentifier(it) }
+            curves = meta.cwtCurves.map { CurveIdentifier(it) },
         )
         "ldp_vp" -> ProofTypeMeta.LdpVp
         else -> error("Unknown Proof Type '$type'")

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/MockData.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/MockData.kt
@@ -81,7 +81,7 @@ internal fun universityDegreeJwt() = W3CSignedJwtCredential(
     "UniversityDegree_JWT",
     listOf(CryptographicBindingMethod.DID("did:example")),
     listOf("ES256K"),
-    mapOf(ProofType.JWT to listOf(JWSAlgorithm.RS256, JWSAlgorithm.ES256)),
+    ProofTypesSupported(setOf(ProofTypeMeta.Jwt(listOf(JWSAlgorithm.RS256, JWSAlgorithm.ES256)))),
     listOf(
         Display(
             "University Credential",
@@ -132,7 +132,7 @@ internal fun universityDegreeLdpVc() = W3CJsonLdDataIntegrityCredential(
     "UniversityDegree_LDP_VC",
     listOf(CryptographicBindingMethod.DID("did:example")),
     listOf("Ed25519Signature2018"),
-    mapOf(ProofType.JWT to listOf(JWSAlgorithm.RS256, JWSAlgorithm.ES256)),
+    ProofTypesSupported(setOf(ProofTypeMeta.Jwt(listOf(JWSAlgorithm.RS256, JWSAlgorithm.ES256)))),
     listOf(
         Display(
             "University Credential",
@@ -192,7 +192,7 @@ internal fun universityDegreeJwtVcJsonLD() = W3CJsonLdSignedJwtCredential(
     "UniversityDegree_JWT_VC_JSON-LD",
     listOf(CryptographicBindingMethod.DID("did:example")),
     listOf("Ed25519Signature2018"),
-    mapOf(ProofType.JWT to listOf(JWSAlgorithm.RS256, JWSAlgorithm.ES256)),
+    ProofTypesSupported(setOf(ProofTypeMeta.Jwt(listOf(JWSAlgorithm.RS256, JWSAlgorithm.ES256)))),
     listOf(
         Display(
             "University Credential",
@@ -251,7 +251,7 @@ internal fun mobileDrivingLicense() = MsoMdocCredential(
     "MobileDrivingLicense_msoMdoc",
     listOf(CryptographicBindingMethod.COSE),
     listOf("ES256", "ES384", "ES512"),
-    mapOf(ProofType.JWT to listOf(JWSAlgorithm.RS256, JWSAlgorithm.ES256)),
+    ProofTypesSupported(setOf(ProofTypeMeta.Jwt(listOf(JWSAlgorithm.RS256, JWSAlgorithm.ES256)))),
     listOf(
         Display(
             "Mobile Driving License",

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/Commons.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/Commons.kt
@@ -55,16 +55,18 @@ val DefaultOpenId4VCIConfig = OpenId4VCIConfig(
     dPoPProofSigner = CryptoGenerator.ecProofSigner(),
 )
 
-internal fun createHttpClient(): HttpClient = HttpClient(Apache) {
+internal fun createHttpClient(enableLogging: Boolean = true): HttpClient = HttpClient(Apache) {
     install(ContentNegotiation) {
         json(
             json = Json { ignoreUnknownKeys = true },
         )
     }
     install(HttpCookies)
-    install(Logging) {
-        logger = Logger.DEFAULT
-        level = LogLevel.ALL
+    if (enableLogging) {
+        install(Logging) {
+            logger = Logger.DEFAULT
+            level = LogLevel.ALL
+        }
     }
     engine {
         customizeClient {


### PR DESCRIPTION
Currently, library models the `proof_types_supported` attribute of a credential configuration, as

```kotlin
Map<ProofType,List<JWSAlgorithm>>
```
This is very limiting given that for different than `ProofType.JWT` there are profiles that define a different set of metadata.

This PR address this problem by introducing a new sealed hierarchy `ProofTypeMeta` supporting different attributes per proof type