### PR TITLE
Deprecate ProofSigner & BindingKey

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,6 @@ dependencies {
     api(libs.ktor.client.content.negotiation)
     api(libs.ktor.client.serialization)
     api(libs.ktor.serialization.kotlinx.json)
-    api(libs.ktor.serialization.kotlinx.cbor)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.jsoup)
     testImplementation(kotlin("test"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.parallel=true
 
 # Project properties
 group=eu.europa.ec.eudi
-version=0.2.4-SNAPSHOT
+version=0.3.0-SNAPSHOT
 
 # Sonar
 systemProp.sonar.host.url=https://sonarcloud.io

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
@@ -32,7 +32,7 @@ typealias ClientId = String
  * @param authorizeIssuanceConfig Instruction on how to assemble the authorization request. If scopes are supported
  * by the credential issuer and [AuthorizeIssuanceConfig.FAVOR_SCOPES] is selected then scopes will be used.
  * Otherwise, authorization details (RAR)
- * @param dPoPProofSigner a signer that if provided will enable the use of DPoP JWT
+ * @param dPoPSigner a signer that if provided will enable the use of DPoP JWT
  */
 data class OpenId4VCIConfig(
     val clientId: ClientId,
@@ -40,12 +40,13 @@ data class OpenId4VCIConfig(
     val keyGenerationConfig: KeyGenerationConfig,
     val credentialResponseEncryptionPolicy: CredentialResponseEncryptionPolicy,
     val authorizeIssuanceConfig: AuthorizeIssuanceConfig = AuthorizeIssuanceConfig.FAVOR_SCOPES,
-    val dPoPProofSigner: ProofSigner? = null,
+    val dPoPSigner: PopSigner.Jwt? = null,
     val clock: Clock = Clock.systemDefaultZone(),
 ) {
+
     init {
-        if (null != dPoPProofSigner) {
-            val key = dPoPProofSigner.getBindingKey()
+        if (null != dPoPSigner) {
+            val key = dPoPSigner.bindingKey
             require(key is JwtBindingKey.Jwk) {
                 "Only JWK can be used with DPoP Proof signer"
             }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
@@ -46,7 +46,7 @@ data class OpenId4VCIConfig(
     init {
         if (null != dPoPProofSigner) {
             val key = dPoPProofSigner.getBindingKey()
-            require(key is BindingKey.Jwk) {
+            require(key is JwtBindingKey.Jwk) {
                 "Only JWK can be used with DPoP Proof signer"
             }
             require(!key.jwk.isPrivate) {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
@@ -252,7 +252,7 @@ interface RequestIssuance {
     @Deprecated(
         message = "Deprecated. Will be removed in a future release.",
         replaceWith = ReplaceWith(
-            "requestSingle(requestPayload, PopSigner.Jwt(proofSigner.getAlgorithm(),proofSigner.getBindingKey(),proofSigner)",
+            "requestSingle(requestPayload, proofSigner.toPopSigner())",
         ),
     )
     suspend fun AuthorizedRequest.ProofRequired.requestSingle(
@@ -261,11 +261,7 @@ interface RequestIssuance {
     ): Result<SubmittedRequest> =
         requestSingle(
             requestPayload,
-            PopSigner.Jwt(
-                algorithm = proofSigner.getAlgorithm(),
-                bindingKey = proofSigner.getBindingKey(),
-                signer = proofSigner,
-            ),
+            proofSigner.toPopSigner(),
         )
 
     /**
@@ -403,13 +399,15 @@ sealed interface PopSigner {
  */
 @Deprecated(
     message = "Deprecated. Will be removed in a future release.",
-    replaceWith = ReplaceWith("PopSigner.Jwt(getAlgorithm(), getBindingKey(), this)"),
+    replaceWith = ReplaceWith("this.toPopSigner()"),
 )
 interface ProofSigner : JWSSigner {
 
     fun getBindingKey(): JwtBindingKey
 
     fun getAlgorithm(): JWSAlgorithm
+
+    fun toPopSigner(): PopSigner.Jwt = PopSigner.Jwt(getAlgorithm(), getBindingKey(), this)
 
     companion object {
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
@@ -359,7 +359,7 @@ fun interface NotifyIssuer {
  */
 interface ProofSigner : JWSSigner {
 
-    fun getBindingKey(): BindingKey
+    fun getBindingKey(): JwtBindingKey
 
     fun getAlgorithm(): JWSAlgorithm
 
@@ -367,21 +367,21 @@ interface ProofSigner : JWSSigner {
 
         fun make(
             privateKey: JWK,
-            publicKey: BindingKey,
+            publicKey: JwtBindingKey,
             algorithm: JWSAlgorithm,
         ): ProofSigner {
             require(privateKey.isPrivate) { "A private key is required" }
             require(
                 when (publicKey) {
-                    is BindingKey.Did -> true // Would require DID resolution which is out of scope
-                    is BindingKey.Jwk -> privateKey.toPublicJWK() == publicKey.jwk
-                    is BindingKey.X509 -> privateKey.toPublicJWK() == JWK.parse(publicKey.chain.first())
+                    is JwtBindingKey.Did -> true // Would require DID resolution which is out of scope
+                    is JwtBindingKey.Jwk -> privateKey.toPublicJWK() == publicKey.jwk
+                    is JwtBindingKey.X509 -> privateKey.toPublicJWK() == JWK.parse(publicKey.chain.first())
                 },
             ) { "Public/private key don't match" }
 
             val signer = DefaultJWSSignerFactory().createJWSSigner(privateKey, algorithm)
             return object : ProofSigner, JWSSigner by signer {
-                override fun getBindingKey(): BindingKey = publicKey
+                override fun getBindingKey(): JwtBindingKey = publicKey
                 override fun getAlgorithm(): JWSAlgorithm = algorithm
             }
         }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
@@ -249,21 +249,6 @@ interface RequestIssuance {
         requestPayload: IssuanceRequestPayload,
     ): Result<SubmittedRequest>
 
-    @Deprecated(
-        message = "Deprecated. Will be removed in a future release.",
-        replaceWith = ReplaceWith(
-            "requestSingle(requestPayload, proofSigner.toPopSigner())",
-        ),
-    )
-    suspend fun AuthorizedRequest.ProofRequired.requestSingle(
-        requestPayload: IssuanceRequestPayload,
-        proofSigner: ProofSigner,
-    ): Result<SubmittedRequest> =
-        requestSingle(
-            requestPayload,
-            proofSigner.toPopSigner(),
-        )
-
     /**
      *  Requests the issuance of a single credential having an [AuthorizedRequest.ProofRequired] authorization. In this
      *  case caller must provide a binding key that will be used for generating a Proof of Possession that issuer expects.

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
@@ -77,7 +77,7 @@ interface Issuer : AuthorizeIssuance, RequestIssuance, QueryForDeferredCredentia
             ktorHttpClientFactory: KtorHttpClientFactory = DefaultHttpClientFactory,
             responseEncryptionSpecFactory: ResponseEncryptionSpecFactory = DefaultResponseEncryptionSpecFactory,
         ): Result<Issuer> = runCatching {
-            val dPoPJwtFactory = config.dPoPProofSigner?.let { signer ->
+            val dPoPJwtFactory = config.dPoPSigner?.let { signer ->
                 DPoPJwtFactory.createForServer(
                     signer = signer,
                     clock = config.clock,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Types.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Types.kt
@@ -179,7 +179,7 @@ value class NotificationId(val value: String) {
 }
 
 @Deprecated(
-    message = "Deprecated. Use JwtBindingKey",
+    message = "Deprecated. It will removed in a future release.",
     replaceWith = ReplaceWith("JwtBindingKey"),
 )
 typealias BindingKey = JwtBindingKey

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Types.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Types.kt
@@ -178,17 +178,25 @@ value class NotificationId(val value: String) {
     }
 }
 
+@Deprecated(
+    message = "Deprecated. Use JwtBindingKey",
+    replaceWith = ReplaceWith("JwtBindingKey"),
+)
+typealias BindingKey = JwtBindingKey
+
 /**
- * A sealed hierarchy that defines the different key formats to be used in order to construct a Proof of Possession.
+ * A sealed hierarchy that defines the different ways of including a PUB key
+ * in a JWT Proof
  */
-sealed interface BindingKey {
+sealed interface JwtBindingKey {
 
     /**
      * A JWK biding key
      */
-    data class Jwk(
+    @JvmInline
+    value class Jwk(
         val jwk: JWK,
-    ) : BindingKey {
+    ) : JwtBindingKey {
         init {
             require(!jwk.isPrivate) { "Binding key of type Jwk must contain a public key" }
         }
@@ -197,16 +205,18 @@ sealed interface BindingKey {
     /**
      * A Did biding key
      */
-    data class Did(
+    @JvmInline
+    value class Did(
         val identity: String,
-    ) : BindingKey
+    ) : JwtBindingKey
 
     /**
      * An X509 biding key
      */
-    data class X509(
+    @JvmInline
+    value class X509(
         val chain: List<X509Certificate>,
-    ) : BindingKey {
+    ) : JwtBindingKey {
         init {
             require(chain.isNotEmpty()) { "Certificate chain cannot be empty" }
         }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/DPoPJwtFactory.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/DPoPJwtFactory.kt
@@ -21,10 +21,7 @@ import com.nimbusds.jwt.SignedJWT
 import com.nimbusds.oauth2.sdk.dpop.DPoPUtils
 import com.nimbusds.oauth2.sdk.id.JWTID
 import com.nimbusds.openid.connect.sdk.Nonce
-import eu.europa.ec.eudi.openid4vci.AccessToken
-import eu.europa.ec.eudi.openid4vci.BindingKey
-import eu.europa.ec.eudi.openid4vci.CIAuthorizationServerMetadata
-import eu.europa.ec.eudi.openid4vci.ProofSigner
+import eu.europa.ec.eudi.openid4vci.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import java.net.URL
@@ -51,7 +48,7 @@ internal class DPoPJwtFactory(
 
     private val publicJwk: JWK by lazy {
         val bk = signer.getBindingKey()
-        require(bk is BindingKey.Jwk) { "Only JWK binding key is supported" }
+        require(bk is JwtBindingKey.Jwk) { "Only JWK binding key is supported" }
         bk.jwk
     }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/DPoPJwtFactory.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/DPoPJwtFactory.kt
@@ -72,7 +72,7 @@ internal class DPoPJwtFactory(
             },
             nonce?.let { Nonce(it) },
         )
-        SignedJWT(jwsHeader, jwtClaimsSet).apply { sign(signer.signer) }
+        SignedJWT(jwsHeader, jwtClaimsSet).apply { sign(signer.jwsSigner) }
     }
 
     private fun now(): Date = Date.from(clock.instant())

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProofBuilder.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProofBuilder.kt
@@ -84,7 +84,7 @@ internal sealed interface ProofBuilder<in POPSigner : PopSigner, out PROOF : Pro
                 claimsSet.issueTime(Date.from(Instant.now()))
                 claimsSet.build()
             }
-            val signedJWT = SignedJWT(header, claims).apply { sign(proofSigner.signer) }
+            val signedJWT = SignedJWT(header, claims).apply { sign(proofSigner.jwsSigner) }
             return Proof.Jwt(signedJWT)
         }
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -86,7 +86,8 @@ internal class RequestIssuanceImpl(
     }
 
     private fun proofFactory(proofSigner: ProofSigner, cNonce: CNonce): ProofFactory = { credentialSupported ->
-        ProofBuilder.ofType(ProofType.JWT) {
+
+        with(ProofBuilder.JwtProofBuilder()) {
             iss(config.clientId)
             aud(credentialOffer.credentialIssuerMetadata.credentialIssuerIdentifier.toString())
             publicKey(proofSigner.getBindingKey())

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -91,7 +91,6 @@ internal class RequestIssuanceImpl(
             is PopSigner.Jwt -> with(ProofBuilder.JwtProofBuilder()) {
                 iss(config.clientId)
                 aud(credentialOffer.credentialIssuerMetadata.credentialIssuerIdentifier.toString())
-                publicKey(proofSigner.bindingKey)
                 credentialSpec(credentialSupported)
                 nonce(cNonce.value)
                 build(proofSigner)

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CryptoGenerator.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CryptoGenerator.kt
@@ -38,19 +38,19 @@ object CryptoGenerator {
         .issueTime(Date(System.currentTimeMillis()))
         .generate()
 
-    fun rsaProofSigner(signingAlgorithm: JWSAlgorithm = JWSAlgorithm.RS256): ProofSigner {
+    fun rsaProofSigner(signingAlgorithm: JWSAlgorithm = JWSAlgorithm.RS256): PopSigner.Jwt {
         val keyPair = randomRSASigningKey(2048)
         val bindingKey = JwtBindingKey.Jwk(
             jwk = keyPair.toPublicJWK(),
         )
-        return ProofSigner.make(keyPair, bindingKey, signingAlgorithm)
+        return PopSigner.jwtPopSigner(keyPair, bindingKey, signingAlgorithm)
     }
 
-    fun ecProofSigner(): ProofSigner {
+    fun ecProofSigner(): PopSigner.Jwt {
         val keyPair = randomECSigningKey(Curve.P_256)
         val bindingKey = JwtBindingKey.Jwk(
             jwk = keyPair.toPublicJWK(),
         )
-        return ProofSigner.make(keyPair, bindingKey, JWSAlgorithm.ES256)
+        return PopSigner.jwtPopSigner(keyPair, bindingKey, JWSAlgorithm.ES256)
     }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CryptoGenerator.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CryptoGenerator.kt
@@ -40,17 +40,13 @@ object CryptoGenerator {
 
     fun rsaProofSigner(signingAlgorithm: JWSAlgorithm = JWSAlgorithm.RS256): PopSigner.Jwt {
         val keyPair = randomRSASigningKey(2048)
-        val bindingKey = JwtBindingKey.Jwk(
-            jwk = keyPair.toPublicJWK(),
-        )
-        return PopSigner.jwtPopSigner(keyPair, bindingKey, signingAlgorithm)
+        val bindingKey = JwtBindingKey.Jwk(keyPair.toPublicJWK())
+        return PopSigner.jwtPopSigner(keyPair, signingAlgorithm, bindingKey)
     }
 
     fun ecProofSigner(): PopSigner.Jwt {
         val keyPair = randomECSigningKey(Curve.P_256)
-        val bindingKey = JwtBindingKey.Jwk(
-            jwk = keyPair.toPublicJWK(),
-        )
-        return PopSigner.jwtPopSigner(keyPair, bindingKey, JWSAlgorithm.ES256)
+        val bindingKey = JwtBindingKey.Jwk(keyPair.toPublicJWK())
+        return PopSigner.jwtPopSigner(keyPair, JWSAlgorithm.ES256, bindingKey)
     }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CryptoGenerator.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CryptoGenerator.kt
@@ -40,7 +40,7 @@ object CryptoGenerator {
 
     fun rsaProofSigner(signingAlgorithm: JWSAlgorithm = JWSAlgorithm.RS256): ProofSigner {
         val keyPair = randomRSASigningKey(2048)
-        val bindingKey = BindingKey.Jwk(
+        val bindingKey = JwtBindingKey.Jwk(
             jwk = keyPair.toPublicJWK(),
         )
         return ProofSigner.make(keyPair, bindingKey, signingAlgorithm)
@@ -48,7 +48,7 @@ object CryptoGenerator {
 
     fun ecProofSigner(): ProofSigner {
         val keyPair = randomECSigningKey(Curve.P_256)
-        val bindingKey = BindingKey.Jwk(
+        val bindingKey = JwtBindingKey.Jwk(
             jwk = keyPair.toPublicJWK(),
         )
         return ProofSigner.make(keyPair, bindingKey, JWSAlgorithm.ES256)

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/Commons.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/Commons.kt
@@ -52,7 +52,7 @@ val DefaultOpenId4VCIConfig = OpenId4VCIConfig(
     authFlowRedirectionURI = URI.create("urn:ietf:wg:oauth:2.0:oob"),
     keyGenerationConfig = KeyGenerationConfig(Curve.P_256, 2048),
     credentialResponseEncryptionPolicy = CredentialResponseEncryptionPolicy.SUPPORTED,
-    dPoPProofSigner = CryptoGenerator.ecProofSigner(),
+    dPoPSigner = CryptoGenerator.ecProofSigner(),
 )
 
 internal fun createHttpClient(enableLogging: Boolean = true): HttpClient = HttpClient(Apache) {

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProofBuilderTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProofBuilderTest.kt
@@ -40,7 +40,6 @@ internal class ProofBuilderTest {
         with(ProofBuilder.JwtProofBuilder()) {
             iss("https://wallet")
             aud("https://issuer")
-            publicKey(signer.bindingKey)
             credentialSpec(universityDegreeJwt())
             nonce("nonce")
             build(signer)
@@ -62,7 +61,6 @@ internal class ProofBuilderTest {
             with(ProofBuilder.JwtProofBuilder()) {
                 iss("https://wallet")
                 aud("https://issuer")
-                publicKey(signer.bindingKey)
                 credentialSpec(universityDegreeJwt())
                 nonce("nonce")
                 build(signer)

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProofBuilderTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProofBuilderTest.kt
@@ -40,7 +40,7 @@ internal class ProofBuilderTest {
         with(ProofBuilder.JwtProofBuilder()) {
             iss("https://wallet")
             aud("https://issuer")
-            publicKey(signer.getBindingKey())
+            publicKey(signer.bindingKey)
             credentialSpec(universityDegreeJwt())
             nonce("nonce")
             build(signer)
@@ -62,7 +62,7 @@ internal class ProofBuilderTest {
             with(ProofBuilder.JwtProofBuilder()) {
                 iss("https://wallet")
                 aud("https://issuer")
-                publicKey(signer.getBindingKey())
+                publicKey(signer.bindingKey)
                 credentialSpec(universityDegreeJwt())
                 nonce("nonce")
                 build(signer)

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProofBuilderTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProofBuilderTest.kt
@@ -37,7 +37,7 @@ internal class ProofBuilderTest {
         assertTrue { signingAlgorithm in proofTypeMeta.algorithms }
 
         val signer = CryptoGenerator.rsaProofSigner(signingAlgorithm)
-        ProofBuilder.ofType(ProofType.JWT) {
+        with(ProofBuilder.JwtProofBuilder()) {
             iss("https://wallet")
             aud("https://issuer")
             publicKey(signer.getBindingKey())
@@ -59,7 +59,7 @@ internal class ProofBuilderTest {
 
         val signer = CryptoGenerator.rsaProofSigner(signingAlgorithm)
         assertFailsWith(CredentialIssuanceError.ProofGenerationError.ProofTypeSigningAlgorithmNotSupported::class) {
-            ProofBuilder.ofType(ProofType.JWT) {
+            with(ProofBuilder.JwtProofBuilder()) {
                 iss("https://wallet")
                 aud("https://issuer")
                 publicKey(signer.getBindingKey())


### PR DESCRIPTION

This PR 
* Deprecates the name `BindingKey` favoring the more correct `JwtBindingKey`
* Deprecates the `ProofSigner` 
* Introduces a new sealed hierarchy named `PopSigner` with a single member `PopSigner.Jwt` 

The usages of `ProofSigner` have been replaced by `PopSigner` or `PopSigner.Jwt` depending on the case.


Closes #232
