### PR TITLE
Improve credential request ergonomics

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
@@ -185,7 +185,8 @@ interface RequestIssuance {
     )
     suspend fun AuthorizedRequest.NoProofRequired.requestSingle(
         requestPayload: IssuanceRequestPayload,
-    ): Result<SubmissionOutcome>
+    ): Result<SubmissionOutcome> =
+        requestSingleAndUpdateState(requestPayload, null).map { it.second }
 
     /**
      *  Requests the issuance of a single credential having an [AuthorizedRequest.ProofRequired] authorization. In this
@@ -196,13 +197,14 @@ interface RequestIssuance {
      *  @return The new state of request or error.
      */
     @Deprecated(
-        message = "Deprecated and will be removed in a future release",
+        message = "Deprecated and will be removed in a future release.",
         replaceWith = ReplaceWith("requestSingleAndUpdateState(requestPayload, proofSigner)"),
     )
     suspend fun AuthorizedRequest.ProofRequired.requestSingle(
         requestPayload: IssuanceRequestPayload,
         proofSigner: PopSigner,
-    ): Result<SubmissionOutcome>
+    ): Result<SubmissionOutcome> =
+        requestSingleAndUpdateState(requestPayload, proofSigner).map { it.second }
 
     /**
      * Special purpose operation to handle the case an 'invalid_proof' error response was received from issuer with

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
@@ -222,7 +222,7 @@ interface RequestIssuance {
     ): AuthorizedRequest.ProofRequired = withCNonce(cNonce)
 }
 
-interface BatchRequestIssuance {
+interface RequestBatchIssuance {
 
     /**
      *  Batch request for issuing multiple credentials having an [AuthorizedRequest.ProofRequired] authorization.

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
@@ -71,6 +71,7 @@ sealed interface SubmissionOutcome : java.io.Serializable {
      */
     data class Success(
         val credentials: List<IssuedCredential>,
+        @Deprecated(message = "Deprecated and will be removed in a future release")
         val cNonce: CNonce?,
     ) : SubmissionOutcome
 
