### PR TITLE
Update setup-gradle github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,11 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Build with Gradle Wrapper
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          gradle-version: wrapper
-          arguments: build
+        run: ./gradlew build
         env:
           CI: true
       - id: extract
@@ -46,11 +45,11 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Publish with Gradle Wrapper
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: publishAllPublicationsToMavenCentral --full-stacktrace
+        run: ./gradlew publishAllPublicationsToMavenCentral --full-stacktrace
         env:
           CI: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,12 +33,11 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Publish with Gradle Wrapper
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          gradle-version: wrapper
-          arguments: build publishAllPublicationsToMavenCentral --no-configuration-cache --full-stacktrace
+        run: ./gradlew build publishAllPublicationsToMavenCentral --no-configuration-cache --full-stacktrace
         env:
           CI: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Some refactoring is needed in order to update to the v4 of setup-gradle-action

https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated