### PR TITLE
Implement DeferredIssuer

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
@@ -30,7 +30,6 @@ data class IssuanceStoredContext(
     val deferredEndpoint: CredentialIssuerEndpoint,
     val tokenEndpoint: URL,
     val dPoPSigner: PopSigner.Jwt? = null,
-    val authorizationServerSupportedDPoPAlgorithms: List<JWSAlgorithm> = emptyList(),
     val responseEncryptionSpec: IssuanceResponseEncryptionSpec? = null,
 ) : Serializable
 
@@ -49,11 +48,10 @@ interface DeferredIssuer : QueryForDeferredCredential {
             ktorHttpClientFactory: KtorHttpClientFactory = DefaultHttpClientFactory,
         ): Result<DeferredIssuer> = runCatching {
             val dPoPJwtFactory = storedContext.dPoPSigner?.let { signer ->
-                DPoPJwtFactory.create(
+                DPoPJwtFactory(
                     signer = signer,
                     clock = clock,
-                    supportedDPopAlgorithms = storedContext.authorizationServerSupportedDPoPAlgorithms,
-                ).getOrThrow()
+                )
             }
 
             val tokenEndpointClient = TokenEndpointClient(

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
@@ -15,64 +15,164 @@
  */
 package eu.europa.ec.eudi.openid4vci
 
-import com.nimbusds.jose.JWSAlgorithm
+import eu.europa.ec.eudi.openid4vci.DeferredIssuer.Companion.make
 import eu.europa.ec.eudi.openid4vci.internal.DPoPJwtFactory
 import eu.europa.ec.eudi.openid4vci.internal.RefreshAccessToken
 import eu.europa.ec.eudi.openid4vci.internal.http.DeferredEndPointClient
 import eu.europa.ec.eudi.openid4vci.internal.http.TokenEndpointClient
-import java.io.Serializable
 import java.net.URI
 import java.net.URL
 import java.time.Clock
 
-data class IssuanceStoredContext(
+/**
+ * A minimal configuration needed to [instantiate][DeferredIssuer.make]
+ * the [DeferredIssuer].
+ *
+ * @param clientId the client_id of the wallet
+ * @param deferredEndpoint the URL of the deferred endpoint
+ * @param tokenEndpoint the URL of the token endpoint. Will be used if needed, to refresh the access token
+ * @param dPoPSigner the signer that was used for DPoP. Must be provided only if DPoP was used.
+ * @param responseEncryptionSpec the encryption key, used for credential response encryption. Used only
+ * it was included in the initial credential request
+ * @param clock Wallet's clock
+ */
+data class DeferredIssuerConfig(
     val clientId: ClientId,
-    val deferredEndpoint: CredentialIssuerEndpoint,
+    val deferredEndpoint: URL,
     val tokenEndpoint: URL,
     val dPoPSigner: PopSigner.Jwt? = null,
     val responseEncryptionSpec: IssuanceResponseEncryptionSpec? = null,
-) : Serializable
+    val clock: Clock = Clock.systemDefaultZone(),
+)
 
+/**
+ * The information required to query the deferred endpoint.
+ * @param authorizedRequest the state of the issuance
+ * @param transactionId the id returned by deferred endpoint
+ */
 data class AuthorizedTransaction(
-    val authorizedRequest: AuthorizedRequest,
+    val authorizedRequest: AuthorizedRequest.NoProofRequired,
     val transactionId: TransactionId,
-) : Serializable
+) {
+    constructor(authorizedRequest: AuthorizedRequest, transactionId: TransactionId) : this(
+        authorizedRequest = when (authorizedRequest) {
+            is AuthorizedRequest.NoProofRequired -> authorizedRequest
+            is AuthorizedRequest.ProofRequired -> AuthorizedRequest.NoProofRequired(
+                accessToken = authorizedRequest.accessToken,
+                refreshToken = authorizedRequest.refreshToken,
+                credentialIdentifiers = authorizedRequest.credentialIdentifiers,
+                timestamp = authorizedRequest.timestamp,
+            )
+        },
+        transactionId = transactionId,
+    )
+}
 
+/**
+ * Represents what a wallet needs to keep to be
+ * able to query deferred endpoint on a later time.
+ *
+ * It can be obtained via [Issuer.deferredContext]
+ */
+data class DeferredIssuanceContext(
+    val config: DeferredIssuerConfig,
+    val authorizedTransaction: AuthorizedTransaction,
+)
+
+/**
+ * A specialized issuer with the capability to [QueryForDeferredCredential]
+ *
+ * In contrast to the [Issuer] that already supports this functionality
+ * the [DeferredIssuer] requires a [minimal set of data][DeferredIssuanceContext]
+ * in ordered to be [instantiated][make].
+ *
+ * Typically, wallet could persist [DeferredIssuanceContext] and
+ * use the [DeferredIssuer.queryForDeferredCredential] to query again the deferred endpoint.
+ *
+ * The [DeferredIssuanceContext] can be obtained by [Issuer.deferredContext]
+ *
+ * Finally, [DeferredIssuer] supports transparent refresh of access token
+ */
 interface DeferredIssuer : QueryForDeferredCredential {
 
     companion object {
 
+        /**
+         * A convenient method for querying the deferred endpoint given a [ctx].
+         * Creates a [DeferredIssuer] using the [ctx] and then queries the endpoint
+         *
+         * @param ctx the context containing the data needed to instantiate the issuer and query the endpoint
+         * @param ktorHttpClientFactory a factory for getting http clients, used while interacting with issuer
+         *
+         * @return The method returns a pair comprised of:
+         * - On the right side, there is the [outcome][DeferredCredentialQueryOutcome] of querying the endpoint
+         * - On the left side, there is a possibly updated [DeferredIssuanceContext]. It will have a value
+         *   only in case the outcome was [DeferredCredentialQueryOutcome.IssuancePending]. Otherwise, it would be null.
+         */
+        suspend fun queryForDeferredCredential(
+            ctx: DeferredIssuanceContext,
+            ktorHttpClientFactory: KtorHttpClientFactory = DefaultHttpClientFactory,
+        ): Result<Pair<DeferredIssuanceContext?, DeferredCredentialQueryOutcome>> = runCatching {
+            val deferredIssuer = make(ctx.config, ktorHttpClientFactory).getOrThrow()
+            val (newAuthorized, outcome) = with(deferredIssuer) {
+                with(ctx.authorizedTransaction.authorizedRequest) {
+                    val deferred = IssuedCredential.Deferred(ctx.authorizedTransaction.transactionId)
+                    queryForDeferredCredential(deferred).getOrThrow()
+                }
+            }
+            val newCtx = when (outcome) {
+                is DeferredCredentialQueryOutcome.IssuancePending, is DeferredCredentialQueryOutcome.Errored -> {
+                    if (newAuthorized != ctx.authorizedTransaction.authorizedRequest) {
+                        check(newAuthorized is AuthorizedRequest.NoProofRequired)
+                        val newAuthorizedTransaction = ctx.authorizedTransaction.copy(authorizedRequest = newAuthorized)
+                        ctx.copy(authorizedTransaction = newAuthorizedTransaction)
+                    } else {
+                        ctx
+                    }
+                }
+
+                is DeferredCredentialQueryOutcome.Issued -> null // will not be needed
+            }
+            newCtx to outcome
+        }
+
+        /**
+         * Factory method for getting an instance of [DeferredIssuer]
+         *
+         * @param config the minimal configuration needed.
+         * @param ktorHttpClientFactory a factory for getting http clients, used while interacting with issuer
+         *
+         * @return the deferred issuer instance
+         */
         fun make(
-            clock: Clock = Clock.systemDefaultZone(),
-            storedContext: IssuanceStoredContext,
+            config: DeferredIssuerConfig,
             ktorHttpClientFactory: KtorHttpClientFactory = DefaultHttpClientFactory,
         ): Result<DeferredIssuer> = runCatching {
-            val dPoPJwtFactory = storedContext.dPoPSigner?.let { signer ->
-                DPoPJwtFactory(
-                    signer = signer,
-                    clock = clock,
-                )
+            val dPoPJwtFactory = config.dPoPSigner?.let { signer ->
+                DPoPJwtFactory(signer = signer, clock = config.clock)
             }
 
             val tokenEndpointClient = TokenEndpointClient(
-                clock,
-                storedContext.clientId,
-                URI.create("https://willNotBeUsed"),
-                storedContext.tokenEndpoint,
+                config.clock,
+                config.clientId,
+                URI.create("https://willNotBeUsed"), // this will not be used
+                config.tokenEndpoint,
                 dPoPJwtFactory,
                 ktorHttpClientFactory,
             )
 
-            val refreshAccessToken = RefreshAccessToken(clock, tokenEndpointClient)
-            val queryForDeferredCredential = run {
-                val client = DeferredEndPointClient(
-                    storedContext.deferredEndpoint,
-                    dPoPJwtFactory,
-                    ktorHttpClientFactory,
+            val refreshAccessToken = RefreshAccessToken(config.clock, tokenEndpointClient)
+            val deferredEndPointClient = DeferredEndPointClient(
+                CredentialIssuerEndpoint.invoke(config.deferredEndpoint.toString()).getOrThrow(),
+                dPoPJwtFactory,
+                ktorHttpClientFactory,
+            )
+            val queryForDeferredCredential =
+                QueryForDeferredCredential(
+                    refreshAccessToken,
+                    deferredEndPointClient,
+                    config.responseEncryptionSpec,
                 )
-                QueryForDeferredCredential(refreshAccessToken, client, storedContext.responseEncryptionSpec)
-            }
-
             object :
                 DeferredIssuer,
                 QueryForDeferredCredential by queryForDeferredCredential {}

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.openid4vci
+
+import com.nimbusds.jose.JWSAlgorithm
+import eu.europa.ec.eudi.openid4vci.internal.DPoPJwtFactory
+import eu.europa.ec.eudi.openid4vci.internal.RefreshAccessToken
+import eu.europa.ec.eudi.openid4vci.internal.http.DeferredEndPointClient
+import eu.europa.ec.eudi.openid4vci.internal.http.TokenEndpointClient
+import java.io.Serializable
+import java.net.URI
+import java.net.URL
+import java.time.Clock
+
+data class IssuanceStoredContext(
+    val clientId: ClientId,
+    val deferredEndpoint: CredentialIssuerEndpoint,
+    val tokenEndpoint: URL,
+    val dPoPSigner: PopSigner.Jwt? = null,
+    val authorizationServerSupportedDPoPAlgorithms: List<JWSAlgorithm> = emptyList(),
+    val responseEncryptionSpec: IssuanceResponseEncryptionSpec? = null,
+) : Serializable
+
+data class AuthorizedTransaction(
+    val authorizedRequest: AuthorizedRequest,
+    val transactionId: TransactionId,
+) : Serializable
+
+interface DeferredIssuer : QueryForDeferredCredential {
+
+    companion object {
+
+        fun make(
+            clock: Clock = Clock.systemDefaultZone(),
+            storedContext: IssuanceStoredContext,
+            ktorHttpClientFactory: KtorHttpClientFactory = DefaultHttpClientFactory,
+        ): Result<DeferredIssuer> = runCatching {
+            val dPoPJwtFactory = storedContext.dPoPSigner?.let { signer ->
+                DPoPJwtFactory.create(
+                    signer = signer,
+                    clock = clock,
+                    supportedDPopAlgorithms = storedContext.authorizationServerSupportedDPoPAlgorithms,
+                ).getOrThrow()
+            }
+
+            val tokenEndpointClient = TokenEndpointClient(
+                clock,
+                storedContext.clientId,
+                URI.create("https://willNotBeUsed"),
+                storedContext.tokenEndpoint,
+                dPoPJwtFactory,
+                ktorHttpClientFactory,
+            )
+
+            val refreshAccessToken = RefreshAccessToken(clock, tokenEndpointClient)
+            val queryForDeferredCredential = run {
+                val client = DeferredEndPointClient(
+                    storedContext.deferredEndpoint,
+                    dPoPJwtFactory,
+                    ktorHttpClientFactory,
+                )
+                QueryForDeferredCredential(refreshAccessToken, client, storedContext.responseEncryptionSpec)
+            }
+
+            object :
+                DeferredIssuer,
+                QueryForDeferredCredential by queryForDeferredCredential {}
+        }
+    }
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
@@ -188,7 +188,7 @@ interface Issuer : AuthorizeIssuance, RequestIssuance, QueryForDeferredCredentia
                     val credentialIssuerMetadata = credentialOffer.credentialIssuerMetadata
                     val authorizationServerMetadata = credentialOffer.authorizationServerMetadata
                     val deferredEndpoint =
-                        checkNotNull(credentialIssuerMetadata.deferredCredentialEndpoint?.value?.value) {
+                        checkNotNull(credentialIssuerMetadata.deferredCredentialEndpoint?.value) {
                             "Missing deferred credential endpoint"
                         }
                     val tokenEndpoint = checkNotNull(authorizationServerMetadata.tokenEndpointURI?.toURL()) {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
@@ -22,9 +22,35 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 
+/**
+ * Entry point to the issuance library
+ *
+ * Provides the following capabilities
+ * - [AuthorizeIssuance]
+ * - [RequestIssuance]
+ * - [QueryForDeferredCredential]
+ * - [NotifyIssuer]
+ *
+ * [Issuer] lifecycle is bound to serve a single [Issuer.credentialOffer]
+ *
+ * Typically, one of the factory methods found on the companion object can be used to get an instance of [Issuer].
+ *
+ */
 interface Issuer : AuthorizeIssuance, RequestIssuance, QueryForDeferredCredential, NotifyIssuer {
 
     val credentialOffer: CredentialOffer
+
+    /**
+     * A convenient method for obtaining a [DeferredIssuanceContext], in case of a deferred issuance
+     * that wallet wants to query again at a later time, using [DeferredIssuer].
+     *
+     * Typically, wallet should store this [DeferredIssuanceContext] and [use it][DeferredIssuer] at a later time
+     *
+     * @receiver the state of issuance
+     * @param deferredCredential the transaction id returned by the issuer
+     * @return the context that would be needed to instantiate a [DeferredIssuer]
+     */
+    fun AuthorizedRequest.deferredContext(deferredCredential: IssuedCredential.Deferred): DeferredIssuanceContext
 
     companion object {
 
@@ -113,9 +139,10 @@ interface Issuer : AuthorizeIssuance, RequestIssuance, QueryForDeferredCredentia
                     dPoPJwtFactory,
                     ktorHttpClientFactory,
                 )
-                val batchEndPointClient = credentialOffer.credentialIssuerMetadata.batchCredentialEndpoint?.let { batchEndPoint ->
-                    BatchEndPointClient(batchEndPoint, dPoPJwtFactory, ktorHttpClientFactory)
-                }
+                val batchEndPointClient =
+                    credentialOffer.credentialIssuerMetadata.batchCredentialEndpoint?.let { batchEndPoint ->
+                        BatchEndPointClient(batchEndPoint, dPoPJwtFactory, ktorHttpClientFactory)
+                    }
                 RequestIssuanceImpl(
                     credentialOffer,
                     config,
@@ -130,7 +157,8 @@ interface Issuer : AuthorizeIssuance, RequestIssuance, QueryForDeferredCredentia
                     null -> QueryForDeferredCredential.NotSupported
                     else -> {
                         val refreshAccessToken = RefreshAccessToken(config.clock, tokenEndpointClient)
-                        val deferredEndPointClient = DeferredEndPointClient(deferredEndpoint, dPoPJwtFactory, ktorHttpClientFactory)
+                        val deferredEndPointClient =
+                            DeferredEndPointClient(deferredEndpoint, dPoPJwtFactory, ktorHttpClientFactory)
                         QueryForDeferredCredential(refreshAccessToken, deferredEndPointClient, responseEncryptionSpec)
                     }
                 }
@@ -153,6 +181,31 @@ interface Issuer : AuthorizeIssuance, RequestIssuance, QueryForDeferredCredentia
                 NotifyIssuer by notifyIssuer {
                 override val credentialOffer: CredentialOffer
                     get() = credentialOffer
+
+                override fun AuthorizedRequest.deferredContext(
+                    deferredCredential: IssuedCredential.Deferred,
+                ): DeferredIssuanceContext {
+                    val credentialIssuerMetadata = credentialOffer.credentialIssuerMetadata
+                    val authorizationServerMetadata = credentialOffer.authorizationServerMetadata
+                    val deferredEndpoint =
+                        checkNotNull(credentialIssuerMetadata.deferredCredentialEndpoint?.value?.value) {
+                            "Missing deferred credential endpoint"
+                        }
+                    val tokenEndpoint = checkNotNull(authorizationServerMetadata.tokenEndpointURI?.toURL()) {
+                        "Missing token endpoint"
+                    }
+                    return DeferredIssuanceContext(
+                        DeferredIssuerConfig(
+                            clientId = config.clientId,
+                            deferredEndpoint = deferredEndpoint,
+                            tokenEndpoint = tokenEndpoint,
+                            dPoPSigner = dPoPJwtFactory?.signer,
+                            responseEncryptionSpec = responseEncryptionSpec,
+                            clock = config.clock,
+                        ),
+                        AuthorizedTransaction(this@deferredContext, deferredCredential.transactionId),
+                    )
+                }
             }
         }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/DPoPJwtFactory.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/DPoPJwtFactory.kt
@@ -39,7 +39,7 @@ internal enum class Htm {
  * https://datatracker.ietf.org/doc/rfc9449/
  */
 internal class DPoPJwtFactory(
-    private val signer: PopSigner.Jwt,
+    val signer: PopSigner.Jwt,
     private val jtiByteLength: Int = NimbusDPoPProofFactory.MINIMAL_JTI_BYTE_LENGTH,
     private val clock: Clock,
 ) {

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/DeferredIssuerExtensions.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/DeferredIssuerExtensions.kt
@@ -33,16 +33,11 @@ suspend fun DeferredIssuer.Companion.queryForDeferredCredential(
     ctxTO: DeferredIssuanceStoredContextTO,
     recreatePopSigner: ((String) -> PopSigner.Jwt)? = null,
     ktorHttpClientFactory: KtorHttpClientFactory = DefaultHttpClientFactory,
-): Result<Pair<DeferredIssuanceStoredContextTO?, String?>> = runCatching {
+): Result<Pair<DeferredIssuanceStoredContextTO?, DeferredCredentialQueryOutcome>> = runCatching {
     val ctx = ctxTO.toDeferredIssuanceStoredContext(clock, recreatePopSigner)
     val (newCtx, outcome) = queryForDeferredCredential(ctx, ktorHttpClientFactory).getOrThrow()
-
-    val cred = when (outcome) {
-        is DeferredCredentialQueryOutcome.Errored -> null
-        is DeferredCredentialQueryOutcome.IssuancePending -> null
-        is DeferredCredentialQueryOutcome.Issued -> outcome.credential.credential
-    }
-    newCtx?.let { DeferredIssuanceStoredContextTO.from(it, ctxTO.dPoPSignerKid) } to cred
+    val newCtxTO = newCtx?.let { DeferredIssuanceStoredContextTO.from(it, ctxTO.dPoPSignerKid) }
+    newCtxTO to outcome
 }
 
 //

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/DeferredIssuerExtensions.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/DeferredIssuerExtensions.kt
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.openid4vci.examples
+
+import com.nimbusds.jose.EncryptionMethod
+import com.nimbusds.jose.JWEAlgorithm
+import com.nimbusds.jose.jwk.JWK
+import eu.europa.ec.eudi.openid4vci.*
+import kotlinx.serialization.Required
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.*
+import java.net.URL
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+
+suspend fun DeferredIssuer.Companion.queryForDeferredCredential(
+    clock: Clock = Clock.systemDefaultZone(),
+    ctxTO: DeferredIssuanceStoredContextTO,
+    recreatePopSigner: ((String) -> PopSigner.Jwt)? = null,
+    ktorHttpClientFactory: KtorHttpClientFactory = DefaultHttpClientFactory,
+): Result<Pair<DeferredIssuanceStoredContextTO?, String?>> = runCatching {
+    val ctx = ctxTO.toDeferredIssuanceStoredContext(clock, recreatePopSigner)
+    val (newCtx, outcome) = queryForDeferredCredential(ctx, ktorHttpClientFactory).getOrThrow()
+
+    val cred = when (outcome) {
+        is DeferredCredentialQueryOutcome.Errored -> null
+        is DeferredCredentialQueryOutcome.IssuancePending -> null
+        is DeferredCredentialQueryOutcome.Issued -> outcome.credential.credential
+    }
+    newCtx?.let { DeferredIssuanceStoredContextTO.from(it, ctxTO.dPoPSignerKid) } to cred
+}
+
+//
+// Serialization
+//
+
+@Serializable
+data class RefreshTokenTO(
+    @Required @SerialName("refresh_token") val refreshToken: String,
+    @SerialName("expires_in") val expiresIn: Long? = null,
+) {
+
+    fun toRefreshToken(): RefreshToken {
+        val exp = expiresIn?.let { Duration.ofSeconds(it) }
+        return RefreshToken(refreshToken, exp)
+    }
+
+    companion object {
+
+        fun from(refreshToken: RefreshToken): RefreshTokenTO =
+            RefreshTokenTO(refreshToken.refreshToken, refreshToken.expiresIn?.toSeconds())
+    }
+}
+
+@Serializable
+enum class AccessTokenTypeTO {
+    DPoP, Bearer
+}
+
+@Serializable
+data class AccessTokenTO(
+    @Required @SerialName("type") val type: AccessTokenTypeTO,
+    @Required @SerialName("access_token") val accessToken: String,
+    @SerialName("expires_in") val expiresIn: Long? = null,
+) {
+
+    fun toAccessToken(): AccessToken {
+        val exp = expiresIn?.let { Duration.ofSeconds(it) }
+        return when (type) {
+            AccessTokenTypeTO.DPoP -> AccessToken.DPoP(accessToken, exp)
+            AccessTokenTypeTO.Bearer -> AccessToken.Bearer(accessToken, exp)
+        }
+    }
+
+    companion object {
+
+        fun from(accessToken: AccessToken): AccessTokenTO {
+            return AccessTokenTO(
+                type = when (accessToken) {
+                    is AccessToken.DPoP -> AccessTokenTypeTO.DPoP
+                    is AccessToken.Bearer -> AccessTokenTypeTO.Bearer
+                },
+                accessToken = accessToken.accessToken,
+                expiresIn = accessToken.expiresIn?.toSeconds(),
+            )
+        }
+    }
+}
+
+@Serializable
+data class DeferredIssuanceStoredContextTO(
+    @Required @SerialName("client_id") val clientId: String,
+    @Required @SerialName("deferred_endpoint") val deferredEndpoint: String,
+    @Required @SerialName("token_endpoint") val tokenEndpoint: String,
+    @SerialName("dpop_key_id") val dPoPSignerKid: String? = null,
+    @SerialName("credential_response_encryption_spec") val responseEncryptionSpec: JsonObject? = null,
+    @SerialName("transaction_id") val transactionId: String,
+    @SerialName("access_token") val accessToken: AccessTokenTO,
+    @SerialName("refresh_token") val refreshToken: RefreshTokenTO? = null,
+    @SerialName("authorization_timestamp") val authorizationTimestamp: Long,
+) {
+
+    fun toDeferredIssuanceStoredContext(
+        clock: Clock,
+        recreatePopSigner: ((String) -> PopSigner.Jwt)?,
+    ): DeferredIssuanceContext {
+        return DeferredIssuanceContext(
+            config = DeferredIssuerConfig(
+                clock = clock,
+                clientId = clientId,
+                deferredEndpoint = URL(deferredEndpoint),
+                tokenEndpoint = URL(tokenEndpoint),
+                dPoPSigner = dPoPSignerKid?.let { requireNotNull(recreatePopSigner).invoke(it) },
+                responseEncryptionSpec = responseEncryptionSpec?.let { responseEncryption(it) },
+            ),
+            authorizedTransaction = AuthorizedTransaction(
+                authorizedRequest = AuthorizedRequest.NoProofRequired(
+                    accessToken = accessToken.toAccessToken(),
+                    refreshToken = refreshToken?.toRefreshToken(),
+                    credentialIdentifiers = emptyMap(),
+                    timestamp = Instant.ofEpochSecond(authorizationTimestamp),
+                ),
+                transactionId = TransactionId(transactionId),
+            ),
+
+        )
+    }
+
+    companion object {
+        fun from(
+            dCtx: DeferredIssuanceContext,
+            dPoPSignerKid: String?,
+        ): DeferredIssuanceStoredContextTO {
+            val authorizedTransaction = dCtx.authorizedTransaction
+            return DeferredIssuanceStoredContextTO(
+                clientId = dCtx.config.clientId,
+                deferredEndpoint = dCtx.config.deferredEndpoint.toString(),
+                tokenEndpoint = dCtx.config.tokenEndpoint.toString(),
+                dPoPSignerKid = dPoPSignerKid,
+                responseEncryptionSpec = dCtx.config.responseEncryptionSpec?.let { responseEncryptionSpecTO(it) },
+                transactionId = authorizedTransaction.transactionId.value,
+                accessToken = AccessTokenTO.from(authorizedTransaction.authorizedRequest.accessToken),
+                refreshToken = authorizedTransaction.authorizedRequest.refreshToken?.let { RefreshTokenTO.from(it) },
+                authorizationTimestamp = authorizedTransaction.authorizedRequest.timestamp.epochSecond,
+            )
+        }
+
+        private fun responseEncryptionSpecTO(spec: IssuanceResponseEncryptionSpec): JsonObject {
+            val jwkJson = Json.parseToJsonElement(spec.jwk.toJSONString())
+            return buildJsonObject {
+                put("jwk", jwkJson)
+                put("algorithm", spec.algorithm.toString())
+                put("encryption_method", spec.encryptionMethod.toString())
+            }
+        }
+
+        private fun responseEncryption(specTO: JsonObject): IssuanceResponseEncryptionSpec =
+            IssuanceResponseEncryptionSpec(
+                jwk = run {
+                    val element = specTO["jwk"]
+                    require(element is JsonObject)
+                    JWK.parse(element.toString())
+                },
+                algorithm = run {
+                    val element = specTO["algorithm"]
+                    require(element is JsonPrimitive)
+                    JWEAlgorithm.parse(requireNotNull(element.contentOrNull))
+                },
+                encryptionMethod = run {
+                    val element = specTO["encryption_method"]
+                    require(element is JsonPrimitive)
+                    EncryptionMethod.parse(requireNotNull(element.contentOrNull))
+                },
+            )
+    }
+}

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/WalletInitiatedIssuanceUsingAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/WalletInitiatedIssuanceUsingAuthorizationFlow.kt
@@ -151,7 +151,7 @@ private suspend fun queryDeferredEndpoint(
     deferredContext: DeferredIssuanceContext,
 ): String {
     var ctx = deferredContext
-    var cred: String? = null
+    var cred: String?
     do {
         val (newCtx, outcome) = DeferredIssuer.queryForDeferredCredential(ctx = ctx).getOrThrow()
         ctx = newCtx ?: ctx


### PR DESCRIPTION
Closes #267 


This PR implements the `DeferredIssuer` as described in the related issue.

In addition, in the test section of the library  there are some extension to allow the wallet implementer to store in JSON all the information needed in order to be able to query deferred endpoint at a later time.

There is the significant constraint that this later time cannot exceed the expiration of `refresh_token`