### PR TITLE
Add resource parameter to PAR

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/AuthorizationEndpointClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/AuthorizationEndpointClient.kt
@@ -151,6 +151,7 @@ internal class AuthorizationEndpointClient(
                 issuerState?.let { customParameter("issuer_state", issuerState) }
                 if (scopes.isNotEmpty()) {
                     scope(NimbusScope(*scopes.map { it.value }.toTypedArray()))
+                    resource(credentialIssuerId.value.value.toURI())
                 }
                 if (credentialsConfigurationIds.isNotEmpty()) {
                     authorizationDetails(credentialsConfigurationIds.map(::toNimbus))
@@ -241,7 +242,7 @@ internal class AuthorizationEndpointClient(
         credentialConfigurationId: CredentialConfigurationIdentifier,
     ): AuthorizationDetail =
         with(NimbusAuthorizationDetail.Builder(AuthorizationType(OPENID_CREDENTIAL))) {
-            if (credentialIssuerId.toString() != authorizationIssuer.toString()) {
+            if (credentialIssuerId.toString() != authorizationIssuer) {
                 val locations = listOf(Location(credentialIssuerId.value.value.toURI()))
                 locations(locations)
             }


### PR DESCRIPTION
As recommended by the [OpenID4VCI draft 14](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-5.1.2-9), use [RFC8707](https://www.rfc-editor.org/info/rfc8707) `resource` parameter when requesting issuance using `scope` parameter.

The exact phrasing in the draft reads:

> If the Credential Issuer metadata contains an `authorization_servers` property, it is **RECOMMENDED** to use a resource parameter.

The information about existence of `authorization_servers` property is unfortunately lost in the TO → domain conversion, so it's not taken into account.

This fix has already been applied to the iOS library in https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift/pull/56.