### PR TITLE
Support CWT Proofs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     api(libs.ktor.client.content.negotiation)
     api(libs.ktor.client.serialization)
     api(libs.ktor.serialization.kotlinx.json)
+    implementation(libs.authlete.cbor)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.jsoup)
     testImplementation(kotlin("test"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ ktlint = "0.50.0"
 dokka = "1.9.20"
 maven-publish = "0.28.0"
 logback = "1.5.6"
+authlete-cbor = "1.15"
 
 [libraries]
 nimbus-oauth2-oidc-sdk = { module = "com.nimbusds:oauth2-oidc-sdk", version.ref = "nimbus-sdk" }
@@ -30,6 +31,7 @@ ktor-client-logging = {module ="io.ktor:ktor-client-logging", version.ref="ktor"
 jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 cbor = { module = "co.nstant.in:cbor", version.ref = "cbor" }
 logback-classic = {module="ch.qos.logback:logback-classic", version.ref="logback"}
+authlete-cbor = {module="com.authlete:cbor", version.ref="authlete-cbor"}
 
 [plugins]
 dependency-check = { id = "org.owasp.dependencycheck", version.ref = "dependency-check" }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
@@ -33,6 +33,8 @@ typealias ClientId = String
  * by the credential issuer and [AuthorizeIssuanceConfig.FAVOR_SCOPES] is selected then scopes will be used.
  * Otherwise, authorization details (RAR)
  * @param dPoPSigner a signer that if provided will enable the use of DPoP JWT
+ * @param parUsage whether to use PAR in case of authorization code grant
+ * @param clock Wallet's clock
  */
 data class OpenId4VCIConfig(
     val clientId: ClientId,
@@ -41,6 +43,7 @@ data class OpenId4VCIConfig(
     val credentialResponseEncryptionPolicy: CredentialResponseEncryptionPolicy,
     val authorizeIssuanceConfig: AuthorizeIssuanceConfig = AuthorizeIssuanceConfig.FAVOR_SCOPES,
     val dPoPSigner: PopSigner.Jwt? = null,
+    val parUsage: ParUsage = ParUsage.IfSupported,
     val clock: Clock = Clock.systemDefaultZone(),
 ) {
 
@@ -55,6 +58,20 @@ data class OpenId4VCIConfig(
             }
         }
     }
+}
+
+/**
+ * Wallet's policy in regard to using PAR, during a authorization code grant.
+ * - [IfSupported]: If authorization server advertises PAR endpoint it will be used. Otherwise, falls back
+ *   to usual authorization code flow
+ * - [DonNot]: Disables PAR. Wallet will use the usual authorization code flow
+ * - [Always]: Wallet always will place PAR request, regardless what if authorization server advertises the PAR
+ *   endpoint
+ */
+enum class ParUsage {
+    IfSupported,
+    DonNot,
+    Always,
 }
 
 /**

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
@@ -65,13 +65,13 @@ data class OpenId4VCIConfig(
  * - [IfSupported]: If authorization server advertises PAR endpoint it will be used. Otherwise, falls back
  *   to usual authorization code flow
  * - [Never]: Disables PAR. Wallet will use the usual authorization code flow
- * - [Always]: Wallet always will place PAR request, regardless what if authorization server advertises the PAR
- *   endpoint
+ * - [Required]: Wallet always will place PAR request, regardless what if authorization server advertises the PAR
+ *   endpoint. If PAR endpoint is not being advertised, the issuance will fail.
  */
 enum class ParUsage {
     IfSupported,
     Never,
-    Always,
+    Required,
 }
 
 /**

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
@@ -64,13 +64,13 @@ data class OpenId4VCIConfig(
  * Wallet's policy in regard to using PAR, during a authorization code grant.
  * - [IfSupported]: If authorization server advertises PAR endpoint it will be used. Otherwise, falls back
  *   to usual authorization code flow
- * - [DonNot]: Disables PAR. Wallet will use the usual authorization code flow
+ * - [Never]: Disables PAR. Wallet will use the usual authorization code flow
  * - [Always]: Wallet always will place PAR request, regardless what if authorization server advertises the PAR
  *   endpoint
  */
 enum class ParUsage {
     IfSupported,
-    DonNot,
+    Never,
     Always,
 }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
@@ -159,6 +159,7 @@ fun MsoMdocClaims.toClaimSet(): MsoMdocClaimSet = MsoMdocClaimSet(
     mapValues { (_, claims) -> claims.keys.toList() }
         .flatMap { (nameSpace, claims) -> claims.map { claimName -> nameSpace to claimName } },
 )
+data class MsoMdocPolicy(val oneTimeUse: Boolean, val batchSize: Int?) : Serializable
 
 /**
  * The data of a Verifiable Credentials issued as an ISO MDOC.
@@ -169,6 +170,7 @@ data class MsoMdocCredential(
     override val credentialSigningAlgorithmsSupported: List<String> = emptyList(),
     val isoCredentialSigningAlgorithmsSupported: List<CoseAlgorithm> = emptyList(),
     val isoCredentialCurvesSupported: List<CoseCurve> = emptyList(),
+    val isoPolicy: MsoMdocPolicy?,
     override val proofTypesSupported: ProofTypesSupported = ProofTypesSupported.Empty,
     override val display: List<Display> = emptyList(),
     val docType: String,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
@@ -64,8 +64,11 @@ sealed interface ProofTypeMeta : Serializable {
         }
     }
 
-    data object Cwt : ProofTypeMeta {
-        private fun readResolve(): Any = Cwt
+    data class Cwt(val algorithms: List<CoseAlgorithm>, val curves: List<CoseCurve>) : ProofTypeMeta {
+        init {
+            require(algorithms.isNotEmpty()) { "Supported algorithms in case of CWT cannot be empty" }
+            require(curves.isNotEmpty()) { "Supported curves in case of CWT cannot be empty" }
+        }
     }
 
     data object LdpVp : ProofTypeMeta {
@@ -152,6 +155,10 @@ data class Claim(
 typealias Namespace = String
 typealias ClaimName = String
 typealias MsoMdocClaims = Map<Namespace, Map<ClaimName, Claim>>
+fun MsoMdocClaims.toClaimSet(): MsoMdocClaimSet = MsoMdocClaimSet(
+    mapValues { (_, claims) -> claims.keys.toList() }
+        .flatMap { (nameSpace, claims) -> claims.map { claimName -> nameSpace to claimName } },
+)
 
 /**
  * The data of a Verifiable Credentials issued as an ISO MDOC.
@@ -160,6 +167,8 @@ data class MsoMdocCredential(
     override val scope: String? = null,
     override val cryptographicBindingMethodsSupported: List<CryptographicBindingMethod> = emptyList(),
     override val credentialSigningAlgorithmsSupported: List<String> = emptyList(),
+    val isoCredentialSigningAlgorithmsSupported: List<CoseAlgorithm> = emptyList(),
+    val isoCredentialCurvesSupported: List<CoseCurve> = emptyList(),
     override val proofTypesSupported: ProofTypesSupported = ProofTypesSupported.Empty,
     override val display: List<Display> = emptyList(),
     val docType: String,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
@@ -94,6 +94,7 @@ interface Issuer : AuthorizeIssuance, RequestIssuance, QueryForDeferredCredentia
                 config,
                 ktorHttpClientFactory,
                 dPoPJwtFactory,
+                config.parUsage,
             )
             val responseEncryptionSpec =
                 responseEncryptionSpec(credentialOffer, config, responseEncryptionSpecFactory).getOrThrow()

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Types.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Types.kt
@@ -223,6 +223,28 @@ sealed interface JwtBindingKey {
     }
 }
 
+sealed interface CwtBindingKey {
+
+    @JvmInline
+    value class CoseKey(val jwk: JWK) : CwtBindingKey {
+        init {
+            require(!jwk.isPrivate) { "Binding key of type Jwk must contain a public key" }
+        }
+    }
+
+    /**
+     * An X509 biding key
+     */
+    @JvmInline
+    value class X509(
+        val chain: List<X509Certificate>,
+    ) : CwtBindingKey {
+        init {
+            require(chain.isNotEmpty()) { "Certificate chain cannot be empty" }
+        }
+    }
+}
+
 data class IssuanceResponseEncryptionSpec(
     val jwk: JWK,
     val algorithm: JWEAlgorithm,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/AuthorizeIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/AuthorizeIssuanceImpl.kt
@@ -34,6 +34,7 @@ internal class AuthorizeIssuanceImpl(
     private val config: OpenId4VCIConfig,
     ktorHttpClientFactory: KtorHttpClientFactory,
     dPoPJwtFactory: DPoPJwtFactory?,
+    parUsage: ParUsage,
 ) : AuthorizeIssuance {
 
     private val authorizationServer: AuthorizationServerClient =
@@ -43,6 +44,7 @@ internal class AuthorizeIssuanceImpl(
             config,
             dPoPJwtFactory,
             ktorHttpClientFactory,
+            parUsage,
         )
 
     override suspend fun prepareAuthorizationRequest(walletState: String?): Result<AuthorizationRequestPrepared> =

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProofBuilder.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProofBuilder.kt
@@ -152,13 +152,9 @@ internal class CwtProofBuilder(
 
     private fun payload(): CBORByteArray {
         val claims = CWTClaimsSetBuilder().apply {
-            // Claim Key 1 (iss)
             iss(iss)
-            // Claim Key 3 (aud)
             aud(aud.toString())
-            // Claim Key 6 (iat)
             iat(Date.from(clock.instant()))
-            // Claim Key 10 (Nonce)
             nonce(nonce.value)
         }.build()
         return CBORByteArray(claims.encode())

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProofBuilder.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProofBuilder.kt
@@ -15,6 +15,10 @@
  */
 package eu.europa.ec.eudi.openid4vci.internal
 
+import com.authlete.cbor.CBORByteArray
+import com.authlete.cose.*
+import com.authlete.cwt.CWT
+import com.authlete.cwt.CWTClaimsSetBuilder
 import com.nimbusds.jose.JOSEObjectType
 import com.nimbusds.jose.JWSHeader
 import com.nimbusds.jose.util.Base64
@@ -51,6 +55,11 @@ internal abstract class ProofBuilder<POP_SIGNER : PopSigner, out PROOF : Proof>(
                 is PopSigner.Jwt -> {
                     JwtProofBuilder.check(popSigner, proofTypesSupported)
                     JwtProofBuilder(clock, iss, aud, nonce, popSigner)
+                }
+
+                is PopSigner.Cwt -> {
+                    CwtProofBuilder.check(popSigner, proofTypesSupported)
+                    CwtProofBuilder(clock, iss, aud, nonce, popSigner)
                 }
             }
         }
@@ -103,6 +112,90 @@ internal class JwtProofBuilder(
             }
             val proofTypeSigningAlgorithmsSupported = spec.algorithms
             ensure(popSigner.algorithm in proofTypeSigningAlgorithmsSupported) {
+                CredentialIssuanceError.ProofGenerationError.ProofTypeSigningAlgorithmNotSupported
+            }
+        }
+    }
+}
+
+internal class CwtProofBuilder(
+    clock: Clock,
+    iss: ClientId,
+    aud: CredentialIssuerId,
+    nonce: CNonce,
+    popSigner: PopSigner.Cwt,
+) : ProofBuilder<PopSigner.Cwt, Proof.Cwt>(clock, iss, aud, nonce, popSigner) {
+
+    override suspend fun build(): Proof.Cwt {
+        val protectedHeader = protectedHeader()
+        val payload = payload()
+        val structure = sigStructure(protectedHeader, payload)
+        val signature: ByteArray = popSigner.sign(structure.encode())
+        val sign1 = sign1(protectedHeader, payload, signature)
+        val cwt = CWT(sign1)
+        return Proof.Cwt(cwt.encodeToBase64Url())
+    }
+
+    private fun protectedHeader(): COSEProtectedHeader =
+        COSEProtectedHeaderBuilder().apply {
+            alg(popSigner.algorithm.value)
+            contentType(HEADER_TYPE)
+            when (val bindingKey = popSigner.bindingKey) {
+                is CwtBindingKey.CoseKey -> {
+                    val key = COSEKey.fromJwk(bindingKey.jwk.toJSONObject())
+                    put("COSE_Key", key)
+                }
+
+                is CwtBindingKey.X509 -> error("Not supported yet")
+            }
+        }.build()
+
+    private fun payload(): CBORByteArray {
+        val claims = CWTClaimsSetBuilder().apply {
+            // Claim Key 1 (iss)
+            iss(iss)
+            // Claim Key 3 (aud)
+            aud(aud.toString())
+            // Claim Key 6 (iat)
+            iat(Date.from(clock.instant()))
+            // Claim Key 10 (Nonce)
+            nonce(nonce.value)
+        }.build()
+        return CBORByteArray(claims.encode())
+    }
+
+    private fun sigStructure(
+        protectedHeader: COSEProtectedHeader,
+        payload: CBORByteArray,
+    ): SigStructure = SigStructureBuilder()
+        .signature1()
+        .bodyAttributes(protectedHeader)
+        .payload(payload)
+        .build()
+
+    private fun sign1(
+        protectedHeader: COSEProtectedHeader,
+        payload: CBORByteArray,
+        signature: ByteArray,
+    ): COSESign1 =
+        COSESign1Builder()
+            .protectedHeader(protectedHeader)
+            .payload(payload)
+            .signature(signature)
+            .build()
+
+    companion object : CheckPopSigner<PopSigner.Cwt> {
+
+        private const val HEADER_TYPE = "openid4vci-proof+cwt"
+        override fun check(popSigner: PopSigner.Cwt, proofTypesSupported: ProofTypesSupported) {
+            val spec = proofTypesSupported.values.filterIsInstance<ProofTypeMeta.Cwt>().firstOrNull()
+            ensureNotNull(spec) {
+                CredentialIssuanceError.ProofGenerationError.ProofTypeNotSupported
+            }
+            ensure(popSigner.algorithm in spec.algorithms) {
+                CredentialIssuanceError.ProofGenerationError.ProofTypeSigningAlgorithmNotSupported
+            }
+            ensure(popSigner.curve in spec.curves) {
                 CredentialIssuanceError.ProofGenerationError.ProofTypeSigningAlgorithmNotSupported
             }
         }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -152,7 +152,11 @@ internal class RequestIssuanceImpl(
         }
         val credentialSupported = credentialSupportedById(credentialConfigurationId)
         val proof = proofFactory?.invoke(credentialSupported)?.also { assertProofSupported(it, credentialSupported) }
-        return CredentialIssuanceRequest.IdentifierBased(credentialId, proof, responseEncryptionSpec.takeIf { includeEncryptionSpec })
+        return CredentialIssuanceRequest.IdentifierBased(
+            credentialId,
+            proof,
+            responseEncryptionSpec.takeIf { includeEncryptionSpec },
+        )
     }
 
     private fun assertProofSupported(p: Proof, credentialSupported: CredentialConfiguration) {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/AuthorizationServerClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/AuthorizationServerClient.kt
@@ -191,7 +191,7 @@ internal class AuthorizationServerClient(
                 if (credentialsConfigurationIds.isNotEmpty()) {
                     authorizationDetails(credentialsConfigurationIds.map(::toNimbus))
                 }
-                // prompt(Prompt.Type.LOGIN)
+                prompt(Prompt.Type.LOGIN)
             }.build()
             PushedAuthorizationRequest(parEndpoint, request)
         }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/AuthorizationServerClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/AuthorizationServerClient.kt
@@ -178,7 +178,7 @@ internal class AuthorizationServerClient(
                 state(State(state))
                 issuerState?.let { customParameter("issuer_state", issuerState) }
                 if (scopes.isNotEmpty()) {
-                    scope(NimbusScope(*scopes.map { it.value }.toTypedArray() + "openid"))
+                    scope(NimbusScope(*scopes.map { it.value }.toTypedArray()))
                 }
                 if (credentialsConfigurationIds.isNotEmpty()) {
                     authorizationDetails(credentialsConfigurationIds.map(::toNimbus))
@@ -210,7 +210,7 @@ internal class AuthorizationServerClient(
             state(State(state))
             issuerState?.let { customParameter("issuer_state", issuerState) }
             if (credentialsScopes.isNotEmpty()) {
-                scope(NimbusScope(*credentialsScopes.map { it.value }.toTypedArray() + "openid"))
+                scope(NimbusScope(*credentialsScopes.map { it.value }.toTypedArray()))
             }
             if (credentialsAuthorizationDetails.isNotEmpty()) {
                 authorizationDetails(credentialsAuthorizationDetails.map(::toNimbus))

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/AuthorizationServerClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/AuthorizationServerClient.kt
@@ -145,7 +145,12 @@ internal class AuthorizationServerClient(
         val usePar = when (parUsage) {
             ParUsage.IfSupported -> supportsPar
             ParUsage.Never -> false
-            ParUsage.Always -> true
+            ParUsage.Required -> {
+                require(supportsPar) {
+                    "PAR uses is required, yet authorization server doesn't advertise PAR endpoint"
+                }
+                true
+            }
         }
         return if (usePar) {
             submitPushedAuthorizationRequest(scopes, credentialsConfigurationIds, state, issuerState)
@@ -177,6 +182,7 @@ internal class AuthorizationServerClient(
         }
 
         val parEndpoint = authorizationServerMetadata.pushedAuthorizationRequestEndpointURI
+        checkNotNull(parEndpoint) { "PAR endpoint not advertised" }
         val clientID = ClientID(config.clientId)
         val codeVerifier = CodeVerifier()
         val pushedAuthorizationRequest = run {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/AuthorizationServerClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/AuthorizationServerClient.kt
@@ -144,7 +144,7 @@ internal class AuthorizationServerClient(
     ): Result<Pair<PKCEVerifier, HttpsUrl>> {
         val usePar = when (parUsage) {
             ParUsage.IfSupported -> supportsPar
-            ParUsage.DonNot -> false
+            ParUsage.Never -> false
             ParUsage.Always -> true
         }
         return if (usePar) {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/AuthorizationServerClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/AuthorizationServerClient.kt
@@ -130,6 +130,7 @@ internal class AuthorizationServerClient(
     private val config: OpenId4VCIConfig,
     private val dPoPJwtFactory: DPoPJwtFactory?,
     private val ktorHttpClientFactory: KtorHttpClientFactory,
+    private val parUsage: ParUsage,
 ) {
 
     private val supportsPar: Boolean
@@ -140,12 +141,18 @@ internal class AuthorizationServerClient(
         credentialsConfigurationIds: List<CredentialConfigurationIdentifier>,
         state: String,
         issuerState: String?,
-    ): Result<Pair<PKCEVerifier, HttpsUrl>> =
-        if (supportsPar) {
+    ): Result<Pair<PKCEVerifier, HttpsUrl>> {
+        val usePar = when (parUsage) {
+            ParUsage.IfSupported -> supportsPar
+            ParUsage.DonNot -> false
+            ParUsage.Always -> true
+        }
+        return if (usePar) {
             submitPushedAuthorizationRequest(scopes, credentialsConfigurationIds, state, issuerState)
         } else {
             authorizationRequestUrl(scopes, credentialsConfigurationIds, state, issuerState)
         }
+    }
 
     /**
      * Submit Pushed Authorization Request for authorizing an issuance request.

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/AuthorizationServerClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/AuthorizationServerClient.kt
@@ -25,6 +25,7 @@ import com.nimbusds.oauth2.sdk.pkce.CodeVerifier
 import com.nimbusds.oauth2.sdk.rar.AuthorizationDetail
 import com.nimbusds.oauth2.sdk.rar.AuthorizationType
 import com.nimbusds.oauth2.sdk.rar.Location
+import com.nimbusds.openid.connect.sdk.Prompt
 import eu.europa.ec.eudi.openid4vci.*
 import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.AccessTokenRequestFailed
 import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.PushedAuthorizationRequestFailed
@@ -183,6 +184,7 @@ internal class AuthorizationServerClient(
                 if (credentialsConfigurationIds.isNotEmpty()) {
                     authorizationDetails(credentialsConfigurationIds.map(::toNimbus))
                 }
+                prompt(Prompt.Type.LOGIN)
             }.build()
             PushedAuthorizationRequest(parEndpoint, request)
         }
@@ -215,6 +217,7 @@ internal class AuthorizationServerClient(
             if (credentialsAuthorizationDetails.isNotEmpty()) {
                 authorizationDetails(credentialsAuthorizationDetails.map(::toNimbus))
             }
+            prompt(Prompt.Type.LOGIN)
         }.build()
 
         val pkceVerifier = PKCEVerifier(codeVerifier.value, CodeChallengeMethod.S256.toString())

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/AuthorizationServerClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/AuthorizationServerClient.kt
@@ -191,7 +191,7 @@ internal class AuthorizationServerClient(
                 if (credentialsConfigurationIds.isNotEmpty()) {
                     authorizationDetails(credentialsConfigurationIds.map(::toNimbus))
                 }
-                prompt(Prompt.Type.LOGIN)
+                // prompt(Prompt.Type.LOGIN)
             }.build()
             PushedAuthorizationRequest(parEndpoint, request)
         }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CryptoGenerator.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CryptoGenerator.kt
@@ -115,6 +115,14 @@ object CryptoGenerator {
             }
             ProofTypeMeta.LdpVp -> null
         }
+
+    fun popSigner(
+        clock: Clock = Clock.systemDefaultZone(),
+        credentialConfiguration: CredentialConfiguration,
+    ): PopSigner? =
+        credentialConfiguration.proofTypesSupported.values.asSequence().mapNotNull {
+            popSigner(clock, it)
+        }.firstOrNull()
 }
 
 fun CoseAlgorithm.toNimbus(): JWSAlgorithm? = JWSAlgorithm.parse(name())

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/MockData.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/MockData.kt
@@ -253,6 +253,7 @@ internal fun mobileDrivingLicense() = MsoMdocCredential(
     listOf("ES256", "ES384", "ES512"),
     emptyList(),
     emptyList(),
+    null,
     ProofTypesSupported(setOf(ProofTypeMeta.Jwt(listOf(JWSAlgorithm.RS256, JWSAlgorithm.ES256)))),
     listOf(
         Display(

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/MockData.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/MockData.kt
@@ -251,6 +251,8 @@ internal fun mobileDrivingLicense() = MsoMdocCredential(
     "MobileDrivingLicense_msoMdoc",
     listOf(CryptographicBindingMethod.COSE),
     listOf("ES256", "ES384", "ES512"),
+    emptyList(),
+    emptyList(),
     ProofTypesSupported(setOf(ProofTypeMeta.Jwt(listOf(JWSAlgorithm.RS256, JWSAlgorithm.ES256)))),
     listOf(
         Display(

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/Commons.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/Commons.kt
@@ -15,102 +15,21 @@
  */
 package eu.europa.ec.eudi.openid4vci.examples
 
-import com.nimbusds.jose.jwk.Curve
 import eu.europa.ec.eudi.openid4vci.*
 import io.ktor.client.*
-import io.ktor.client.call.*
 import io.ktor.client.engine.apache.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.plugins.cookies.*
 import io.ktor.client.plugins.logging.*
-import io.ktor.client.request.*
-import io.ktor.client.request.forms.*
-import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import org.apache.http.conn.ssl.NoopHostnameVerifier
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy
 import org.apache.http.ssl.SSLContextBuilder
-import org.jsoup.Jsoup
-import org.jsoup.nodes.FormElement
-import java.net.URI
-import java.net.URL
 
-internal object PidDevIssuer {
-    private const val BASE_URL = "https://dev.issuer-backend.eudiw.dev"
-    private const val WALLET_CLIENT_ID = "wallet-dev"
-    private val WalletRedirectURI = URI.create("urn:ietf:wg:oauth:2.0:oob")
-    val IssuerId = CredentialIssuerId(BASE_URL).getOrThrow()
-    val TestUser = ActingUser("tneal", "password")
-
-    internal class ActingUser(
-        val username: String,
-        val password: String,
-    )
-
-    val PID_SdJwtVC_config_id = CredentialConfigurationIdentifier("eu.europa.ec.eudiw.pid_vc_sd_jwt")
-    val PID_MsoMdoc_config_id = CredentialConfigurationIdentifier("eu.europa.ec.eudiw.pid_mso_mdoc")
-    val MDL_config_id = CredentialConfigurationIdentifier("org.iso.18013.5.1.mDL")
-
-    val AllCredentialConfigurationIds = listOf(
-        PID_SdJwtVC_config_id,
-        PID_MsoMdoc_config_id,
-        MDL_config_id,
-    )
-
-    val Cfg = OpenId4VCIConfig(
-        clientId = WALLET_CLIENT_ID,
-        authFlowRedirectionURI = WalletRedirectURI,
-        keyGenerationConfig = KeyGenerationConfig(Curve.P_256, 2048),
-        credentialResponseEncryptionPolicy = CredentialResponseEncryptionPolicy.SUPPORTED,
-        dPoPSigner = CryptoGenerator.ecProofSigner(),
-    )
-
-    suspend fun loginUserAndGetAuthCode(
-        preparedAuthorizationCodeRequest: AuthorizationRequestPrepared,
-        actingUser: ActingUser,
-    ): Pair<String, String>? = coroutineScope {
-        suspend fun extractASLoginUrl(html: String): URL = withContext(Dispatchers.IO) {
-            val form = Jsoup.parse(html).body().getElementById("kc-form-login") as FormElement
-            val action = form.attr("action")
-            URL(action)
-        }
-
-        val response = createHttpClient().use { client ->
-            val loginUrl = async {
-                val url = preparedAuthorizationCodeRequest.authorizationCodeURL.value
-                val loginHtml = client.get(url).body<String>()
-                extractASLoginUrl(loginHtml)
-            }
-            client.submitForm(
-                url = loginUrl.await().toString(),
-                formParameters = Parameters.build {
-                    append("username", actingUser.username)
-                    append("password", actingUser.password)
-                },
-            )
-        }
-        val redirectLocation = response.headers["Location"].toString()
-        with(URLBuilder(redirectLocation)) {
-            parameters["code"] to parameters["state"]
-        }.toNullable()
-    }
-
-    private fun <A, B> Pair<A?, B?>.toNullable(): Pair<A, B>? {
-        return if (first != null && second != null) first!! to second!!
-        else null
-    }
+fun interface UserInteractionAuthorizeIssuance {
+    suspend operator fun invoke(authorizationRequestPrepared: AuthorizationRequestPrepared): Pair<String, String>
 }
-
-val DefaultProofSignersMap = mapOf(
-    PidDevIssuer.PID_SdJwtVC_config_id to CryptoGenerator.rsaProofSigner(),
-    PidDevIssuer.PID_MsoMdoc_config_id to CryptoGenerator.ecProofSigner(),
-    PidDevIssuer.MDL_config_id to CryptoGenerator.ecProofSigner(),
-)
 
 internal fun createHttpClient(enableLogging: Boolean = true): HttpClient = HttpClient(Apache) {
     install(ContentNegotiation) {
@@ -142,4 +61,17 @@ internal fun authorizationLog(message: String) {
 
 internal fun issuanceLog(message: String) {
     println("--> [ISSUANCE] $message")
+}
+
+//
+// Issuer extensions
+//
+
+fun Issuer.popSigner(credentialConfigurationIdentifier: CredentialConfigurationIdentifier): PopSigner {
+    val credentialConfigurationsSupported =
+        credentialOffer.credentialIssuerMetadata.credentialConfigurationsSupported
+    val credentialConfiguration =
+        checkNotNull(credentialConfigurationsSupported[credentialConfigurationIdentifier])
+    val popSigner = CryptoGenerator.popSigner(credentialConfiguration = credentialConfiguration)
+    return checkNotNull(popSigner) { "No signer can be generated for $credentialConfigurationIdentifier" }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/Commons.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/Commons.kt
@@ -22,14 +22,16 @@ import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.plugins.cookies.*
 import io.ktor.client.plugins.logging.*
 import io.ktor.serialization.kotlinx.json.*
+import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.json.Json
 import org.apache.http.conn.ssl.NoopHostnameVerifier
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy
 import org.apache.http.ssl.SSLContextBuilder
-
-fun interface UserInteractionAuthorizeIssuance {
-    suspend operator fun invoke(authorizationRequestPrepared: AuthorizationRequestPrepared): Pair<String, String>
-}
+import org.junit.jupiter.api.assertDoesNotThrow
+import java.net.URI
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.fail
 
 internal fun createHttpClient(enableLogging: Boolean = true): HttpClient = HttpClient(Apache) {
     install(ContentNegotiation) {
@@ -74,4 +76,189 @@ fun Issuer.popSigner(credentialConfigurationIdentifier: CredentialConfigurationI
         checkNotNull(credentialConfigurationsSupported[credentialConfigurationIdentifier])
     val popSigner = CryptoGenerator.popSigner(credentialConfiguration = credentialConfiguration)
     return checkNotNull(popSigner) { "No signer can be generated for $credentialConfigurationIdentifier" }
+}
+
+suspend fun Issuer.submitCredentialRequest(
+    authorizedRequest: AuthorizedRequest,
+    credentialConfigurationId: CredentialConfigurationIdentifier =
+        credentialOffer.credentialConfigurationIdentifiers.first(),
+    claimSet: ClaimSet? = null,
+): SubmittedRequest {
+    val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, claimSet)
+    return when (authorizedRequest) {
+        is AuthorizedRequest.ProofRequired -> {
+            with(authorizedRequest) {
+                val popSigner = popSigner(credentialConfigurationId)
+                requestSingle(requestPayload, popSigner).getOrThrow()
+            }
+        }
+
+        is AuthorizedRequest.NoProofRequired -> with(authorizedRequest) { requestSingle(requestPayload).getOrThrow() }
+    }
+}
+
+suspend fun <ENV, USER> Issuer.authorizeUsingAuthorizationCodeFlow(env: ENV): AuthorizedRequest
+    where
+          ENV : HasTestUser<USER>,
+          ENV : CanAuthorizeIssuance<USER> =
+    coroutineScope {
+        val authorizationRequestPrepared = prepareAuthorizationRequest(walletState = null).getOrThrow()
+        with(authorizationRequestPrepared) {
+            val testUser = env.testUser
+            val (authorizationCode, serverState) = env.loginUserAndGetAuthCode(authorizationRequestPrepared, testUser)
+            authorizeWithAuthorizationCode(AuthorizationCode(authorizationCode), serverState).getOrThrow()
+        }
+    }
+
+/**
+ *
+ */
+suspend fun <ENV, USER> Issuer.testIssuanceWithAuthorizationCodeFlow(
+    env: ENV,
+    credCfgId: CredentialConfigurationIdentifier = credentialOffer.credentialConfigurationIdentifiers.first(),
+    claimSetToRequest: ClaimSet? = null,
+) where
+      ENV : HasTestUser<USER>,
+      ENV : CanAuthorizeIssuance<USER> =
+    coroutineScope {
+        val outcome = run {
+            val authorizedRequest = authorizeUsingAuthorizationCodeFlow(env)
+            submitCredentialRequest(authorizedRequest, credCfgId, claimSetToRequest)
+        }
+
+        ensureIssued(outcome)
+        Unit
+    }
+
+suspend fun Issuer.testIssuanceWithPreAuthorizedCodeFlow(
+    txCode: String?,
+    credCfgId: CredentialConfigurationIdentifier,
+    claimSetToRequest: ClaimSet?,
+) {
+    val outcome = run {
+        val authorizedRequest = authorizeWithPreAuthorizationCode(txCode).getOrThrow()
+        submitCredentialRequest(authorizedRequest, credCfgId, claimSetToRequest)
+    }
+
+    ensureIssued(outcome)
+}
+
+fun ensureIssued(outcome: SubmittedRequest): List<String> =
+    when (outcome) {
+        is SubmittedRequest.Failed -> {
+            fail("Issuer rejected request. Reason :${outcome.error.message}")
+        }
+
+        is SubmittedRequest.InvalidProof -> {
+            val (_, error) = outcome
+            fail("Issuer rejected proof. Reason: ${error ?: "n/a"}")
+        }
+
+        is SubmittedRequest.Success -> {
+            outcome.credentials.map { issued ->
+                val issuedCredential = assertIs<IssuedCredential.Issued>(issued)
+                issuedCredential.credential.also { println(it) }
+            }
+        }
+    }
+
+//
+// ENV extensions
+//
+
+/**
+ * Test the issuance of [credCfgId] using authorize code flow
+ *
+ * 1) Places a request for a [CredentialOffer]
+ * 2) Creates an [Issuer]
+ * 3) Uses the above to run execute the issuance
+ *
+ *
+ */
+suspend fun <ENV, USER> ENV.testIssuanceWithAuthorizationCodeFlow(
+    credCfgId: CredentialConfigurationIdentifier,
+    enableHttLogging: Boolean = false,
+    claimSetToRequest: (CredentialConfiguration) -> ClaimSet? = { null },
+) where
+      ENV : HasTestUser<USER>,
+      ENV : CanAuthorizeIssuance<USER>,
+      ENV : CanBeUsedWithVciLib,
+      ENV : CanRequestForCredentialOffer<USER> {
+    val credentialOfferUri = requestAuthorizationCodeGrantOffer(credCfgIds = setOf(credCfgId))
+    val issuer = assertDoesNotThrow {
+        createIssuer(credentialOfferUri.toString(), enableHttLogging)
+    }
+
+    with(issuer) {
+        val credCfg = credentialOffer.credentialIssuerMetadata.credentialConfigurationsSupported[credCfgId]
+        assertNotNull(credCfg)
+        testIssuanceWithAuthorizationCodeFlow(
+            env = this@testIssuanceWithAuthorizationCodeFlow,
+            claimSetToRequest = claimSetToRequest.invoke(credCfg),
+        )
+    }
+}
+
+suspend fun <ENV, USER> ENV.testIssuanceWithPreAuthorizedCodeFlow(
+    txCode: String?,
+    credCfgId: CredentialConfigurationIdentifier,
+    credentialOfferEndpoint: String? = null,
+    enableHttLogging: Boolean = false,
+    claimSetToRequest: (CredentialConfiguration) -> ClaimSet? = { null },
+) where ENV : CanBeUsedWithVciLib, ENV : HasTestUser<USER>, ENV : CanRequestForCredentialOffer<USER> {
+    val credentialOfferUri = requestPreAuthorizedCodeGrantOffer(
+        setOf(credCfgId),
+        txCode = txCode,
+        credentialOfferEndpoint = credentialOfferEndpoint,
+    )
+    val issuer = assertDoesNotThrow {
+        createIssuer(credentialOfferUri.toString(), enableHttLogging)
+    }
+    with(issuer) {
+        val credCfg = credentialOffer.credentialIssuerMetadata.credentialConfigurationsSupported[credCfgId]
+        assertNotNull(credCfg)
+        testIssuanceWithPreAuthorizedCodeFlow(txCode, credCfgId, claimSetToRequest(credCfg))
+    }
+}
+
+/**
+ * Given that a [Credential Issuer][ENV] [HasTestUser] and [CanRequestForCredentialOffer]
+ * the method places a request for a [CredentialOffer] that uses the authorization code grant
+ */
+suspend fun <ENV, USER> ENV.requestAuthorizationCodeGrantOffer(
+    credCfgIds: Set<CredentialConfigurationIdentifier>,
+    issuerStateIncluded: Boolean = true,
+    credentialOfferEndpoint: String? = null,
+): URI
+    where
+          ENV : HasTestUser<USER>,
+          ENV : CanRequestForCredentialOffer<USER> {
+    val form = CredentialOfferForm.authorizationCodeGrant(
+        user = testUser,
+        credCfgIds,
+        issuerStateIncluded,
+        credentialOfferEndpoint,
+    )
+    return requestCredentialOffer(form)
+}
+
+/**
+ * Given that a [Credential Issuer][ENV] [HasTestUser] and [CanRequestForCredentialOffer]
+ * the method places a request for a [CredentialOffer] that uses the pre-authorized code grant
+ */
+suspend fun <ENV, USER> ENV.requestPreAuthorizedCodeGrantOffer(
+    credCfgIds: Set<CredentialConfigurationIdentifier>,
+    txCode: String?,
+    credentialOfferEndpoint: String? = null,
+): URI
+    where
+          ENV : HasTestUser<USER>,
+          ENV : CanRequestForCredentialOffer<USER> {
+    val form = CredentialOfferForm.preAuthorizedCodeGrant(
+        testUser,
+        credCfgIds,
+        txCode,
+        credentialOfferEndpoint,
+    )
+    return requestCredentialOffer(form)
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingAuthorizationFlow.kt
@@ -68,7 +68,7 @@ fun main(): Unit = runBlocking {
 
 private suspend fun authorizeRequestWithAuthCodeUseCase(
     issuer: Issuer,
-    actingUser: PidDevIssuer.ActingUser,
+    actingUser: ActingUser,
 ): AuthorizedRequest =
     with(issuer) {
         authorizationLog("Preparing authorization code request")
@@ -79,7 +79,6 @@ private suspend fun authorizeRequestWithAuthCodeUseCase(
 
         val (authorizationCode, serverState) =
             PidDevIssuer.loginUserAndGetAuthCode(prepareAuthorizationCodeRequest, actingUser)
-                ?: error("Could not retrieve authorization code")
 
         authorizationLog("Authorization code retrieved: $authorizationCode")
 
@@ -122,9 +121,7 @@ private suspend fun submitProvidingProofs(
     credentialConfigurationId: CredentialConfigurationIdentifier,
 ): String {
     with(issuer) {
-        val proofSigner = DefaultProofSignersMap[credentialConfigurationId]
-            ?: error("No signer found for credential $credentialConfigurationId")
-
+        val proofSigner = popSigner(credentialConfigurationId)
         val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, null)
         val submittedRequest = authorized.requestSingle(requestPayload, proofSigner).getOrThrow()
 

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingAuthorizationFlow.kt
@@ -68,7 +68,7 @@ fun main(): Unit = runBlocking {
 
 private suspend fun authorizeRequestWithAuthCodeUseCase(
     issuer: Issuer,
-    actingUser: ActingUser,
+    actingUser: KeycloakUser,
 ): AuthorizedRequest =
     with(issuer) {
         authorizationLog("Preparing authorization code request")

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingAuthorizationFlow.kt
@@ -30,7 +30,7 @@ fun main(): Unit = runBlocking {
     println("[[Scenario: Issuance based on credential offer url: $credentialOfferUrl]] ")
 
     val issuer = Issuer.make(
-        config = PidDevIssuer.Cfg,
+        config = PidDevIssuer.cfg,
         credentialOfferUri = credentialOfferUrl,
         ktorHttpClientFactory = ::createHttpClient,
     ).getOrThrow()
@@ -41,7 +41,7 @@ fun main(): Unit = runBlocking {
     }
 
     authorizationLog("Using authorized code flow to authorize")
-    val authorizedRequest = authorizeRequestWithAuthCodeUseCase(issuer, PidDevIssuer.TestUser)
+    val authorizedRequest = authorizeRequestWithAuthCodeUseCase(issuer, PidDevIssuer.testUser)
     authorizationLog("Authorization retrieved: $authorizedRequest")
 
     val offerCredentialConfIds = credentialOffer.credentialConfigurationIdentifiers

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingPreAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingPreAuthorizationFlow.kt
@@ -99,9 +99,7 @@ private suspend fun submitProvidingProofs(
     credentialConfigurationId: CredentialConfigurationIdentifier,
 ): String {
     with(issuer) {
-        val proofSigner = DefaultProofSignersMap[credentialConfigurationId]
-            ?: error("No signer found for credential $credentialConfigurationId")
-
+        val proofSigner = popSigner(credentialConfigurationId)
         val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, null)
         val submittedRequest = authorized.requestSingle(requestPayload, proofSigner).getOrThrow()
 

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuer.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuer.kt
@@ -17,30 +17,28 @@ package eu.europa.ec.eudi.openid4vci.examples
 
 import com.nimbusds.jose.jwk.Curve
 import eu.europa.ec.eudi.openid4vci.*
-import java.net.URI
-
-typealias ActingUser = KeycloakUser
 
 private const val BASE_URL = "https://dev.issuer-backend.eudiw.dev"
 private val IssuerId = CredentialIssuerId(BASE_URL).getOrThrow()
 
 internal object PidDevIssuer :
     HasIssuerId,
-    HasTestUser<ActingUser>,
-    CanAuthorizeIssuance<ActingUser> by Keycloak,
+    HasTestUser<KeycloakUser>,
+    CanAuthorizeIssuance<KeycloakUser> by Keycloak,
     CanBeUsedWithVciLib,
-    CanRequestForCredentialOffer<ActingUser> by CanRequestForCredentialOffer.onlyStatelessAuthorizationCode(IssuerId) {
+    CanRequestForCredentialOffer<KeycloakUser> by CanRequestForCredentialOffer.onlyStatelessAuthorizationCode(IssuerId) {
 
     private const val WALLET_CLIENT_ID = "wallet-dev"
-    private val WalletRedirectURI = URI.create("urn:ietf:wg:oauth:2.0:oob")
 
     override val issuerId = IssuerId
-    override val testUser: ActingUser = ActingUser("tneal", "password")
+    override val testUser = KeycloakUser("tneal", "password")
     override val cfg = OpenId4VCIConfig(
         clientId = WALLET_CLIENT_ID,
-        authFlowRedirectionURI = WalletRedirectURI,
+        authFlowRedirectionURI = Keycloak.DebugRedirectUri,
         keyGenerationConfig = KeyGenerationConfig(Curve.P_256, 2048),
         credentialResponseEncryptionPolicy = CredentialResponseEncryptionPolicy.SUPPORTED,
+        authorizeIssuanceConfig = AuthorizeIssuanceConfig.FAVOR_SCOPES,
+        parUsage = ParUsage.IfSupported,
         dPoPSigner = CryptoGenerator.ecProofSigner(),
     )
 

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuer.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuer.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.openid4vci.examples
+
+import com.nimbusds.jose.jwk.Curve
+import eu.europa.ec.eudi.openid4vci.*
+import java.net.URI
+
+typealias ActingUser = KeycloakUser
+
+internal object PidDevIssuer : CanAuthorizeIssuance<ActingUser> by Keycloak {
+    private const val BASE_URL = "https://dev.issuer-backend.eudiw.dev"
+    private const val WALLET_CLIENT_ID = "wallet-dev"
+    private val WalletRedirectURI = URI.create("urn:ietf:wg:oauth:2.0:oob")
+    val IssuerId = CredentialIssuerId(BASE_URL).getOrThrow()
+    val TestUser = ActingUser("tneal", "password")
+
+    val PID_SdJwtVC_config_id = CredentialConfigurationIdentifier("eu.europa.ec.eudiw.pid_vc_sd_jwt")
+    val PID_MsoMdoc_config_id = CredentialConfigurationIdentifier("eu.europa.ec.eudiw.pid_mso_mdoc")
+    val MDL_config_id = CredentialConfigurationIdentifier("org.iso.18013.5.1.mDL")
+
+    val AllCredentialConfigurationIds = listOf(
+        PID_SdJwtVC_config_id,
+        PID_MsoMdoc_config_id,
+        MDL_config_id,
+    )
+
+    val Cfg = OpenId4VCIConfig(
+        clientId = WALLET_CLIENT_ID,
+        authFlowRedirectionURI = WalletRedirectURI,
+        keyGenerationConfig = KeyGenerationConfig(Curve.P_256, 2048),
+        credentialResponseEncryptionPolicy = CredentialResponseEncryptionPolicy.SUPPORTED,
+        dPoPSigner = CryptoGenerator.ecProofSigner(),
+    )
+}

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuerTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuerTest.kt
@@ -33,7 +33,7 @@ class PidDevIssuerTest {
         PidDevIssuer.testIssuanceWithAuthorizationCodeFlow(PidDevIssuer.PID_SdJwtVC_config_id, enableHttLogging = false)
     }
 
-    @Test
+    @Test @Ignore
     fun `Issue mDL in mso_mdoc using authorize code flow`() = runTest {
         PidDevIssuer.testIssuanceWithAuthorizationCodeFlow(PidDevIssuer.MDL_config_id, enableHttLogging = false)
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuerTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuerTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.openid4vci.examples
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.DisplayName
+import kotlin.test.Ignore
+import kotlin.test.Test
+
+@DisplayName("PID DEV Issuer Test")
+class PidDevIssuerTest {
+
+    @Test @Ignore
+    fun `Issue PID in mso_mdoc using authorize code flow`() = runTest {
+        PidDevIssuer.testIssuanceWithAuthorizationCodeFlow(PidDevIssuer.PID_MsoMdoc_config_id, enableHttLogging = false)
+    }
+
+    @Test @Ignore
+    fun `Issue PID in sd-jwt-vc using authorize code flow`() = runTest {
+        PidDevIssuer.testIssuanceWithAuthorizationCodeFlow(PidDevIssuer.PID_SdJwtVC_config_id, enableHttLogging = false)
+    }
+
+    @Test
+    fun `Issue mDL in mso_mdoc using authorize code flow`() = runTest {
+        PidDevIssuer.testIssuanceWithAuthorizationCodeFlow(PidDevIssuer.MDL_config_id, enableHttLogging = false)
+    }
+}

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/TestableIssuer.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/TestableIssuer.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.openid4vci.examples
+
+import eu.europa.ec.eudi.openid4vci.AuthorizationRequestPrepared
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.client.request.forms.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+import org.jsoup.Jsoup
+import org.jsoup.nodes.FormElement
+import java.net.URL
+
+/**
+ * The ability of an authorization server, to allow a [USER]
+ * to authorize credential issuance
+ */
+interface CanAuthorizeIssuance<USER> {
+
+    suspend fun loginUserAndGetAuthCode(
+        authorizationRequestPrepared: AuthorizationRequestPrepared,
+        user: USER,
+        enableHttpLogging: Boolean = false,
+    ): Pair<String, String> = coroutineScope {
+        suspend fun HttpClient.visitAuthorizationPage(): HttpResponse {
+            val url = authorizationRequestPrepared.authorizationCodeURL.toString()
+            return get(url)
+        }
+
+        val response = createHttpClient(enableLogging = enableHttpLogging).use { httpClient ->
+
+            val loginHtml = httpClient.visitAuthorizationPage().body<String>()
+            httpClient.authorizeIssuance(loginHtml, user)
+        }
+        response.pareseCodeAndStatus()
+    }
+
+    fun HttpResponse.pareseCodeAndStatus(): Pair<String, String> {
+        fun <A, B> Pair<A?, B?>.toNullable(): Pair<A, B>? {
+            return if (first != null && second != null) first!! to second!!
+            else null
+        }
+        val redirectLocation = headers["Location"].toString()
+        return with(URLBuilder(redirectLocation)) {
+            parameters["code"] to parameters["state"]
+        }.toNullable() ?: error("Failed to get authorization code & state")
+    }
+    suspend fun HttpClient.authorizeIssuance(loginHtml: String, user: USER): HttpResponse
+}
+
+//
+// Keycloak Support
+//
+data class KeycloakUser(val username: String, val password: String)
+
+object Keycloak : CanAuthorizeIssuance<KeycloakUser> {
+    override suspend fun HttpClient.authorizeIssuance(loginHtml: String, user: KeycloakUser): HttpResponse {
+        suspend fun extractASLoginUrl(): URL = withContext(Dispatchers.IO) {
+            val form = Jsoup.parse(loginHtml).body().getElementById("kc-form-login") as FormElement
+            val action = form.attr("action")
+            URL(action)
+        }
+        fun formParameters() = Parameters.build {
+            append("username", user.username)
+            append("password", user.password)
+        }
+        return coroutineScope {
+            val loginUrl = extractASLoginUrl()
+            submitForm(url = loginUrl.toString(), formParameters = formParameters())
+        }
+    }
+}

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/TestableIssuer.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/TestableIssuer.kt
@@ -204,4 +204,6 @@ object Keycloak : CanAuthorizeIssuance<KeycloakUser> {
             submitForm(url = loginUrl.toString(), formParameters = formParameters())
         }
     }
+
+    val DebugRedirectUri: URI = URI.create("urn:ietf:wg:oauth:2.0:oob")
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/WalletInitiatedIssuanceUsingAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/WalletInitiatedIssuanceUsingAuthorizationFlow.kt
@@ -49,7 +49,7 @@ fun runUseCase(
     val issuer = Issuer.make(
         config = PidDevIssuer.cfg,
         credentialOffer = credentialOffer,
-        ktorHttpClientFactory = ::createHttpClient,
+        ktorHttpClientFactory = { createHttpClient(enableLogging = false) },
     ).getOrThrow()
 
     with(issuer) {
@@ -66,7 +66,7 @@ fun runUseCase(
     }
 }
 
-private suspend fun Issuer.authorizeRequestWithAuthCodeUseCase(actingUser: ActingUser): AuthorizedRequest {
+private suspend fun Issuer.authorizeRequestWithAuthCodeUseCase(actingUser: KeycloakUser): AuthorizedRequest {
     authorizationLog("Preparing authorization code request")
 
     val prepareAuthorizationCodeRequest = prepareAuthorizationRequest().getOrThrow().also {


### PR DESCRIPTION
This PR introduces support for CWT proofs. 

In particular, issuer metada for each supported configuration have been updated for CWT proofs to follow the LSP Potential Interoperability Specs like the example bellow.

```json
"proof_types_supported": {
    "cwt": {
       "proof_alg_values_supported": [ -7 ],
       "proof_crv_values_supported": [ 1 ]
     }
}
```
Note that this is a deviation from VCI Draft 13 where in paragraph [7.2.1.3](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-cwt-proof-type) requires that the metadata for CWT proofs should be

> Cryptographic algorithm names used in the proof_signing_alg_values_supported Credential Issuer metadata parameter for this proof type SHOULD be one of those defined in [[IANA.COSE.ALGS](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#IANA.COSE.ALGS)].

Furthermore the PR:
* Introduces `PopSigner.Cwt` to the public API to allow a caller to sign the CWT 
* Introduces a CwtProofBuilder (internal class) to form the CWT and delegate signing to caller-provided `PopSigner.Cwt`.
* Introduces a configuration option to define the policy of using PAR endpoint

Closes #237 
Closes #239 
Closes #240
Closes #241 