@@ -95,6 +96,7 @@ sealed interface SubmissionOutcome : java.io.Serializable {
      * @param cNonce The c_nonce provided from issuer along the error
      * @param errorDescription Description of the error that caused the failure
      */
+    @Deprecated(message = "Deprecated and will be removed in a future release")
     data class InvalidProof(
         val cNonce: CNonce,
         val errorDescription: String? = null,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
@@ -177,6 +177,24 @@ interface RequestIssuance {
     ): Result<SubmissionOutcome>
 
     /**
+     * Special purpose operation to handle the case an 'invalid_proof' error response was received from issuer with
+     * fresh c_nonce provided to be used with a request retry.
+     *
+     * @param cNonce    The c_nonce provided from issuer along the 'invalid_proof' error code.
+     * @return The new state of the request.
+     */
+    @Deprecated(
+        message = "Deprecated and will be removed in a future release",
+        replaceWith = ReplaceWith("withCNonce(cNonce)"),
+    )
+    suspend fun AuthorizedRequest.NoProofRequired.handleInvalidProof(
+        cNonce: CNonce,
+    ): AuthorizedRequest.ProofRequired = withCNonce(cNonce)
+}
+
+interface BatchRequestIssuance {
+
+    /**
      *  Batch request for issuing multiple credentials having an [AuthorizedRequest.NoProofRequired] authorization.
      *
      *  @param credentialsMetadata   The metadata specifying the credentials that will be requested.
@@ -196,21 +214,6 @@ interface RequestIssuance {
     suspend fun AuthorizedRequest.ProofRequired.requestBatch(
         credentialsMetadata: List<Pair<IssuanceRequestPayload, PopSigner>>,
     ): Result<SubmissionOutcome>
-
-    /**
-     * Special purpose operation to handle the case an 'invalid_proof' error response was received from issuer with
-     * fresh c_nonce provided to be used with a request retry.
-     *
-     * @param cNonce    The c_nonce provided from issuer along the 'invalid_proof' error code.
-     * @return The new state of the request.
-     */
-    @Deprecated(
-        message = "Deprecated and will be removed in a future release",
-        replaceWith = ReplaceWith("withCNonce(cNonce)"),
-    )
-    suspend fun AuthorizedRequest.NoProofRequired.handleInvalidProof(
-        cNonce: CNonce,
-    ): AuthorizedRequest.ProofRequired = withCNonce(cNonce)
 }
 
 sealed interface PopSigner {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
@@ -148,10 +148,30 @@ sealed interface IssuanceRequestPayload {
 typealias AuthorizedRequestAnd<T> = Pair<AuthorizedRequest, T>
 
 /**
- * An interface for submitting a credential issuance request. Contains all the operation available to transition an [AuthorizedRequest]
- * to a [SubmissionOutcome]
+ * An interface for submitting a credential issuance request.
  */
 interface RequestIssuance {
+
+    /**
+     * Places a request to the credential issuance endpoint.
+     * Method will attempt to automatically retry submission in case
+     * - Initial authorization state is [AuthorizedRequest.NoProofRequired] and
+     * - a [popSigner] has been provided
+     *
+     * @receiver the current authorization state
+     * @param requestPayload the payload of the request
+     * @param popSigner Signer component of the proof to be sent. Although this is an optional
+     * parameter, only required in case the present authorization state is [AuthorizedRequest.ProofRequired],
+     * caller is advised to provide it, in order to allow the method to automatically retry
+     * in case of [SubmissionOutcome.InvalidProof]
+     *
+     * @return the possibly updated [AuthorizedRequest] (if updated it will contain a fresh c_nonce) and
+     * the [SubmissionOutcome]
+     */
+    suspend fun AuthorizedRequest.requestSingleAndUpdateState(
+        requestPayload: IssuanceRequestPayload,
+        popSigner: PopSigner?,
+    ): Result<AuthorizedRequestAnd<SubmissionOutcome>>
 
     /**
      *  Requests the issuance of a single credential having an [AuthorizedRequest.NoProofRequired] authorization.
@@ -159,6 +179,10 @@ interface RequestIssuance {
      *  @param requestPayload   The payload of the request.
      *  @return The new state of the request or error.
      */
+    @Deprecated(
+        message = "Deprecated and will be removed in a future release",
+        replaceWith = ReplaceWith("requestSingleAndUpdateState(requestPayload, null)"),
+    )
     suspend fun AuthorizedRequest.NoProofRequired.requestSingle(
         requestPayload: IssuanceRequestPayload,
     ): Result<SubmissionOutcome>
@@ -171,6 +195,10 @@ interface RequestIssuance {
      *  @param proofSigner  Signer component of the proof to be sent.
      *  @return The new state of request or error.
      */
+    @Deprecated(
+        message = "Deprecated and will be removed in a future release",
+        replaceWith = ReplaceWith("requestSingleAndUpdateState(requestPayload, proofSigner)"),
+    )
     suspend fun AuthorizedRequest.ProofRequired.requestSingle(
         requestPayload: IssuanceRequestPayload,
         proofSigner: PopSigner,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.coroutineScope
  * Provides the following capabilities
  * - [AuthorizeIssuance]
  * - [RequestIssuance]
+ * - [BatchRequestIssuance]
  * - [QueryForDeferredCredential]
  * - [NotifyIssuer]
  *
@@ -36,7 +37,12 @@ import kotlinx.coroutines.coroutineScope
  * Typically, one of the factory methods found on the companion object can be used to get an instance of [Issuer].
  *
  */
-interface Issuer : AuthorizeIssuance, RequestIssuance, QueryForDeferredCredential, NotifyIssuer {
+interface Issuer :
+    AuthorizeIssuance,
+    RequestIssuance,
+    BatchRequestIssuance,
+    QueryForDeferredCredential,
+    NotifyIssuer {
 
     val credentialOffer: CredentialOffer
 
@@ -177,6 +183,7 @@ interface Issuer : AuthorizeIssuance, RequestIssuance, QueryForDeferredCredentia
                 Issuer,
                 AuthorizeIssuance by authorizeIssuance,
                 RequestIssuance by requestIssuance,
+                BatchRequestIssuance by requestIssuance,
                 QueryForDeferredCredential by queryForDeferredCredential,
                 NotifyIssuer by notifyIssuer {
                 override val credentialOffer: CredentialOffer

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.coroutineScope
  * Provides the following capabilities
  * - [AuthorizeIssuance]
  * - [RequestIssuance]
- * - [BatchRequestIssuance]
+ * - [RequestBatchIssuance]
  * - [QueryForDeferredCredential]
  * - [NotifyIssuer]
  *
@@ -40,7 +40,7 @@ import kotlinx.coroutines.coroutineScope
 interface Issuer :
     AuthorizeIssuance,
     RequestIssuance,
-    BatchRequestIssuance,
+    RequestBatchIssuance,
     QueryForDeferredCredential,
     NotifyIssuer {
 
@@ -183,7 +183,7 @@ interface Issuer :
                 Issuer,
                 AuthorizeIssuance by authorizeIssuance,
                 RequestIssuance by requestIssuance,
-                BatchRequestIssuance by requestIssuance,
+                RequestBatchIssuance by requestIssuance,
                 QueryForDeferredCredential by queryForDeferredCredential,
                 NotifyIssuer by notifyIssuer {
                 override val credentialOffer: CredentialOffer

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -40,7 +40,7 @@ internal class RequestIssuanceImpl(
     private val credentialEndpointClient: CredentialEndpointClient,
     private val batchEndPointClient: BatchEndPointClient?,
     private val responseEncryptionSpec: IssuanceResponseEncryptionSpec?,
-) : RequestIssuance {
+) : RequestIssuance, BatchRequestIssuance {
 
     override suspend fun AuthorizedRequest.NoProofRequired.requestSingle(
         requestPayload: IssuanceRequestPayload,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -40,7 +40,7 @@ internal class RequestIssuanceImpl(
     private val credentialEndpointClient: CredentialEndpointClient,
     private val batchEndPointClient: BatchEndPointClient?,
     private val responseEncryptionSpec: IssuanceResponseEncryptionSpec?,
-) : RequestIssuance, BatchRequestIssuance {
+) : RequestIssuance, RequestBatchIssuance {
 
     override suspend fun AuthorizedRequest.requestSingleAndUpdateState(
         requestPayload: IssuanceRequestPayload,

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceBatchRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceBatchRequestTest.kt
@@ -81,7 +81,7 @@ class IssuanceBatchRequestTest {
                 },
             ) {},
         )
-        val (_, authorizedRequest, issuer) =
+        val (authorizedRequest, issuer) =
             authorizeRequestForCredentialOffer(mockedKtorHttpClientFactory, CREDENTIAL_OFFER_NO_GRANTS)
 
         val claimSet_mso_mdoc = MsoMdocClaimSet(

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceBatchRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceBatchRequestTest.kt
@@ -81,7 +81,10 @@ class IssuanceBatchRequestTest {
             ) {},
         )
         val (authorizedRequest, issuer) =
-            authorizeRequestForCredentialOffer(mockedKtorHttpClientFactory, CREDENTIAL_OFFER_NO_GRANTS)
+            authorizeRequestForCredentialOffer(
+                credentialOfferStr = CREDENTIAL_OFFER_NO_GRANTS,
+                ktorHttpClientFactory = mockedKtorHttpClientFactory,
+            )
 
         val requests = reqs()
         val (_, outcome) = with(issuer) {

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceDeferredRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceDeferredRequestTest.kt
@@ -38,7 +38,7 @@ class IssuanceDeferredRequestTest {
                 responseBuilder = { defaultIssuanceResponseDataBuilder(credentialIsReady = true, transactionIdIsValid = false) },
             ),
         )
-        val (_, authorizedRequest, issuer) =
+        val (authorizedRequest, issuer) =
             authorizeRequestForCredentialOffer(
                 mockedKtorHttpClientFactory,
                 CredentialOfferWithSdJwtVc_NO_GRANTS,
@@ -55,16 +55,16 @@ class IssuanceDeferredRequestTest {
             assertIs<SubmissionOutcome.InvalidProof>(submittedRequest)
 
             val proofRequired = authorizedRequest.withCNonce(submittedRequest.cNonce)
-            val secondSubmittedRequest =
-                proofRequired.requestSingle(requestPayload, CryptoGenerator.rsaProofSigner()).getOrThrow()
+            val (newAuthorizedRequest, outcome) =
+                proofRequired.requestSingleAndUpdateState(requestPayload, CryptoGenerator.rsaProofSigner()).getOrThrow()
 
-            assertIs<SubmissionOutcome.Success>(secondSubmittedRequest)
+            assertIs<SubmissionOutcome.Success>(outcome)
 
-            val issuedCredential = secondSubmittedRequest.credentials[0]
+            val issuedCredential = outcome.credentials[0]
             assertIs<IssuedCredential.Deferred>(issuedCredential)
 
             val (_, requestDeferredIssuance) =
-                authorizedRequest.queryForDeferredCredential(issuedCredential)
+                newAuthorizedRequest.queryForDeferredCredential(issuedCredential)
                     .getOrThrow()
 
             assertIs<DeferredCredentialQueryOutcome.Errored>(requestDeferredIssuance)
@@ -89,7 +89,7 @@ class IssuanceDeferredRequestTest {
             ),
         )
 
-        val (_, authorizedRequest, issuer) =
+        val (authorizedRequest, issuer) =
             authorizeRequestForCredentialOffer(
                 mockedKtorHttpClientFactory,
                 CredentialOfferWithSdJwtVc_NO_GRANTS,
@@ -105,15 +105,15 @@ class IssuanceDeferredRequestTest {
 
             assertIs<SubmissionOutcome.InvalidProof>(submittedRequest)
             val proofRequired = authorizedRequest.withCNonce(submittedRequest.cNonce)
-            val secondSubmittedRequest =
-                proofRequired.requestSingle(requestPayload, CryptoGenerator.rsaProofSigner()).getOrThrow()
+            val (newAuthorizedRequest, outcome) =
+                proofRequired.requestSingleAndUpdateState(requestPayload, CryptoGenerator.rsaProofSigner()).getOrThrow()
 
-            assertIs<SubmissionOutcome.Success>(secondSubmittedRequest)
-            val issuedCredential = secondSubmittedRequest.credentials[0]
+            assertIs<SubmissionOutcome.Success>(outcome)
+            val issuedCredential = outcome.credentials[0]
             assertIs<IssuedCredential.Deferred>(issuedCredential)
 
             val (_, requestDeferredIssuance) =
-                authorizedRequest.queryForDeferredCredential(issuedCredential)
+                newAuthorizedRequest.queryForDeferredCredential(issuedCredential)
                     .getOrThrow()
 
             assertIs<DeferredCredentialQueryOutcome.IssuancePending>(requestDeferredIssuance)
@@ -157,7 +157,7 @@ class IssuanceDeferredRequestTest {
             ),
         )
 
-        val (_, authorizedRequest, issuer) =
+        val (authorizedRequest, issuer) =
             authorizeRequestForCredentialOffer(
                 mockedKtorHttpClientFactory,
                 CredentialOfferWithSdJwtVc_NO_GRANTS,
@@ -169,19 +169,16 @@ class IssuanceDeferredRequestTest {
                 CredentialConfigurationIdentifier(PID_SdJwtVC),
                 null,
             )
-            val submittedRequest = authorizedRequest.requestSingle(requestPayload).getOrThrow()
+            val (newAuthorized, outcome) = authorizedRequest.requestSingleAndUpdateState(
+                requestPayload,
+                CryptoGenerator.rsaProofSigner(),
+            ).getOrThrow()
 
-            assertIs<SubmissionOutcome.InvalidProof>(submittedRequest)
-            val proofRequired = authorizedRequest.withCNonce(submittedRequest.cNonce)
-            val secondSubmittedRequest =
-                proofRequired.requestSingle(requestPayload, CryptoGenerator.rsaProofSigner()).getOrThrow()
-
-            assertIs<SubmissionOutcome.Success>(secondSubmittedRequest)
-            val issuedCredential = secondSubmittedRequest.credentials[0]
+            assertIs<SubmissionOutcome.Success>(outcome)
+            val issuedCredential = outcome.credentials[0]
             require(issuedCredential is IssuedCredential.Deferred)
 
-            val (_, requestDeferredIssuance) = authorizedRequest.queryForDeferredCredential(issuedCredential)
-                .getOrThrow()
+            val (_, requestDeferredIssuance) = newAuthorized.queryForDeferredCredential(issuedCredential).getOrThrow()
             assertIs<DeferredCredentialQueryOutcome.Issued>(requestDeferredIssuance)
         }
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceDeferredRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceDeferredRequestTest.kt
@@ -51,13 +51,9 @@ class IssuanceDeferredRequestTest {
                 CredentialConfigurationIdentifier(PID_SdJwtVC),
                 null,
             )
-            val submittedRequest = authorizedRequest.requestSingle(requestPayload).getOrThrow()
-            assertIs<SubmissionOutcome.InvalidProof>(submittedRequest)
-
-            val proofRequired = authorizedRequest.withCNonce(submittedRequest.cNonce)
+            val popSigner = CryptoGenerator.rsaProofSigner()
             val (newAuthorizedRequest, outcome) =
-                proofRequired.requestSingleAndUpdateState(requestPayload, CryptoGenerator.rsaProofSigner()).getOrThrow()
-
+                authorizedRequest.requestSingleAndUpdateState(requestPayload, popSigner).getOrThrow()
             assertIs<SubmissionOutcome.Success>(outcome)
 
             val issuedCredential = outcome.credentials[0]
@@ -101,13 +97,9 @@ class IssuanceDeferredRequestTest {
                 CredentialConfigurationIdentifier(PID_SdJwtVC),
                 null,
             )
-            val submittedRequest = authorizedRequest.requestSingle(requestPayload).getOrThrow()
-
-            assertIs<SubmissionOutcome.InvalidProof>(submittedRequest)
-            val proofRequired = authorizedRequest.withCNonce(submittedRequest.cNonce)
+            val popSigner = CryptoGenerator.rsaProofSigner()
             val (newAuthorizedRequest, outcome) =
-                proofRequired.requestSingleAndUpdateState(requestPayload, CryptoGenerator.rsaProofSigner()).getOrThrow()
-
+                authorizedRequest.requestSingleAndUpdateState(requestPayload, popSigner).getOrThrow()
             assertIs<SubmissionOutcome.Success>(outcome)
             val issuedCredential = outcome.credentials[0]
             assertIs<IssuedCredential.Deferred>(issuedCredential)

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceDeferredRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceDeferredRequestTest.kt
@@ -40,8 +40,8 @@ class IssuanceDeferredRequestTest {
         )
         val (authorizedRequest, issuer) =
             authorizeRequestForCredentialOffer(
-                mockedKtorHttpClientFactory,
-                CredentialOfferWithSdJwtVc_NO_GRANTS,
+                credentialOfferStr = CredentialOfferWithSdJwtVc_NO_GRANTS,
+                ktorHttpClientFactory = mockedKtorHttpClientFactory,
             )
 
         with(issuer) {
@@ -87,8 +87,8 @@ class IssuanceDeferredRequestTest {
 
         val (authorizedRequest, issuer) =
             authorizeRequestForCredentialOffer(
-                mockedKtorHttpClientFactory,
-                CredentialOfferWithSdJwtVc_NO_GRANTS,
+                credentialOfferStr = CredentialOfferWithSdJwtVc_NO_GRANTS,
+                ktorHttpClientFactory = mockedKtorHttpClientFactory,
             )
 
         with(issuer) {
@@ -151,8 +151,8 @@ class IssuanceDeferredRequestTest {
 
         val (authorizedRequest, issuer) =
             authorizeRequestForCredentialOffer(
-                mockedKtorHttpClientFactory,
-                CredentialOfferWithSdJwtVc_NO_GRANTS,
+                credentialOfferStr = CredentialOfferWithSdJwtVc_NO_GRANTS,
+                ktorHttpClientFactory = mockedKtorHttpClientFactory,
             )
 
         with(issuer) {

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceEncryptedResponsesTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceEncryptedResponsesTest.kt
@@ -53,9 +53,9 @@ class IssuanceEncryptedResponsesTest {
             assertFailsWith<ResponseEncryptionAlgorithmNotSupportedByIssuer>(
                 block = {
                     authorizeRequestForCredentialOffer(
-                        ktorHttpClientFactory = mockedKtorHttpClientFactory,
                         credentialOfferStr = CredentialOfferMsoMdoc_NO_GRANTS,
                         responseEncryptionSpecFactory = { _, _ -> issuanceResponseEncryptionSpec },
+                        ktorHttpClientFactory = mockedKtorHttpClientFactory,
                     )
                 },
             )
@@ -79,9 +79,9 @@ class IssuanceEncryptedResponsesTest {
             assertFailsWith<ResponseEncryptionMethodNotSupportedByIssuer>(
                 block = {
                     authorizeRequestForCredentialOffer(
-                        ktorHttpClientFactory = mockedKtorHttpClientFactory,
                         credentialOfferStr = CredentialOfferMsoMdoc_NO_GRANTS,
                         responseEncryptionSpecFactory = { _, _ -> issuanceResponseEncryptionSpec },
+                        ktorHttpClientFactory = mockedKtorHttpClientFactory,
                     )
                 },
             )
@@ -105,12 +105,12 @@ class IssuanceEncryptedResponsesTest {
             assertFailsWith<ResponseEncryptionRequiredByWalletButNotSupportedByIssuer>(
                 block = {
                     authorizeRequestForCredentialOffer(
-                        ktorHttpClientFactory = mockedKtorHttpClientFactory,
-                        credentialOfferStr = CredentialOfferMsoMdoc_NO_GRANTS,
-                        responseEncryptionSpecFactory = { _, _ -> issuanceResponseEncryptionSpec },
                         config = OpenId4VCIConfiguration.copy(
                             credentialResponseEncryptionPolicy = CredentialResponseEncryptionPolicy.REQUIRED,
                         ),
+                        credentialOfferStr = CredentialOfferMsoMdoc_NO_GRANTS,
+                        responseEncryptionSpecFactory = { _, _ -> issuanceResponseEncryptionSpec },
+                        ktorHttpClientFactory = mockedKtorHttpClientFactory,
                     )
                 },
             )
@@ -129,12 +129,12 @@ class IssuanceEncryptedResponsesTest {
             assertFailsWith<WalletRequiresCredentialResponseEncryptionButNoCryptoMaterialCanBeGenerated>(
                 block = {
                     authorizeRequestForCredentialOffer(
-                        ktorHttpClientFactory = mockedKtorHttpClientFactory,
-                        credentialOfferStr = CredentialOfferMsoMdoc_NO_GRANTS,
-                        responseEncryptionSpecFactory = { _, _ -> null },
                         config = OpenId4VCIConfiguration.copy(
                             credentialResponseEncryptionPolicy = CredentialResponseEncryptionPolicy.REQUIRED,
                         ),
+                        credentialOfferStr = CredentialOfferMsoMdoc_NO_GRANTS,
+                        responseEncryptionSpecFactory = { _, _ -> null },
+                        ktorHttpClientFactory = mockedKtorHttpClientFactory,
                     )
                 },
             )
@@ -164,9 +164,9 @@ class IssuanceEncryptedResponsesTest {
                 encryptionMethod = EncryptionMethod.A128CBC_HS256,
             )
             val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-                ktorHttpClientFactory = mockedKtorHttpClientFactory,
                 credentialOfferStr = CredentialOfferMsoMdoc_NO_GRANTS,
                 responseEncryptionSpecFactory = { _, _ -> issuanceResponseEncryptionSpec },
+                ktorHttpClientFactory = mockedKtorHttpClientFactory,
             )
 
             with(issuer) {
@@ -201,9 +201,9 @@ class IssuanceEncryptedResponsesTest {
                 encryptionMethod = EncryptionMethod.A128CBC_HS256,
             )
             val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-                ktorHttpClientFactory = mockedKtorHttpClientFactory,
                 credentialOfferStr = CredentialOfferMsoMdoc_NO_GRANTS,
                 responseEncryptionSpecFactory = { _, _ -> issuanceResponseEncryptionSpec },
+                ktorHttpClientFactory = mockedKtorHttpClientFactory,
             )
 
             with(issuer) {
@@ -233,9 +233,9 @@ class IssuanceEncryptedResponsesTest {
                 ),
             )
             val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-                ktorHttpClientFactory = mockedKtorHttpClientFactory,
                 credentialOfferStr = CredentialOfferMsoMdoc_NO_GRANTS,
                 responseEncryptionSpecFactory = { _, _ -> null },
+                ktorHttpClientFactory = mockedKtorHttpClientFactory,
             )
 
             with(issuer) {
@@ -309,9 +309,9 @@ class IssuanceEncryptedResponsesTest {
             )
 
             val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-                ktorHttpClientFactory = mockedKtorHttpClientFactory,
                 credentialOfferStr = CredentialOfferMsoMdoc_NO_GRANTS,
                 responseEncryptionSpecFactory = { _, _ -> issuanceResponseEncryptionSpec },
+                ktorHttpClientFactory = mockedKtorHttpClientFactory,
             )
 
             with(issuer) {
@@ -383,9 +383,9 @@ class IssuanceEncryptedResponsesTest {
             )
 
             val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-                ktorHttpClientFactory = mockedKtorHttpClientFactory,
                 credentialOfferStr = CREDENTIAL_OFFER_NO_GRANTS,
                 responseEncryptionSpecFactory = { _, _ -> issuanceResponseEncryptionSpec },
+                ktorHttpClientFactory = mockedKtorHttpClientFactory,
             )
 
             val batchRequestPayload = listOf(
@@ -442,9 +442,9 @@ class IssuanceEncryptedResponsesTest {
             )
 
             val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-                ktorHttpClientFactory = mockedKtorHttpClientFactory,
                 credentialOfferStr = CREDENTIAL_OFFER_NO_GRANTS,
                 responseEncryptionSpecFactory = { _, _ -> issuanceResponseEncryptionSpec },
+                ktorHttpClientFactory = mockedKtorHttpClientFactory,
             )
 
             val batchRequestPayload = listOf(
@@ -489,9 +489,9 @@ class IssuanceEncryptedResponsesTest {
             )
 
             val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-                ktorHttpClientFactory = mockedKtorHttpClientFactory,
                 credentialOfferStr = CredentialOfferWithSdJwtVc_NO_GRANTS,
                 responseEncryptionSpecFactory = { _, _ -> issuanceResponseEncryptionSpec },
+                ktorHttpClientFactory = mockedKtorHttpClientFactory,
             )
 
             with(issuer) {
@@ -557,9 +557,9 @@ class IssuanceEncryptedResponsesTest {
         )
 
         val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            ktorHttpClientFactory = mockedKtorHttpClientFactory,
             credentialOfferStr = CredentialOfferWithSdJwtVc_NO_GRANTS,
             responseEncryptionSpecFactory = { _, _ -> responseEncryption },
+            ktorHttpClientFactory = mockedKtorHttpClientFactory,
         )
 
         with(issuer) {

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceEncryptedResponsesTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceEncryptedResponsesTest.kt
@@ -163,7 +163,7 @@ class IssuanceEncryptedResponsesTest {
                 algorithm = JWEAlgorithm.RSA_OAEP_256,
                 encryptionMethod = EncryptionMethod.A128CBC_HS256,
             )
-            val (offer, authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
                 ktorHttpClientFactory = mockedKtorHttpClientFactory,
                 credentialOfferStr = CredentialOfferMsoMdoc_NO_GRANTS,
                 responseEncryptionSpecFactory = { _, _ -> issuanceResponseEncryptionSpec },
@@ -171,7 +171,7 @@ class IssuanceEncryptedResponsesTest {
 
             with(issuer) {
                 val noProofRequired = authorizedRequest as AuthorizedRequest.NoProofRequired
-                val credentialConfigurationId = offer.credentialConfigurationIdentifiers[0]
+                val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, null)
                 noProofRequired.requestSingle(requestPayload).getOrThrow()
             }
@@ -200,7 +200,7 @@ class IssuanceEncryptedResponsesTest {
                 algorithm = JWEAlgorithm.RSA_OAEP_256,
                 encryptionMethod = EncryptionMethod.A128CBC_HS256,
             )
-            val (offer, authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
                 ktorHttpClientFactory = mockedKtorHttpClientFactory,
                 credentialOfferStr = CredentialOfferMsoMdoc_NO_GRANTS,
                 responseEncryptionSpecFactory = { _, _ -> issuanceResponseEncryptionSpec },
@@ -208,7 +208,7 @@ class IssuanceEncryptedResponsesTest {
 
             with(issuer) {
                 val noProofRequired = authorizedRequest as AuthorizedRequest.NoProofRequired
-                val credentialConfigurationId = offer.credentialConfigurationIdentifiers[0]
+                val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, null)
                 noProofRequired.requestSingle(requestPayload).getOrThrow()
             }
@@ -232,7 +232,7 @@ class IssuanceEncryptedResponsesTest {
                     },
                 ),
             )
-            val (offer, authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
                 ktorHttpClientFactory = mockedKtorHttpClientFactory,
                 credentialOfferStr = CredentialOfferMsoMdoc_NO_GRANTS,
                 responseEncryptionSpecFactory = { _, _ -> null },
@@ -240,7 +240,7 @@ class IssuanceEncryptedResponsesTest {
 
             with(issuer) {
                 val noProofRequired = authorizedRequest as AuthorizedRequest.NoProofRequired
-                val credentialConfigurationId = offer.credentialConfigurationIdentifiers[0]
+                val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, null)
                 noProofRequired.requestSingle(requestPayload).getOrThrow()
             }
@@ -308,7 +308,7 @@ class IssuanceEncryptedResponsesTest {
                 encryptionMethod = EncryptionMethod.A128CBC_HS256,
             )
 
-            val (offer, authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
                 ktorHttpClientFactory = mockedKtorHttpClientFactory,
                 credentialOfferStr = CredentialOfferMsoMdoc_NO_GRANTS,
                 responseEncryptionSpecFactory = { _, _ -> issuanceResponseEncryptionSpec },
@@ -316,7 +316,7 @@ class IssuanceEncryptedResponsesTest {
 
             with(issuer) {
                 assertIs<AuthorizedRequest.NoProofRequired>(authorizedRequest)
-                val credentialConfigurationId = offer.credentialConfigurationIdentifiers[0]
+                val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, claimSet)
                 val submittedRequest = authorizedRequest.requestSingle(requestPayload).getOrThrow()
                 assertIs<SubmissionOutcome.Success>(submittedRequest)
@@ -360,7 +360,7 @@ class IssuanceEncryptedResponsesTest {
                 encryptionMethod = EncryptionMethod.A128CBC_HS256,
             )
 
-            val (_, authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
                 ktorHttpClientFactory = mockedKtorHttpClientFactory,
                 credentialOfferStr = CREDENTIAL_OFFER_NO_GRANTS,
                 responseEncryptionSpecFactory = { _, _ -> issuanceResponseEncryptionSpec },
@@ -429,7 +429,7 @@ class IssuanceEncryptedResponsesTest {
                 encryptionMethod = EncryptionMethod.A128CBC_HS256,
             )
 
-            val (_, authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
                 ktorHttpClientFactory = mockedKtorHttpClientFactory,
                 credentialOfferStr = CREDENTIAL_OFFER_NO_GRANTS,
                 responseEncryptionSpecFactory = { _, _ -> issuanceResponseEncryptionSpec },
@@ -490,7 +490,7 @@ class IssuanceEncryptedResponsesTest {
                 encryptionMethod = EncryptionMethod.A128CBC_HS256,
             )
 
-            val (_, authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
                 ktorHttpClientFactory = mockedKtorHttpClientFactory,
                 credentialOfferStr = CredentialOfferWithSdJwtVc_NO_GRANTS,
                 responseEncryptionSpecFactory = { _, _ -> issuanceResponseEncryptionSpec },
@@ -559,7 +559,7 @@ class IssuanceEncryptedResponsesTest {
             ),
         )
 
-        val (_, authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+        val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
             ktorHttpClientFactory = mockedKtorHttpClientFactory,
             credentialOfferStr = CredentialOfferWithSdJwtVc_NO_GRANTS,
             responseEncryptionSpecFactory = { _, _ -> responseEncryption },

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceEncryptedResponsesTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceEncryptedResponsesTest.kt
@@ -173,7 +173,7 @@ class IssuanceEncryptedResponsesTest {
                 val noProofRequired = authorizedRequest as AuthorizedRequest.NoProofRequired
                 val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, null)
-                noProofRequired.requestSingle(requestPayload).getOrThrow()
+                noProofRequired.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
             }
         }
 
@@ -210,7 +210,7 @@ class IssuanceEncryptedResponsesTest {
                 val noProofRequired = authorizedRequest as AuthorizedRequest.NoProofRequired
                 val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, null)
-                noProofRequired.requestSingle(requestPayload).getOrThrow()
+                noProofRequired.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
             }
         }
 
@@ -242,7 +242,7 @@ class IssuanceEncryptedResponsesTest {
                 val noProofRequired = authorizedRequest as AuthorizedRequest.NoProofRequired
                 val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, null)
-                noProofRequired.requestSingle(requestPayload).getOrThrow()
+                noProofRequired.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
             }
         }
 
@@ -318,8 +318,8 @@ class IssuanceEncryptedResponsesTest {
                 assertIs<AuthorizedRequest.NoProofRequired>(authorizedRequest)
                 val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, claimSet)
-                val submittedRequest = authorizedRequest.requestSingle(requestPayload).getOrThrow()
-                assertIs<SubmissionOutcome.Success>(submittedRequest)
+                val (_, outcome) = authorizedRequest.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
+                assertIs<SubmissionOutcome.Success>(outcome)
             }
         }
 
@@ -502,14 +502,14 @@ class IssuanceEncryptedResponsesTest {
                     CredentialConfigurationIdentifier(PID_SdJwtVC),
                     null,
                 )
-                val submittedRequest = authorizedRequest.requestSingle(requestPayload).getOrThrow()
-                assertIs<SubmissionOutcome.Success>(submittedRequest)
-                val deferredCredential = submittedRequest.credentials.firstOrNull()
+                val (newAuthorizedRequest, outcome) = authorizedRequest.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
+                assertIs<SubmissionOutcome.Success>(outcome)
+                val deferredCredential = outcome.credentials.firstOrNull()
                 assertIs<IssuedCredential.Deferred>(deferredCredential)
 
                 assertFailsWith<CredentialIssuanceError.InvalidResponseContentType>(
                     block = {
-                        authorizedRequest.queryForDeferredCredential(deferredCredential).getOrThrow()
+                        newAuthorizedRequest.queryForDeferredCredential(deferredCredential).getOrThrow()
                     },
                 )
             }
@@ -571,15 +571,16 @@ class IssuanceEncryptedResponsesTest {
                 CredentialConfigurationIdentifier(PID_SdJwtVC),
                 null,
             )
-            val submittedRequest = authorizedRequest.requestSingle(requestPayload).getOrThrow()
-            assertIs<SubmissionOutcome.Success>(submittedRequest)
+            val (newAuthorizedRequest, outcome) =
+                authorizedRequest.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
+            assertIs<SubmissionOutcome.Success>(outcome)
 
-            val deferredCredential = submittedRequest.credentials[0]
+            val deferredCredential = outcome.credentials[0]
             assertIs<IssuedCredential.Deferred>(deferredCredential)
 
-            val (_, οutcome) = authorizedRequest.queryForDeferredCredential(deferredCredential).getOrThrow()
+            val (_, deferredOutcome) = newAuthorizedRequest.queryForDeferredCredential(deferredCredential).getOrThrow()
 
-            assertIs<DeferredCredentialQueryOutcome.Issued>(οutcome)
+            assertIs<DeferredCredentialQueryOutcome.Issued>(deferredOutcome)
         }
     }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceNotificationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceNotificationTest.kt
@@ -65,8 +65,8 @@ class IssuanceNotificationTest {
             ),
         )
         val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            mockedKtorHttpClientFactory,
-            CredentialOfferWithSdJwtVc_NO_GRANTS,
+            credentialOfferStr = CredentialOfferWithSdJwtVc_NO_GRANTS,
+            ktorHttpClientFactory = mockedKtorHttpClientFactory,
         )
         with(issuer) {
             when (authorizedRequest) {
@@ -119,8 +119,8 @@ class IssuanceNotificationTest {
             ),
         )
         val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            mockedKtorHttpClientFactory,
-            CredentialOfferWithSdJwtVc_NO_GRANTS,
+            credentialOfferStr = CredentialOfferWithSdJwtVc_NO_GRANTS,
+            ktorHttpClientFactory = mockedKtorHttpClientFactory,
         )
         with(issuer) {
             val result = authorizedRequest.notify(

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
@@ -347,9 +347,10 @@ class IssuanceSingleRequestTest {
                 is AuthorizedRequest.NoProofRequired -> {
                     val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
                     val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, claimSet)
+                    val popSigner = CryptoGenerator.rsaProofSigner()
                     val (newAuthorizedRequest, outcome) = authorizedRequest.requestSingleAndUpdateState(
                         requestPayload,
-                        CryptoGenerator.rsaProofSigner(),
+                        popSigner,
                     ).getOrThrow()
                     assertTrue { authorizedRequest != newAuthorizedRequest }
                     assertIs<SubmissionOutcome.Success>(outcome)

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
@@ -74,8 +74,8 @@ class IssuanceSingleRequestTest {
             ),
         )
         val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            mockedKtorHttpClientFactory,
-            CredentialOfferMsoMdoc_NO_GRANTS,
+            credentialOfferStr = CredentialOfferMsoMdoc_NO_GRANTS,
+            ktorHttpClientFactory = mockedKtorHttpClientFactory,
         )
 
         val claimSet = MsoMdocClaimSet(
@@ -130,8 +130,8 @@ class IssuanceSingleRequestTest {
                 ),
             )
             val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-                mockedKtorHttpClientFactory,
-                CredentialOfferMsoMdoc_NO_GRANTS,
+                credentialOfferStr = CredentialOfferMsoMdoc_NO_GRANTS,
+                ktorHttpClientFactory = mockedKtorHttpClientFactory,
             )
 
             val claimSet = MsoMdocClaimSet(
@@ -171,8 +171,8 @@ class IssuanceSingleRequestTest {
                 tokenPostMocker(),
             )
             val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-                mockedKtorHttpClientFactory,
-                CREDENTIAL_OFFER_NO_GRANTS,
+                credentialOfferStr = CREDENTIAL_OFFER_NO_GRANTS,
+                ktorHttpClientFactory = mockedKtorHttpClientFactory,
             )
 
             with(issuer) {
@@ -206,8 +206,8 @@ class IssuanceSingleRequestTest {
                 tokenPostMocker(),
             )
             val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-                mockedKtorHttpClientFactory,
-                CREDENTIAL_OFFER_NO_GRANTS,
+                credentialOfferStr = CREDENTIAL_OFFER_NO_GRANTS,
+                ktorHttpClientFactory = mockedKtorHttpClientFactory,
             )
 
             assertIs<AuthorizedRequest.NoProofRequired>(authorizedRequest)
@@ -246,8 +246,8 @@ class IssuanceSingleRequestTest {
         )
 
         val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            mockedKtorHttpClientFactory,
-            CredentialOfferMsoMdoc_NO_GRANTS,
+            credentialOfferStr = CredentialOfferMsoMdoc_NO_GRANTS,
+            ktorHttpClientFactory = mockedKtorHttpClientFactory,
         )
 
         val claimSet = MsoMdocClaimSet(
@@ -283,8 +283,8 @@ class IssuanceSingleRequestTest {
         )
 
         val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            mockedKtorHttpClientFactory,
-            CredentialOfferWithSdJwtVc_NO_GRANTS,
+            credentialOfferStr = CredentialOfferWithSdJwtVc_NO_GRANTS,
+            ktorHttpClientFactory = mockedKtorHttpClientFactory,
         )
 
         val claimSet = GenericClaimSet(
@@ -330,8 +330,8 @@ class IssuanceSingleRequestTest {
         )
 
         val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            mockedKtorHttpClientFactory,
-            CredentialOfferWithJwtVcJson_NO_GRANTS,
+            credentialOfferStr = CredentialOfferWithJwtVcJson_NO_GRANTS,
+            ktorHttpClientFactory = mockedKtorHttpClientFactory,
         )
 
         val claimSet = GenericClaimSet(
@@ -385,8 +385,8 @@ class IssuanceSingleRequestTest {
                 ),
             )
             val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-                mockedKtorHttpClientFactory,
-                CREDENTIAL_OFFER_NO_GRANTS,
+                credentialOfferStr = CREDENTIAL_OFFER_NO_GRANTS,
+                ktorHttpClientFactory = mockedKtorHttpClientFactory,
             )
 
             val requestPayload =
@@ -426,8 +426,8 @@ class IssuanceSingleRequestTest {
                 ),
             )
             val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-                mockedKtorHttpClientFactory,
-                CREDENTIAL_OFFER_NO_GRANTS,
+                credentialOfferStr = CREDENTIAL_OFFER_NO_GRANTS,
+                ktorHttpClientFactory = mockedKtorHttpClientFactory,
             )
 
             val requestPayload = IssuanceRequestPayload.IdentifierBased(
@@ -462,8 +462,8 @@ class IssuanceSingleRequestTest {
                 ),
             )
             val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-                mockedKtorHttpClientFactory,
-                CREDENTIAL_OFFER_NO_GRANTS,
+                credentialOfferStr = CREDENTIAL_OFFER_NO_GRANTS,
+                ktorHttpClientFactory = mockedKtorHttpClientFactory,
             )
 
             val requestPayload = IssuanceRequestPayload.IdentifierBased(
@@ -499,8 +499,8 @@ class IssuanceSingleRequestTest {
             ),
         )
         val (authorizedRequest, _) = authorizeRequestForCredentialOffer(
-            mockedKtorHttpClientFactory,
-            CREDENTIAL_OFFER_NO_GRANTS,
+            credentialOfferStr = CREDENTIAL_OFFER_NO_GRANTS,
+            ktorHttpClientFactory = mockedKtorHttpClientFactory,
         )
 
         assertTrue("Identifiers expected to be parsed") {

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
@@ -90,11 +90,12 @@ class IssuanceSingleRequestTest {
             when (authorizedRequest) {
                 is AuthorizedRequest.NoProofRequired -> {
                     val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
-                    val (_, outcome) = assertDoesNotThrow {
+                    val (updatedAuthorizedRequest, outcome) = assertDoesNotThrow {
                         val requestPayload =
                             IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, claimSet)
                         authorizedRequest.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
                     }
+                    assertIs<AuthorizedRequest.ProofRequired>(updatedAuthorizedRequest)
                     assertIs<SubmissionOutcome.InvalidProof>(outcome)
                 }
 

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
@@ -90,11 +90,12 @@ class IssuanceSingleRequestTest {
             when (authorizedRequest) {
                 is AuthorizedRequest.NoProofRequired -> {
                     val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
-                    val submittedRequest = assertDoesNotThrow {
-                        val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, claimSet)
-                        authorizedRequest.requestSingle(requestPayload).getOrThrow()
+                    val (_, outcome) = assertDoesNotThrow {
+                        val requestPayload =
+                            IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, claimSet)
+                        authorizedRequest.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
                     }
-                    assertIs<SubmissionOutcome.InvalidProof>(submittedRequest)
+                    assertIs<SubmissionOutcome.InvalidProof>(outcome)
                 }
 
                 is AuthorizedRequest.ProofRequired -> fail(
@@ -105,126 +106,120 @@ class IssuanceSingleRequestTest {
     }
 
     @Test
-    fun `when issuer responds with 'invalid_proof' and no c_nonce then ResponseUnparsable error is returned `() = runTest {
-        val mockedKtorHttpClientFactory = mockedKtorHttpClientFactory(
-            oidcWellKnownMocker(),
-            authServerWellKnownMocker(),
-            parPostMocker(),
-            tokenPostMocker(),
-            singleIssuanceRequestMocker(
-                responseBuilder = {
-                    respond(
-                        content = """
+    fun `when issuer responds with 'invalid_proof' and no c_nonce then ResponseUnparsable error is returned `() =
+        runTest {
+            val mockedKtorHttpClientFactory = mockedKtorHttpClientFactory(
+                oidcWellKnownMocker(),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                tokenPostMocker(),
+                singleIssuanceRequestMocker(
+                    responseBuilder = {
+                        respond(
+                            content = """
                             {
                                 "error": "invalid_proof"                               
                             } 
-                        """.trimIndent(),
-                        status = HttpStatusCode.BadRequest,
-                        headers = headersOf(
-                            HttpHeaders.ContentType to listOf("application/json"),
-                        ),
+                            """.trimIndent(),
+                            status = HttpStatusCode.BadRequest,
+                            headers = headersOf(
+                                HttpHeaders.ContentType to listOf("application/json"),
+                            ),
+                        )
+                    },
+                ),
+            )
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                mockedKtorHttpClientFactory,
+                CredentialOfferMsoMdoc_NO_GRANTS,
+            )
+
+            val claimSet = MsoMdocClaimSet(
+                claims = listOf(
+                    "org.iso.18013.5.1" to "given_name",
+                    "org.iso.18013.5.1" to "family_name",
+                    "org.iso.18013.5.1" to "birth_date",
+                ),
+            )
+            with(issuer) {
+                when (authorizedRequest) {
+                    is AuthorizedRequest.NoProofRequired -> {
+                        val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
+                        val (_, outcome) = assertDoesNotThrow {
+                            val requestPayload =
+                                IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, claimSet)
+                            authorizedRequest.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
+                        }
+                        assertIs<SubmissionOutcome.Failed>(outcome)
+                        assertIs<CredentialIssuanceError.ResponseUnparsable>(outcome.error)
+                    }
+
+                    is AuthorizedRequest.ProofRequired -> fail(
+                        "State should be Authorized.NoProofRequired when no c_nonce returned from token endpoint",
                     )
-                },
-            ),
-        )
-        val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            mockedKtorHttpClientFactory,
-            CredentialOfferMsoMdoc_NO_GRANTS,
-        )
-
-        val claimSet = MsoMdocClaimSet(
-            claims = listOf(
-                "org.iso.18013.5.1" to "given_name",
-                "org.iso.18013.5.1" to "family_name",
-                "org.iso.18013.5.1" to "birth_date",
-            ),
-        )
-        with(issuer) {
-            when (authorizedRequest) {
-                is AuthorizedRequest.NoProofRequired -> {
-                    val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
-                    val request = assertDoesNotThrow {
-                        val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, claimSet)
-                        authorizedRequest.requestSingle(requestPayload).getOrThrow()
-                    }
-                    assertIs<SubmissionOutcome.Failed>(request)
-                    assertIs<CredentialIssuanceError.ResponseUnparsable>(request.error)
                 }
-
-                is AuthorizedRequest.ProofRequired -> fail(
-                    "State should be Authorized.NoProofRequired when no c_nonce returned from token endpoint",
-                )
             }
         }
-    }
 
     @Test
-    fun `when issuance request contains unsupported claims exception CredentialIssuanceException is thrown`() = runTest {
-        val mockedKtorHttpClientFactory = mockedKtorHttpClientFactory(
-            oidcWellKnownMocker(),
-            authServerWellKnownMocker(),
-            parPostMocker(),
-            tokenPostMocker(),
-        )
-        val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            mockedKtorHttpClientFactory,
-            CREDENTIAL_OFFER_NO_GRANTS,
-        )
+    fun `when issuance request contains unsupported claims exception CredentialIssuanceException is thrown`() =
+        runTest {
+            val mockedKtorHttpClientFactory = mockedKtorHttpClientFactory(
+                oidcWellKnownMocker(),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                tokenPostMocker(),
+            )
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                mockedKtorHttpClientFactory,
+                CREDENTIAL_OFFER_NO_GRANTS,
+            )
 
-        with(issuer) {
-            when (authorizedRequest) {
-                is AuthorizedRequest.NoProofRequired -> {
-                    val claimSetMsoMdoc = MsoMdocClaimSet(listOf("org.iso.18013.5.1" to "degree"))
-                    var credentialConfigurationId = CredentialConfigurationIdentifier(PID_MsoMdoc)
-                    assertFailsWith<CredentialIssuanceError.InvalidIssuanceRequest> {
-                        val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, claimSetMsoMdoc)
-                        authorizedRequest.requestSingle(requestPayload).getOrThrow()
-                    }
+            with(issuer) {
+                assertIs<AuthorizedRequest.NoProofRequired>(authorizedRequest)
+                val claimSetMsoMdoc = MsoMdocClaimSet(listOf("org.iso.18013.5.1" to "degree"))
+                var credentialConfigurationId = CredentialConfigurationIdentifier(PID_MsoMdoc)
 
-                    val claimSetSdJwtVc = GenericClaimSet(listOf("degree"))
-                    credentialConfigurationId = CredentialConfigurationIdentifier(PID_SdJwtVC)
-                    assertFailsWith<CredentialIssuanceError.InvalidIssuanceRequest> {
-                        val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, claimSetSdJwtVc)
-                        authorizedRequest.requestSingle(requestPayload).getOrThrow()
-                    }
+                assertFailsWith<CredentialIssuanceError.InvalidIssuanceRequest> {
+                    val requestPayload =
+                        IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, claimSetMsoMdoc)
+                    authorizedRequest.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
                 }
 
-                is AuthorizedRequest.ProofRequired -> fail(
-                    "State should be Authorized.NoProofRequired when no c_nonce returned from token endpoint",
-                )
+                val claimSetSdJwtVc = GenericClaimSet(listOf("degree"))
+                credentialConfigurationId = CredentialConfigurationIdentifier(PID_SdJwtVC)
+                assertFailsWith<CredentialIssuanceError.InvalidIssuanceRequest> {
+                    val requestPayload =
+                        IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, claimSetSdJwtVc)
+                    authorizedRequest.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
+                }
             }
         }
-    }
 
     @Test
-    fun `when issuer used to request credential not included in offer an IllegalArgumentException is thrown`() = runTest {
-        val mockedKtorHttpClientFactory = mockedKtorHttpClientFactory(
-            oidcWellKnownMocker(),
-            authServerWellKnownMocker(),
-            parPostMocker(),
-            tokenPostMocker(),
-        )
-        val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            mockedKtorHttpClientFactory,
-            CREDENTIAL_OFFER_NO_GRANTS,
-        )
+    fun `when issuer used to request credential not included in offer an IllegalArgumentException is thrown`() =
+        runTest {
+            val mockedKtorHttpClientFactory = mockedKtorHttpClientFactory(
+                oidcWellKnownMocker(),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                tokenPostMocker(),
+            )
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                mockedKtorHttpClientFactory,
+                CREDENTIAL_OFFER_NO_GRANTS,
+            )
 
-        with(issuer) {
-            when (authorizedRequest) {
-                is AuthorizedRequest.NoProofRequired -> {
-                    val credentialConfigurationId = CredentialConfigurationIdentifier("UniversityDegree")
-                    assertFailsWith<IllegalArgumentException> {
-                        val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, null)
-                        authorizedRequest.requestSingle(requestPayload).getOrThrow()
-                    }
+            assertIs<AuthorizedRequest.NoProofRequired>(authorizedRequest)
+            val credentialConfigurationId = CredentialConfigurationIdentifier("UniversityDegree")
+            assertFailsWith<IllegalArgumentException> {
+                val requestPayload =
+                    IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, null)
+                with(issuer) {
+                    authorizedRequest.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
                 }
-
-                is AuthorizedRequest.ProofRequired -> fail(
-                    "State should be Authorized.NoProofRequired when no c_nonce returned from token endpoint",
-                )
             }
         }
-    }
 
     @Test
     fun `successful issuance of credential in mso_mdoc format`() = runTest {
@@ -263,21 +258,15 @@ class IssuanceSingleRequestTest {
             ),
         )
 
-        with(issuer) {
-            when (authorizedRequest) {
-                is AuthorizedRequest.NoProofRequired -> {
-                    val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
-                    val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, claimSet)
-                    val popSigner = CryptoGenerator.rsaProofSigner()
-                    val (newAuthorized, outcome) = authorizedRequest.requestSingleAndUpdateState(requestPayload, popSigner).getOrThrow()
-                    assertIs<SubmissionOutcome.Success>(outcome)
-                }
-
-                is AuthorizedRequest.ProofRequired -> fail(
-                    "State should be Authorized.NoProofRequired when no c_nonce returned from token endpoint",
-                )
+        assertIs<AuthorizedRequest.NoProofRequired>(authorizedRequest)
+        val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
+        val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, claimSet)
+        val popSigner = CryptoGenerator.rsaProofSigner()
+        val (_, outcome) =
+            with(issuer) {
+                authorizedRequest.requestSingleAndUpdateState(requestPayload, popSigner).getOrThrow()
             }
-        }
+        assertIs<SubmissionOutcome.Success>(outcome)
     }
 
     @Test
@@ -373,131 +362,119 @@ class IssuanceSingleRequestTest {
     }
 
     @Test
-    fun `when token endpoint returns credential identifiers, issuance request must be IdentifierBasedIssuanceRequestTO`() = runTest {
-        val mockedKtorHttpClientFactory = mockedKtorHttpClientFactory(
-            oidcWellKnownMocker(),
-            authServerWellKnownMocker(),
-            parPostMocker(),
-            tokenPostMockerWithAuthDetails(
-                listOf(CredentialConfigurationIdentifier("eu.europa.ec.eudiw.pid_vc_sd_jwt")),
-            ),
-            singleIssuanceRequestMocker(
-                credential = "credential",
-                requestValidator = {
-                    val textContent = it.body as TextContent
-                    val issuanceRequestTO = Json.decodeFromString<CredentialRequestTO>(textContent.text)
-                    assertThat(
-                        "Expected identifier based issuance request but credential_identifier is null",
-                        issuanceRequestTO.credentialIdentifier != null,
-                    )
-                },
-            ),
-        )
-        val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            mockedKtorHttpClientFactory,
-            CREDENTIAL_OFFER_NO_GRANTS,
-        )
+    fun `when token endpoint returns credential identifiers, issuance request must be IdentifierBasedIssuanceRequestTO`() =
+        runTest {
+            val mockedKtorHttpClientFactory = mockedKtorHttpClientFactory(
+                oidcWellKnownMocker(),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                tokenPostMockerWithAuthDetails(
+                    listOf(CredentialConfigurationIdentifier("eu.europa.ec.eudiw.pid_vc_sd_jwt")),
+                ),
+                singleIssuanceRequestMocker(
+                    credential = "credential",
+                    requestValidator = {
+                        val textContent = it.body as TextContent
+                        val issuanceRequestTO = Json.decodeFromString<CredentialRequestTO>(textContent.text)
+                        assertThat(
+                            "Expected identifier based issuance request but credential_identifier is null",
+                            issuanceRequestTO.credentialIdentifier != null,
+                        )
+                    },
+                ),
+            )
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                mockedKtorHttpClientFactory,
+                CREDENTIAL_OFFER_NO_GRANTS,
+            )
 
-        with(issuer) {
-            when (authorizedRequest) {
-                is AuthorizedRequest.NoProofRequired -> {
-                    val requestPayload = authorizedRequest.credentialIdentifiers?.let {
-                        IssuanceRequestPayload.IdentifierBased(it.entries.first().key, it.entries.first().value[0])
-                    } ?: error("No credential identifier")
-                    authorizedRequest.requestSingle(requestPayload).getOrThrow()
-                }
-
-                is AuthorizedRequest.ProofRequired ->
-                    fail("State should be Authorized.NoProofRequired when no c_nonce returned from token endpoint")
+            val requestPayload =
+                authorizedRequest.credentialIdentifiers
+                    ?.let {
+                        IssuanceRequestPayload.IdentifierBased(
+                            it.entries.first().key,
+                            it.entries.first().value[0],
+                        )
+                    }
+                    ?: error("No credential identifier")
+            with(issuer) {
+                authorizedRequest.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
             }
         }
-    }
 
     @Test
-    fun `when request is by credential id, this id must be in the list of identifiers returned from token endpoint`() = runTest {
-        val mockedKtorHttpClientFactory = mockedKtorHttpClientFactory(
-            oidcWellKnownMocker(),
-            authServerWellKnownMocker(),
-            parPostMocker(),
-            tokenPostMockerWithAuthDetails(
-                listOf(CredentialConfigurationIdentifier("eu.europa.ec.eudiw.pid_vc_sd_jwt")),
-            ),
-            singleIssuanceRequestMocker(
-                credential = "credential",
-                requestValidator = {
-                    val textContent = it.body as TextContent
-                    val issuanceRequestTO = Json.decodeFromString<CredentialRequestTO>(textContent.text)
-                    assertThat(
-                        "Expected identifier based issuance request but credential_identifier is null",
-                        issuanceRequestTO.credentialResponseEncryption != null,
-                    )
-                },
-            ),
-        )
-        val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            mockedKtorHttpClientFactory,
-            CREDENTIAL_OFFER_NO_GRANTS,
-        )
+    fun `when request is by credential id, this id must be in the list of identifiers returned from token endpoint`() =
+        runTest {
+            val mockedKtorHttpClientFactory = mockedKtorHttpClientFactory(
+                oidcWellKnownMocker(),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                tokenPostMockerWithAuthDetails(
+                    listOf(CredentialConfigurationIdentifier("eu.europa.ec.eudiw.pid_vc_sd_jwt")),
+                ),
+                singleIssuanceRequestMocker(
+                    credential = "credential",
+                    requestValidator = {
+                        val textContent = it.body as TextContent
+                        val issuanceRequestTO = Json.decodeFromString<CredentialRequestTO>(textContent.text)
+                        assertThat(
+                            "Expected identifier based issuance request but credential_identifier is null",
+                            issuanceRequestTO.credentialResponseEncryption != null,
+                        )
+                    },
+                ),
+            )
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                mockedKtorHttpClientFactory,
+                CREDENTIAL_OFFER_NO_GRANTS,
+            )
 
-        with(issuer) {
-            when (authorizedRequest) {
-                is AuthorizedRequest.NoProofRequired -> {
-                    val requestPayload = IssuanceRequestPayload.IdentifierBased(
-                        CredentialConfigurationIdentifier("eu.europa.ec.eudiw.pid_vc_sd_jwt"),
-                        CredentialIdentifier("DUMMY"),
-                    )
-                    assertThrows<IllegalArgumentException> {
-                        authorizedRequest.requestSingle(requestPayload).getOrThrow()
-                    }
+            val requestPayload = IssuanceRequestPayload.IdentifierBased(
+                CredentialConfigurationIdentifier("eu.europa.ec.eudiw.pid_vc_sd_jwt"),
+                CredentialIdentifier("DUMMY"),
+            )
+            assertThrows<IllegalArgumentException> {
+                with(issuer) {
+                    authorizedRequest.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
                 }
-
-                is AuthorizedRequest.ProofRequired ->
-                    fail("State should be Authorized.NoProofRequired when no c_nonce returned from token endpoint")
             }
         }
-    }
 
     @Test
-    fun `issuance request by credential id, is allowed only when token endpoint has returned credential identifiers`() = runTest {
-        val mockedKtorHttpClientFactory = mockedKtorHttpClientFactory(
-            oidcWellKnownMocker(),
-            authServerWellKnownMocker(),
-            parPostMocker(),
-            tokenPostMocker(),
-            singleIssuanceRequestMocker(
-                credential = "credential",
-                requestValidator = {
-                    val textContent = it.body as TextContent
-                    val issuanceRequestTO = Json.decodeFromString<CredentialRequestTO>(textContent.text)
-                    assertThat(
-                        "Expected identifier based issuance request but credential_identifier is null",
-                        issuanceRequestTO.credentialIdentifier != null,
-                    )
-                },
-            ),
-        )
-        val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            mockedKtorHttpClientFactory,
-            CREDENTIAL_OFFER_NO_GRANTS,
-        )
+    fun `issuance request by credential id, is allowed only when token endpoint has returned credential identifiers`() =
+        runTest {
+            val mockedKtorHttpClientFactory = mockedKtorHttpClientFactory(
+                oidcWellKnownMocker(),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                tokenPostMocker(),
+                singleIssuanceRequestMocker(
+                    credential = "credential",
+                    requestValidator = {
+                        val textContent = it.body as TextContent
+                        val issuanceRequestTO = Json.decodeFromString<CredentialRequestTO>(textContent.text)
+                        assertThat(
+                            "Expected identifier based issuance request but credential_identifier is null",
+                            issuanceRequestTO.credentialIdentifier != null,
+                        )
+                    },
+                ),
+            )
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                mockedKtorHttpClientFactory,
+                CREDENTIAL_OFFER_NO_GRANTS,
+            )
 
-        with(issuer) {
-            when (authorizedRequest) {
-                is AuthorizedRequest.NoProofRequired -> {
-                    val requestPayload = IssuanceRequestPayload.IdentifierBased(
-                        CredentialConfigurationIdentifier("eu.europa.ec.eudiw.pid_vc_sd_jwt"),
-                        CredentialIdentifier("id"),
-                    )
-                    assertThrows<IllegalArgumentException> {
-                        authorizedRequest.requestSingle(requestPayload).getOrThrow()
-                    }
+            val requestPayload = IssuanceRequestPayload.IdentifierBased(
+                CredentialConfigurationIdentifier("eu.europa.ec.eudiw.pid_vc_sd_jwt"),
+                CredentialIdentifier("id"),
+            )
+            assertThrows<IllegalArgumentException> {
+                with(issuer) {
+                    authorizedRequest.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
                 }
-
-                is AuthorizedRequest.ProofRequired ->
-                    fail("State should be Authorized.NoProofRequired when no c_nonce returned from token endpoint")
             }
         }
-    }
 
     @Test
     fun `when token endpoint returns authorization_details they are parsed properly`() = runTest {

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
@@ -16,6 +16,7 @@
 package eu.europa.ec.eudi.openid4vci
 
 import com.nimbusds.jose.jwk.Curve
+import eu.europa.ec.eudi.openid4vci.Issuer.Companion.DefaultResponseEncryptionSpecFactory
 import java.net.URI
 import java.util.*
 
@@ -61,33 +62,26 @@ val OpenId4VCIConfiguration = OpenId4VCIConfig(
 )
 
 suspend fun authorizeRequestForCredentialOffer(
-    ktorHttpClientFactory: KtorHttpClientFactory,
-    credentialOfferStr: String,
     config: OpenId4VCIConfig? = OpenId4VCIConfiguration,
-    responseEncryptionSpecFactory: ResponseEncryptionSpecFactory? = null,
+    credentialOfferStr: String,
+    responseEncryptionSpecFactory: ResponseEncryptionSpecFactory = DefaultResponseEncryptionSpecFactory,
+    ktorHttpClientFactory: KtorHttpClientFactory,
 ): Pair<AuthorizedRequest, Issuer> {
-    val offer = CredentialOfferRequestResolver(ktorHttpClientFactory = ktorHttpClientFactory)
-        .resolve("https://$CREDENTIAL_ISSUER_PUBLIC_URL/credentialoffer?credential_offer=$credentialOfferStr")
-        .getOrThrow()
-
-    val issuer = responseEncryptionSpecFactory?.let {
-        Issuer.make(
-            config = config.takeIf { config != null } ?: OpenId4VCIConfiguration,
-            credentialOffer = offer,
-            ktorHttpClientFactory = ktorHttpClientFactory,
-            responseEncryptionSpecFactory = responseEncryptionSpecFactory,
-        ).getOrThrow()
-    } ?: Issuer.make(
+    val issuer = Issuer.make(
         config = config.takeIf { config != null } ?: OpenId4VCIConfiguration,
-        credentialOffer = offer,
+        credentialOfferUri = "openid-credential-offer://?credential_offer=$credentialOfferStr",
         ktorHttpClientFactory = ktorHttpClientFactory,
+        responseEncryptionSpecFactory = responseEncryptionSpecFactory,
     ).getOrThrow()
 
-    val authorizedRequest = with(issuer) {
-        val authRequestPrepared = prepareAuthorizationRequest().getOrThrow()
-        val authorizationCode = UUID.randomUUID().toString()
-        val serverState = authRequestPrepared.state
-        authRequestPrepared.authorizeWithAuthorizationCode(AuthorizationCode(authorizationCode), serverState).getOrThrow()
-    }
+    val authorizedRequest =
+        with(issuer) {
+            val authRequestPrepared = prepareAuthorizationRequest().getOrThrow()
+            with(authRequestPrepared) {
+                val authorizationCode = AuthorizationCode(UUID.randomUUID().toString())
+                val serverState = authRequestPrepared.state
+                authorizeWithAuthorizationCode(authorizationCode, serverState).getOrThrow()
+            }
+        }
     return authorizedRequest to issuer
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
@@ -65,7 +65,7 @@ suspend fun authorizeRequestForCredentialOffer(
     credentialOfferStr: String,
     config: OpenId4VCIConfig? = OpenId4VCIConfiguration,
     responseEncryptionSpecFactory: ResponseEncryptionSpecFactory? = null,
-): Triple<CredentialOffer, AuthorizedRequest, Issuer> {
+): Pair<AuthorizedRequest, Issuer> {
     val offer = CredentialOfferRequestResolver(ktorHttpClientFactory = ktorHttpClientFactory)
         .resolve("https://$CREDENTIAL_ISSUER_PUBLIC_URL/credentialoffer?credential_offer=$credentialOfferStr")
         .getOrThrow()
@@ -89,5 +89,5 @@ suspend fun authorizeRequestForCredentialOffer(
         val serverState = authRequestPrepared.state
         authRequestPrepared.authorizeWithAuthorizationCode(AuthorizationCode(authorizationCode), serverState).getOrThrow()
     }
-    return Triple(offer, authorizedRequest, issuer)
+    return authorizedRequest to issuer
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/Commons.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/Commons.kt
@@ -130,7 +130,7 @@ suspend fun <ENV, USER> Issuer.testIssuanceWithAuthorizationCodeFlow(
       ENV : CanAuthorizeIssuance<USER> =
     coroutineScope {
         val authorizedRequest = authorizeUsingAuthorizationCodeFlow(env, enableHttpLogging)
-        val (newAuthorizedRequest, outcome) =
+        val (_, outcome) =
             submitCredentialRequest(authorizedRequest, credCfgId, claimSetToRequest, popSignerPreference)
 
         ensureIssued(outcome)

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/Commons.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/Commons.kt
@@ -87,18 +87,13 @@ suspend fun Issuer.submitCredentialRequest(
         credentialOffer.credentialConfigurationIdentifiers.first(),
     claimSet: ClaimSet? = null,
     popSignerPreference: ProofTypeMetaPreference,
-): SubmissionOutcome {
+): AuthorizedRequestAnd<SubmissionOutcome> {
     val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, claimSet)
-    return when (authorizedRequest) {
-        is AuthorizedRequest.ProofRequired -> {
-            with(authorizedRequest) {
-                val popSigner = popSigner(credentialConfigurationId, popSignerPreference)
-                requestSingle(requestPayload, popSigner).getOrThrow()
-            }
-        }
-
-        is AuthorizedRequest.NoProofRequired -> with(authorizedRequest) { requestSingle(requestPayload).getOrThrow() }
-    }
+    val popSigner =
+        if (authorizedRequest is AuthorizedRequest.ProofRequired) {
+            popSigner(credentialConfigurationId, popSignerPreference)
+        } else null
+    return authorizedRequest.requestSingleAndUpdateState(requestPayload, popSigner).getOrThrow()
 }
 
 suspend fun <ENV, USER> Issuer.authorizeUsingAuthorizationCodeFlow(
@@ -134,16 +129,9 @@ suspend fun <ENV, USER> Issuer.testIssuanceWithAuthorizationCodeFlow(
       ENV : HasTestUser<USER>,
       ENV : CanAuthorizeIssuance<USER> =
     coroutineScope {
-        val outcome = run {
-            val authorizedRequest = authorizeUsingAuthorizationCodeFlow(env, enableHttpLogging)
-            val outcome = submitCredentialRequest(authorizedRequest, credCfgId, claimSetToRequest, popSignerPreference)
-            // If authorization server doesn't provide c_nonce in its token response
-            // there is the chance that provides c_nonce via credential endpoint
-            if (authorizedRequest is AuthorizedRequest.NoProofRequired && outcome is SubmissionOutcome.InvalidProof) {
-                val proofRequired = authorizedRequest.withCNonce(outcome.cNonce)
-                submitCredentialRequest(proofRequired, credCfgId, claimSetToRequest, popSignerPreference)
-            } else outcome
-        }
+        val authorizedRequest = authorizeUsingAuthorizationCodeFlow(env, enableHttpLogging)
+        val (newAuthorizedRequest, outcome) =
+            submitCredentialRequest(authorizedRequest, credCfgId, claimSetToRequest, popSignerPreference)
 
         ensureIssued(outcome)
         Unit
@@ -157,13 +145,7 @@ suspend fun Issuer.testIssuanceWithPreAuthorizedCodeFlow(
 ) = coroutineScope {
     val (authorized, outcome) = run {
         val authorizedRequest = authorizeWithPreAuthorizationCode(txCode).getOrThrow()
-        val outcome = submitCredentialRequest(authorizedRequest, credCfgId, claimSetToRequest, popSignerPreference)
-        // If authorization server doesn't provide c_nonce in its token response,
-        // there is the chance that provides c_nonce via credential endpoint
-        if (authorizedRequest is AuthorizedRequest.NoProofRequired && outcome is SubmissionOutcome.InvalidProof) {
-            val proofRequired = authorizedRequest.withCNonce(outcome.cNonce)
-            proofRequired to submitCredentialRequest(proofRequired, credCfgId, claimSetToRequest, popSignerPreference)
-        } else authorizedRequest to outcome
+        submitCredentialRequest(authorizedRequest, credCfgId, claimSetToRequest, popSignerPreference)
     }
 
     val issuedCredentials = ensureIssued(outcome)

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingAuthorizationFlow.kt
@@ -123,11 +123,11 @@ private suspend fun submitProvidingProofs(
     with(issuer) {
         val proofSigner = popSigner(credentialConfigurationId)
         val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, null)
-        val submittedRequest = authorized.requestSingle(requestPayload, proofSigner).getOrThrow()
+        val (newAuthorized, outcome) = authorized.requestSingleAndUpdateState(requestPayload, proofSigner).getOrThrow()
 
-        return when (submittedRequest) {
-            is SubmissionOutcome.Success -> handleSuccess(submittedRequest, issuer, authorized)
-            is SubmissionOutcome.Failed -> throw submittedRequest.error
+        return when (outcome) {
+            is SubmissionOutcome.Success -> handleSuccess(outcome, issuer, newAuthorized)
+            is SubmissionOutcome.Failed -> throw outcome.error
             is SubmissionOutcome.InvalidProof -> throw IllegalStateException(
                 "Although providing a proof with c_nonce the proof is still invalid",
             )

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingPreAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingPreAuthorizationFlow.kt
@@ -101,11 +101,11 @@ private suspend fun submitProvidingProofs(
     with(issuer) {
         val proofSigner = popSigner(credentialConfigurationId)
         val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, null)
-        val submittedRequest = authorized.requestSingle(requestPayload, proofSigner).getOrThrow()
+        val (newAuthorized, outcome) = authorized.requestSingleAndUpdateState(requestPayload, proofSigner).getOrThrow()
 
-        return when (submittedRequest) {
-            is SubmissionOutcome.Success -> handleSuccess(submittedRequest, issuer, authorized)
-            is SubmissionOutcome.Failed -> throw submittedRequest.error
+        return when (outcome) {
+            is SubmissionOutcome.Success -> handleSuccess(outcome, issuer, newAuthorized)
+            is SubmissionOutcome.Failed -> throw outcome.error
             is SubmissionOutcome.InvalidProof -> throw IllegalStateException(
                 "Although providing a proof with c_nonce the proof is still invalid",
             )


### PR DESCRIPTION
Closes #274 
Closes #275 

The PR : 
- Split the `RequestIssuance` interface into `RequestIssuance` and `BatchRequestIssuance`.
- Adds a new method to `RequestIssuance` that automatically retries, if needed, in case of `invalid_proof` 

Example

Old API
```kotlin 

   val firstOutcome = when(authorizedRequest) {
      is AuthorizedRequest.NoProofRequired -> authorizeRequest.requestSingle(requestPayload).gerOrThrow()
      is AuthorizedRequest.ProofRequired -> authorizedRequest.requestSingle(requestPayload, popSigner).gerOrThrow()
   }
   val updatedAuthorizedRequest = when(firstOutcome) {
      is SubmissionOutcome.Success-> firstOutcome.cNonce?.let( authorizedRequest.withCNonce(it) }
      is SubmissionOutcome.InvalidProod -> authorizedRequest.withCNonce(fiestOutcome.cNonce)
      else -> null
   } ?: authorizedRequest
   
   val outcome = when(firstOutcome) {
      is SumissionOutcome.InvalidProof -> updatedAuthorizedRequest.requestSingle(requestPayload, popSigner).gerOrThrow()
      else -> firstOutcome
   }

```

With the new method the above code is reduced to 

```kotlin
val (updatedAuthorizedRequest, outcome) = 
    with(issuer) {
        authorizedRequest.requestSingleAndUpdateState(  requestPayload,   popSigner).getOrThrow()
    }
                    
```

In the above example the `requestSingleAndUpdateState` retries, if needed, the request in case of an `invalid_proof` error and
returns both the possibly updated `AuthorizedRequest` (will contain always the latest `c_nonce`) and the final submission outcome