### PR TITLE
Remove deprecated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ val request =
 val (updatedAuthorizedRequest, outcome) =
     with(issuer) {
         with(authorizedRequest) {
-            requestSingleAndUpdateState(request, popSigner)
+            requestSingle(request, popSigner)
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -330,8 +330,7 @@ The result of placing a request is represented by a `SubmissionOutcome` as follo
 
 - `SubmissionOutcome.Sucess` This could represent either the issued credential or a transaction_id in case
 of deferred issuance, or
-- `SubmissionOutcome.InvalidProof` indicating that credential issuer requires PoP or PoP provided was not valid
-- `SubmissionOutcome.Failed` indication that credential issuer rejected the request, or 
+- `SubmissionOutcome.Failed` indication that credential issuer rejected the request, including the `invalid_proof` case.
 
 In case of an unexpected error a runtime will be raised.
 
@@ -368,8 +367,9 @@ According to the specification, the wallet must be able to receive a
 in the library.
 
 For this reason, it is not uncommon that the first request to the credential issuance endpoint
-will have as an outcome `InvalidProof`. That's typical if credential issuer's token endpoint
-doesn't provide a `c_nonce` and proof is required for the requested credential.
+will have as an outcome `Failed` with an error `InvalidProof`. 
+That's typical if credential issuer's token endpoint doesn't provide a `c_nonce` and 
+proof is required for the requested credential.
 
 The library will automatically try to handle the invalid proof response and place a second request 
 which includes proofs. This can be done only if caller has provided a `popSigner` while 

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ proof is required for the requested credential.
 The library will automatically try to handle the invalid proof response and place a second request 
 which includes proofs. This can be done only if caller has provided a `popSigner` while 
 invoking `requestSingleAndUpdateState()`. In case, that this second request fails with `invalid_proof` 
-library will not retry the request and an error will be reported to caller.
+library will report as `IrrecoverableInvalidProof`.
 
 #### Place credential request next steps
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
@@ -123,6 +123,15 @@ typealias AuthorizedRequestAnd<T> = Pair<AuthorizedRequest, T>
  */
 interface RequestIssuance {
 
+    @Deprecated(
+        message = "Deprecated and will be removed",
+        replaceWith = ReplaceWith("requestSingle(requestPayload, popSigner)"),
+    )
+    suspend fun AuthorizedRequest.requestSingleAndUpdateState(
+        requestPayload: IssuanceRequestPayload,
+        popSigner: PopSigner?,
+    ): Result<AuthorizedRequestAnd<SubmissionOutcome>> = requestSingle(requestPayload, popSigner)
+
     /**
      * Places a request to the credential issuance endpoint.
      * Method will attempt to automatically retry submission in case
@@ -139,7 +148,7 @@ interface RequestIssuance {
      * @return the possibly updated [AuthorizedRequest] (if updated it will contain a fresh c_nonce) and
      * the [SubmissionOutcome]
      */
-    suspend fun AuthorizedRequest.requestSingleAndUpdateState(
+    suspend fun AuthorizedRequest.requestSingle(
         requestPayload: IssuanceRequestPayload,
         popSigner: PopSigner?,
     ): Result<AuthorizedRequestAnd<SubmissionOutcome>>
@@ -147,13 +156,21 @@ interface RequestIssuance {
 
 interface RequestBatchIssuance {
 
+    @Deprecated(
+        message = "Deprecated and will be removed",
+        replaceWith = ReplaceWith("requestBatch(credentialsMetadata)"),
+    )
+    suspend fun AuthorizedRequest.requestBatchAndUpdateState(
+        credentialsMetadata: List<Pair<IssuanceRequestPayload, PopSigner?>>,
+    ): Result<AuthorizedRequestAnd<SubmissionOutcome>> = requestBatch(credentialsMetadata)
+
     /**
      *  Batch request for issuing multiple credentials having an [AuthorizedRequest.ProofRequired] authorization.
      *
      *  @param credentialsMetadata   The metadata specifying the credentials that will be requested.
      *  @return The new state of request or error.
      */
-    suspend fun AuthorizedRequest.requestBatchAndUpdateState(
+    suspend fun AuthorizedRequest.requestBatch(
         credentialsMetadata: List<Pair<IssuanceRequestPayload, PopSigner?>>,
     ): Result<AuthorizedRequestAnd<SubmissionOutcome>>
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
@@ -61,7 +61,6 @@ sealed interface SubmissionOutcome : java.io.Serializable {
      * @param credentials The outcome of the issuance request.
      * If the issuance request was a batch request, it will contain the results of each issuance request.
      * If it was a single issuance request list will contain only one result.
-     * @param cNonce Nonce information sent back from the issuance server.
      */
     data class Success(val credentials: List<IssuedCredential>) : SubmissionOutcome
 
@@ -135,7 +134,7 @@ interface RequestIssuance {
      * @param popSigner Signer component of the proof to be sent. Although this is an optional
      * parameter, only required in case the present authorization state is [AuthorizedRequest.ProofRequired],
      * caller is advised to provide it, in order to allow the method to automatically retry
-     * in case of [SubmissionOutcome.InvalidProof]
+     * in case of [CredentialIssuanceError.InvalidProof]
      *
      * @return the possibly updated [AuthorizedRequest] (if updated it will contain a fresh c_nonce) and
      * the [SubmissionOutcome]
@@ -359,11 +358,6 @@ sealed class CredentialIssuanceError(message: String) : Throwable(message) {
     class IssuerDoesNotSupportDeferredIssuance : CredentialIssuanceError("IssuerDoesNotSupportDeferredIssuance")
 
     /**
-     * Issuance server does not support notifications
-     */
-    class IssuerDoesNotSupportNotifications : CredentialIssuanceError("IssuerDoesNotSupportNotifications")
-
-    /**
      * Generic failure during issuance request
      */
     data class IssuanceRequestFailed(
@@ -389,17 +383,6 @@ sealed class CredentialIssuanceError(message: String) : Throwable(message) {
     sealed class ProofGenerationError(message: String) : CredentialIssuanceError(message) {
 
         /**
-         * Binding method specified is not supported from issuer server
-         */
-        class CryptographicSuiteNotSupported : ProofGenerationError("BindingMethodNotSupported")
-
-        /**
-         * Cryptographic binding method is not supported from the issuance server for a specific credential
-         */
-        class CryptographicBindingMethodNotSupported :
-            ProofGenerationError("CryptographicBindingMethodNotSupported")
-
-        /**
          * Proof type provided for specific credential is not supported from issuance server
          */
         class ProofTypeNotSupported : ProofGenerationError("ProofTypeNotSupported")
@@ -409,12 +392,6 @@ sealed class CredentialIssuanceError(message: String) : Throwable(message) {
          */
         class ProofTypeSigningAlgorithmNotSupported :
             ProofGenerationError("ProofTypeSigningAlgorithmNotSupported")
-
-        /**
-         * Proof type curve provided for specific credential is not supported from issuance server
-         */
-        class ProofTypeSigningCurveNotSupported :
-            ProofGenerationError("ProofTypeSigningCurveNotSupported")
     }
 
     /**

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
@@ -310,6 +310,13 @@ sealed class CredentialIssuanceError(message: String) : Throwable(message) {
     ) : CredentialIssuanceError("Invalid Proof")
 
     /**
+     * Issuer rejected the issuance request because considered the proof erroneous.
+     * It is marked as irrecoverable because it is raised only after the library
+     * has automatically retried to recover from an [InvalidProof] error and failed
+     */
+    data class IrrecoverableInvalidProof(val errorDescription: String? = null) : CredentialIssuanceError("Irrecoverable invalid proof ")
+
+    /**
      * Issuer has not issued yet deferred credential. Retry interval (in seconds) is provided to caller
      */
     data class DeferredCredentialIssuancePending(

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Types.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Types.kt
@@ -207,12 +207,6 @@ value class NotificationId(val value: String) {
     }
 }
 
-@Deprecated(
-    message = "Deprecated. It will removed in a future release.",
-    replaceWith = ReplaceWith("JwtBindingKey"),
-)
-typealias BindingKey = JwtBindingKey
-
 /**
  * A sealed hierarchy that defines the different ways of including a PUB key
  * in a JWT Proof

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -42,7 +42,7 @@ internal class RequestIssuanceImpl(
     private val responseEncryptionSpec: IssuanceResponseEncryptionSpec?,
 ) : RequestIssuance, RequestBatchIssuance {
 
-    override suspend fun AuthorizedRequest.requestSingleAndUpdateState(
+    override suspend fun AuthorizedRequest.requestSingle(
         requestPayload: IssuanceRequestPayload,
         popSigner: PopSigner?,
     ): Result<AuthorizedRequestAnd<SubmissionOutcome>> = runCatching {
@@ -76,7 +76,7 @@ internal class RequestIssuanceImpl(
                 outcome.isInvalidProof()
 
         suspend fun retry() =
-            updatedAuthorizedRequest.requestSingleAndUpdateState(requestPayload, popSigner)
+            updatedAuthorizedRequest.requestSingle(requestPayload, popSigner)
                 .getOrThrow()
                 .markInvalidProofIrrecoverable()
 
@@ -96,7 +96,7 @@ internal class RequestIssuanceImpl(
         return updated ?: this
     }
 
-    override suspend fun AuthorizedRequest.requestBatchAndUpdateState(
+    override suspend fun AuthorizedRequest.requestBatch(
         credentialsMetadata: List<Pair<IssuanceRequestPayload, PopSigner?>>,
     ): Result<AuthorizedRequestAnd<SubmissionOutcome>> = runCatching {
         //
@@ -131,7 +131,7 @@ internal class RequestIssuanceImpl(
                 outcome.isInvalidProof()
 
         suspend fun retry() =
-            updatedAuthorizedRequest.requestBatchAndUpdateState(credentialsMetadata)
+            updatedAuthorizedRequest.requestBatch(credentialsMetadata)
                 .getOrThrow()
                 .markInvalidProofIrrecoverable()
 

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceBatchRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceBatchRequestTest.kt
@@ -88,7 +88,7 @@ class IssuanceBatchRequestTest {
 
         val requests = reqs()
         val (_, outcome) = with(issuer) {
-            authorizedRequest.requestBatchAndUpdateState(requests).getOrThrow()
+            authorizedRequest.requestBatch(requests).getOrThrow()
         }
 
         assertIs<SubmissionOutcome.Success>(outcome)

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceDeferredRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceDeferredRequestTest.kt
@@ -53,7 +53,7 @@ class IssuanceDeferredRequestTest {
             )
             val popSigner = CryptoGenerator.rsaProofSigner()
             val (newAuthorizedRequest, outcome) =
-                authorizedRequest.requestSingleAndUpdateState(requestPayload, popSigner).getOrThrow()
+                authorizedRequest.requestSingle(requestPayload, popSigner).getOrThrow()
             assertIs<SubmissionOutcome.Success>(outcome)
 
             val issuedCredential = outcome.credentials[0]
@@ -99,7 +99,7 @@ class IssuanceDeferredRequestTest {
             )
             val popSigner = CryptoGenerator.rsaProofSigner()
             val (newAuthorizedRequest, outcome) =
-                authorizedRequest.requestSingleAndUpdateState(requestPayload, popSigner).getOrThrow()
+                authorizedRequest.requestSingle(requestPayload, popSigner).getOrThrow()
             assertIs<SubmissionOutcome.Success>(outcome)
             val issuedCredential = outcome.credentials[0]
             assertIs<IssuedCredential.Deferred>(issuedCredential)
@@ -161,7 +161,7 @@ class IssuanceDeferredRequestTest {
                 CredentialConfigurationIdentifier(PID_SdJwtVC),
                 null,
             )
-            val (newAuthorized, outcome) = authorizedRequest.requestSingleAndUpdateState(
+            val (newAuthorized, outcome) = authorizedRequest.requestSingle(
                 requestPayload,
                 CryptoGenerator.rsaProofSigner(),
             ).getOrThrow()

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceEncryptedResponsesTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceEncryptedResponsesTest.kt
@@ -173,7 +173,7 @@ class IssuanceEncryptedResponsesTest {
                 val noProofRequired = authorizedRequest as AuthorizedRequest.NoProofRequired
                 val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, null)
-                noProofRequired.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
+                noProofRequired.requestSingle(requestPayload, null).getOrThrow()
             }
         }
 
@@ -210,7 +210,7 @@ class IssuanceEncryptedResponsesTest {
                 val noProofRequired = authorizedRequest as AuthorizedRequest.NoProofRequired
                 val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, null)
-                noProofRequired.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
+                noProofRequired.requestSingle(requestPayload, null).getOrThrow()
             }
         }
 
@@ -242,7 +242,7 @@ class IssuanceEncryptedResponsesTest {
                 val noProofRequired = authorizedRequest as AuthorizedRequest.NoProofRequired
                 val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, null)
-                noProofRequired.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
+                noProofRequired.requestSingle(requestPayload, null).getOrThrow()
             }
         }
 
@@ -318,7 +318,7 @@ class IssuanceEncryptedResponsesTest {
                 assertIs<AuthorizedRequest.NoProofRequired>(authorizedRequest)
                 val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, claimSet)
-                val (_, outcome) = authorizedRequest.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
+                val (_, outcome) = authorizedRequest.requestSingle(requestPayload, null).getOrThrow()
                 assertIs<SubmissionOutcome.Success>(outcome)
             }
         }
@@ -395,7 +395,7 @@ class IssuanceEncryptedResponsesTest {
             ).map { IssuanceRequestPayload.ConfigurationBased(CredentialConfigurationIdentifier(it)) to null }
 
             with(issuer) {
-                authorizedRequest.requestBatchAndUpdateState(batchRequestPayload).getOrThrow()
+                authorizedRequest.requestBatch(batchRequestPayload).getOrThrow()
             }
         }
 
@@ -454,7 +454,7 @@ class IssuanceEncryptedResponsesTest {
             ).map { IssuanceRequestPayload.ConfigurationBased(CredentialConfigurationIdentifier(it)) to null }
 
             val (_, outcome) = with(issuer) {
-                authorizedRequest.requestBatchAndUpdateState(batchRequestPayload).getOrThrow()
+                authorizedRequest.requestBatch(batchRequestPayload).getOrThrow()
             }
             assertIs<SubmissionOutcome.Success>(outcome)
             assertTrue("One deferred credential response expected") {
@@ -499,7 +499,7 @@ class IssuanceEncryptedResponsesTest {
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(
                     CredentialConfigurationIdentifier(PID_SdJwtVC),
                 )
-                val (newAuthorizedRequest, outcome) = authorizedRequest.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
+                val (newAuthorizedRequest, outcome) = authorizedRequest.requestSingle(requestPayload, null).getOrThrow()
                 assertIs<SubmissionOutcome.Success>(outcome)
                 val deferredCredential = outcome.credentials.firstOrNull()
                 assertIs<IssuedCredential.Deferred>(deferredCredential)
@@ -569,7 +569,7 @@ class IssuanceEncryptedResponsesTest {
                 null,
             )
             val (newAuthorizedRequest, outcome) =
-                authorizedRequest.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
+                authorizedRequest.requestSingle(requestPayload, null).getOrThrow()
             assertIs<SubmissionOutcome.Success>(outcome)
 
             val deferredCredential = outcome.credentials[0]

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceNotificationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceNotificationTest.kt
@@ -75,7 +75,7 @@ class IssuanceNotificationTest {
                     val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, null)
                     val popSigner = CryptoGenerator.rsaProofSigner()
                     val (newAuthorizedRequest, outcome) =
-                        authorizedRequest.requestSingleAndUpdateState(requestPayload, popSigner).getOrThrow()
+                        authorizedRequest.requestSingle(requestPayload, popSigner).getOrThrow()
                     assertIs<SubmissionOutcome.Success>(outcome, "Not a successful issuance")
 
                     val issuedCredential = outcome.credentials.firstOrNull()

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
@@ -93,7 +93,7 @@ class IssuanceSingleRequestTest {
                     val (updatedAuthorizedRequest, outcome) = assertDoesNotThrow {
                         val requestPayload =
                             IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, claimSet)
-                        authorizedRequest.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
+                        authorizedRequest.requestSingle(requestPayload, null).getOrThrow()
                     }
                     assertIs<AuthorizedRequest.ProofRequired>(updatedAuthorizedRequest)
                     assertIs<SubmissionOutcome.Failed>(outcome)
@@ -150,7 +150,7 @@ class IssuanceSingleRequestTest {
                         val (_, outcome) = assertDoesNotThrow {
                             val requestPayload =
                                 IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, claimSet)
-                            authorizedRequest.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
+                            authorizedRequest.requestSingle(requestPayload, null).getOrThrow()
                         }
                         assertIs<SubmissionOutcome.Failed>(outcome)
                         assertIs<CredentialIssuanceError.ResponseUnparsable>(outcome.error)
@@ -185,7 +185,7 @@ class IssuanceSingleRequestTest {
                 assertFailsWith<CredentialIssuanceError.InvalidIssuanceRequest> {
                     val requestPayload =
                         IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, claimSetMsoMdoc)
-                    authorizedRequest.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
+                    authorizedRequest.requestSingle(requestPayload, null).getOrThrow()
                 }
 
                 val claimSetSdJwtVc = GenericClaimSet(listOf("degree"))
@@ -193,7 +193,7 @@ class IssuanceSingleRequestTest {
                 assertFailsWith<CredentialIssuanceError.InvalidIssuanceRequest> {
                     val requestPayload =
                         IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, claimSetSdJwtVc)
-                    authorizedRequest.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
+                    authorizedRequest.requestSingle(requestPayload, null).getOrThrow()
                 }
             }
         }
@@ -218,7 +218,7 @@ class IssuanceSingleRequestTest {
                 val requestPayload =
                     IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, null)
                 with(issuer) {
-                    authorizedRequest.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
+                    authorizedRequest.requestSingle(requestPayload, null).getOrThrow()
                 }
             }
         }
@@ -266,7 +266,7 @@ class IssuanceSingleRequestTest {
         val popSigner = CryptoGenerator.rsaProofSigner()
         val (_, outcome) =
             with(issuer) {
-                authorizedRequest.requestSingleAndUpdateState(requestPayload, popSigner).getOrThrow()
+                authorizedRequest.requestSingle(requestPayload, popSigner).getOrThrow()
             }
         assertIs<SubmissionOutcome.Success>(outcome)
     }
@@ -303,7 +303,7 @@ class IssuanceSingleRequestTest {
                     val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
                     val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, claimSet)
                     val popSigner = CryptoGenerator.rsaProofSigner()
-                    val (newAuthorizedRequest, outcome) = authorizedRequest.requestSingleAndUpdateState(
+                    val (newAuthorizedRequest, outcome) = authorizedRequest.requestSingle(
                         requestPayload,
                         popSigner,
                     ).getOrThrow()
@@ -350,7 +350,7 @@ class IssuanceSingleRequestTest {
                     val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
                     val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, claimSet)
                     val popSigner = CryptoGenerator.rsaProofSigner()
-                    val (newAuthorizedRequest, outcome) = authorizedRequest.requestSingleAndUpdateState(
+                    val (newAuthorizedRequest, outcome) = authorizedRequest.requestSingle(
                         requestPayload,
                         popSigner,
                     ).getOrThrow()
@@ -401,7 +401,7 @@ class IssuanceSingleRequestTest {
                     }
                     ?: error("No credential identifier")
             with(issuer) {
-                authorizedRequest.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
+                authorizedRequest.requestSingle(requestPayload, null).getOrThrow()
             }
         }
 
@@ -438,7 +438,7 @@ class IssuanceSingleRequestTest {
             )
             assertThrows<IllegalArgumentException> {
                 with(issuer) {
-                    authorizedRequest.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
+                    authorizedRequest.requestSingle(requestPayload, null).getOrThrow()
                 }
             }
         }
@@ -474,7 +474,7 @@ class IssuanceSingleRequestTest {
             )
             assertThrows<IllegalArgumentException> {
                 with(issuer) {
-                    authorizedRequest.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
+                    authorizedRequest.requestSingle(requestPayload, null).getOrThrow()
                 }
             }
         }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
@@ -96,7 +96,8 @@ class IssuanceSingleRequestTest {
                         authorizedRequest.requestSingleAndUpdateState(requestPayload, null).getOrThrow()
                     }
                     assertIs<AuthorizedRequest.ProofRequired>(updatedAuthorizedRequest)
-                    assertIs<SubmissionOutcome.InvalidProof>(outcome)
+                    assertIs<SubmissionOutcome.Failed>(outcome)
+                    assertIs<CredentialIssuanceError.InvalidProof>(outcome.error)
                 }
 
                 is AuthorizedRequest.ProofRequired -> fail(

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/Commons.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/Commons.kt
@@ -166,18 +166,8 @@ suspend fun Issuer.testIssuanceWithPreAuthorizedCodeFlow(
 
 fun ensureIssued(outcome: SubmissionOutcome): List<IssuedCredential> =
     when (outcome) {
-        is SubmissionOutcome.Failed -> {
-            fail("Issuer rejected request. Reason :${outcome.error.message}")
-        }
-
-        is SubmissionOutcome.InvalidProof -> {
-            val (_, error) = outcome
-            fail("Issuer rejected proof. Reason: ${error ?: "n/a"}")
-        }
-
-        is SubmissionOutcome.Success -> {
-            outcome.credentials
-        }
+        is SubmissionOutcome.Failed -> fail("Issuer rejected request. Reason :${outcome.error.message}")
+        is SubmissionOutcome.Success -> outcome.credentials
     }
 
 suspend fun handleDeferred(

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/Commons.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/Commons.kt
@@ -97,7 +97,7 @@ suspend fun Issuer.submitCredentialRequest(
 ): AuthorizedRequestAnd<SubmissionOutcome> {
     val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, claimSet)
     val popSigner = popSigner(credentialConfigurationId, popSignerPreference)
-    return authorizedRequest.requestSingleAndUpdateState(requestPayload, popSigner).getOrThrow()
+    return authorizedRequest.requestSingle(requestPayload, popSigner).getOrThrow()
 }
 
 suspend fun <ENV, USER> Issuer.authorizeUsingAuthorizationCodeFlow(

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingAuthorizationFlow.kt
@@ -93,7 +93,7 @@ private suspend fun submit(
     with(issuer) {
         val proofSigner = popSigner(credentialConfigurationId)
         val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, null)
-        val (newAuthorized, outcome) = authorized.requestSingleAndUpdateState(requestPayload, proofSigner).getOrThrow()
+        val (newAuthorized, outcome) = authorized.requestSingle(requestPayload, proofSigner).getOrThrow()
         return when (outcome) {
             is SubmissionOutcome.Success -> newAuthorized to handleSuccess(outcome, issuer, newAuthorized)
             is SubmissionOutcome.Failed ->

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingAuthorizationFlow.kt
@@ -96,10 +96,10 @@ private suspend fun submit(
         val (newAuthorized, outcome) = authorized.requestSingleAndUpdateState(requestPayload, proofSigner).getOrThrow()
         return when (outcome) {
             is SubmissionOutcome.Success -> newAuthorized to handleSuccess(outcome, issuer, newAuthorized)
-            is SubmissionOutcome.Failed -> throw outcome.error
-            is SubmissionOutcome.InvalidProof -> throw IllegalStateException(
-                "Although providing a proof with c_nonce the proof is still invalid",
-            )
+            is SubmissionOutcome.Failed ->
+                throw if (outcome.error is CredentialIssuanceError.InvalidProof) {
+                    IllegalStateException("Although providing a proof with c_nonce the proof is still invalid")
+                } else outcome.error
         }
     }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingPreAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingPreAuthorizationFlow.kt
@@ -72,7 +72,7 @@ private suspend fun submit(
     with(issuer) {
         val proofSigner = popSigner(credentialConfigurationId)
         val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, null)
-        val (newAuthorized, outcome) = authorized.requestSingleAndUpdateState(requestPayload, proofSigner).getOrThrow()
+        val (newAuthorized, outcome) = authorized.requestSingle(requestPayload, proofSigner).getOrThrow()
 
         return when (outcome) {
             is SubmissionOutcome.Success -> newAuthorized to handleSuccess(outcome, issuer, newAuthorized)

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingPreAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingPreAuthorizationFlow.kt
@@ -76,10 +76,10 @@ private suspend fun submit(
 
         return when (outcome) {
             is SubmissionOutcome.Success -> newAuthorized to handleSuccess(outcome, issuer, newAuthorized)
-            is SubmissionOutcome.Failed -> throw outcome.error
-            is SubmissionOutcome.InvalidProof -> throw IllegalStateException(
-                "Although providing a proof with c_nonce the proof is still invalid",
-            )
+            is SubmissionOutcome.Failed ->
+                throw if (outcome.error is CredentialIssuanceError.InvalidProof) {
+                    IllegalStateException("Although providing a proof with c_nonce the proof is still invalid")
+                } else outcome.error
         }
     }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/WalletInitiatedIssuanceUsingAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/WalletInitiatedIssuanceUsingAuthorizationFlow.kt
@@ -88,10 +88,10 @@ private suspend fun Issuer.submitCredentialRequest(
 
     return when (outcome) {
         is SubmissionOutcome.Success -> newAuthorized to handleSuccess(newAuthorized, outcome)
-        is SubmissionOutcome.Failed -> throw outcome.error
-        is SubmissionOutcome.InvalidProof -> throw IllegalStateException(
-            "Although providing a proof with c_nonce the proof is still invalid",
-        )
+        is SubmissionOutcome.Failed ->
+            throw if (outcome.error is CredentialIssuanceError.InvalidProof) {
+                IllegalStateException("Although providing a proof with c_nonce the proof is still invalid")
+            } else outcome.error
     }
 }
 

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/WalletInitiatedIssuanceUsingAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/WalletInitiatedIssuanceUsingAuthorizationFlow.kt
@@ -83,7 +83,7 @@ private suspend fun Issuer.submitCredentialRequest(
     issuanceLog("Requesting issuance of '$credentialConfigurationId'")
     val proofSigner = popSigner(credentialConfigurationId)
     val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, null)
-    val (newAuthorized, outcome) = authorizedRequest.requestSingleAndUpdateState(requestPayload, proofSigner)
+    val (newAuthorized, outcome) = authorizedRequest.requestSingle(requestPayload, proofSigner)
         .getOrThrow()
 
     return when (outcome) {


### PR DESCRIPTION
Closes #276 
Closes #288

The most significant change is the removal of `SubmissionOutcome.InvalidProof`

After the introduction of the library feature for automatically retrying (if possible) in case of an `invalid_proof` error, this error is being reported to the caller as `SubmissionOutcome.Failed` having an error of type `CredentialIssuanceError.InvalidProof` 

If caller has provided the proofs, an `InvalidProof` means that the credential issuer indeed rejected proof because actually evaluates them as erroneous. This special case is reported with `IrrecoverableInvalidProof` 

