### PR TITLE
Mark as deprecated Batch EndPoint and CWT Proofs

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
@@ -64,6 +64,9 @@ sealed interface ProofTypeMeta : Serializable {
         }
     }
 
+    @Deprecated(
+        message = "CWT proofs have been removed from OpenId4VCI",
+    )
     data class Cwt(val algorithms: List<CoseAlgorithm>, val curves: List<CoseCurve>) : ProofTypeMeta {
         init {
             require(algorithms.isNotEmpty()) { "Supported algorithms in case of CWT cannot be empty" }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialIssuerMetadataResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialIssuerMetadataResolver.kt
@@ -62,6 +62,9 @@ data class CredentialIssuerMetadata(
     val credentialIssuerIdentifier: CredentialIssuerId,
     val authorizationServers: List<HttpsUrl> = listOf(credentialIssuerIdentifier.value),
     val credentialEndpoint: CredentialIssuerEndpoint,
+    @Deprecated(
+        message = "Batch credential endpoint has been removed from OpenId4VCI",
+    )
     val batchCredentialEndpoint: CredentialIssuerEndpoint? = null,
     val deferredCredentialEndpoint: CredentialIssuerEndpoint? = null,
     val notificationEndpoint: CredentialIssuerEndpoint? = null,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
@@ -154,6 +154,9 @@ interface RequestIssuance {
     ): Result<AuthorizedRequestAnd<SubmissionOutcome>>
 }
 
+@Deprecated(
+    message = "Batch endpoint has been removed from OpenId4VCI",
+)
 interface RequestBatchIssuance {
 
     @Deprecated(
@@ -200,6 +203,9 @@ sealed interface PopSigner {
      * @param sign A suspended function to actually sign the data. It is required that implementer, uses
      * the P1363 format
      */
+    @Deprecated(
+        message = "CWT proofs have been removed from OpenId4VCI",
+    )
     data class Cwt(
         val algorithm: CoseAlgorithm,
         val curve: CoseCurve,
@@ -248,7 +254,9 @@ sealed interface PopSigner {
          * In case of [JwtBindingKey.Did] this condition is not being checked.
          * @return the CWT signer
          */
-
+        @Deprecated(
+            message = "CWT proofs have been removed from OpenId4VCI",
+        )
         fun cwtPopSigner(
             privateKey: ECKey,
         ): Cwt {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/Proof.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/Proof.kt
@@ -42,6 +42,9 @@ internal sealed interface Proof {
      *
      * @param cwt The proof CWT
      */
+    @Deprecated(
+        message = "CWT proofs have been removed from OpenId4VCI",
+    )
     @JvmInline
     value class Cwt(val cwt: String) : Proof
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProofBuilder.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProofBuilder.kt
@@ -118,6 +118,9 @@ internal class JwtProofBuilder(
     }
 }
 
+@Deprecated(
+    message = "CWT proofs have been removed from OpenId4VCI",
+)
 internal class CwtProofBuilder(
     clock: Clock,
     iss: ClientId,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialIssuerMetadataJsonParser.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialIssuerMetadataJsonParser.kt
@@ -334,7 +334,7 @@ private data class W3CSignedJwtCredentialTO(
         fun toDomain(): W3CSignedJwtCredential.CredentialDefinition =
             W3CSignedJwtCredential.CredentialDefinition(
                 type = types,
-                credentialSubject = credentialSubject?.let { it.toDomain() },
+                credentialSubject = credentialSubject?.toDomain(),
             )
     }
 
@@ -366,6 +366,9 @@ private data class CredentialIssuerMetadataTO(
     @SerialName("credential_issuer") @Required val credentialIssuerIdentifier: String,
     @SerialName("authorization_servers") val authorizationServers: List<String>? = null,
     @SerialName("credential_endpoint") @Required val credentialEndpoint: String,
+    @Deprecated(
+        message = "Batch credential endpoint has been removed from OpenId4VCI",
+    )
     @SerialName("batch_credential_endpoint") val batchCredentialEndpoint: String? = null,
     @SerialName("deferred_credential_endpoint") val deferredCredentialEndpoint: String? = null,
     @SerialName("notification_endpoint") val notificationEndpoint: String? = null,

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CryptoGenerator.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CryptoGenerator.kt
@@ -61,6 +61,9 @@ object CryptoGenerator {
         return keyPair to PopSigner.jwtPopSigner(keyPair, alg, bindingKey)
     }
 
+    @Deprecated(
+        message = "CWT proofs have been removed from OpenId4VCI",
+    )
     private fun ecKeyAndCwtPopSigner(
         clock: Clock,
         alg: CoseAlgorithm,

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProofBuilderTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProofBuilderTest.kt
@@ -79,6 +79,9 @@ internal class ProofBuilderTest {
         }
     }
 
+    @Deprecated(
+        message = "CWT Proofs have been removed from OpenId4VCI",
+    )
     @Test
     fun `check cwt proof`() = runTest {
         val clock = Clock.fixed(Instant.now(), ZoneId.systemDefault())
@@ -97,6 +100,9 @@ internal class ProofBuilderTest {
         }
     }
 
+    @Deprecated(
+        message = "CWT Proofs have been removed from OpenId4VCI",
+    )
     @Test
     fun `check cwt proof with authlete impl`() = runTest {
         val clock = Clock.fixed(Instant.now(), ZoneId.systemDefault())
@@ -124,6 +130,9 @@ internal class ProofBuilderTest {
     }
 }
 
+@Deprecated(
+    message = "CWT Proofs have been removed from OpenId4VCI",
+)
 internal object CwtProofValidator {
 
     fun isValid(


### PR DESCRIPTION
This PR marks as deprecated parts of the public API of the library that are related to:

- Batch Credential Endpoint 
- CWT Proofs

Both of them were removed in draft 14.

