### PR TITLE
Fix proof generation on tests

### DIFF
--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/Commons.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/Commons.kt
@@ -71,14 +71,21 @@ internal fun issuanceLog(message: String) {
 fun Issuer.popSigner(
     credentialConfigurationIdentifier: CredentialConfigurationIdentifier,
     popSignerPreference: ProofTypeMetaPreference = ProofTypeMetaPreference.FavorJWT,
-): PopSigner {
+): PopSigner? {
     val credentialConfigurationsSupported =
         credentialOffer.credentialIssuerMetadata.credentialConfigurationsSupported
     val credentialConfiguration =
         checkNotNull(credentialConfigurationsSupported[credentialConfigurationIdentifier])
-    val popSigner =
-        CryptoGenerator.popSigner(credentialConfiguration = credentialConfiguration, preference = popSignerPreference)
-    return checkNotNull(popSigner) { "No signer can be generated for $credentialConfigurationIdentifier" }
+
+    return if (credentialConfiguration.proofTypesSupported.values.isEmpty()) null
+    else {
+        val popSigner =
+            CryptoGenerator.popSigner(
+                credentialConfiguration = credentialConfiguration,
+                preference = popSignerPreference,
+            )
+        checkNotNull(popSigner) { "No signer can be generated for $credentialConfigurationIdentifier" }
+    }
 }
 
 suspend fun Issuer.submitCredentialRequest(


### PR DESCRIPTION
The PR

Fixes a bug on the tests related to the automatic generations of proofs. 
Now this is enable if the issuer requires proofs for the specific credential (configuration)