### PR TITLE
Add support for authorization server-provided `dpopNonce`

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
@@ -64,6 +64,7 @@ data class AuthorizedTransaction(
                 refreshToken = authorizedRequest.refreshToken,
                 credentialIdentifiers = authorizedRequest.credentialIdentifiers,
                 timestamp = authorizedRequest.timestamp,
+                dpopNonce = authorizedRequest.dpopNonce,
             )
         },
         transactionId = transactionId,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
@@ -124,6 +124,7 @@ interface Issuer :
                     credentialOffer.credentialIssuerIdentifier,
                     credentialOffer.authorizationServerMetadata,
                     config,
+                    dPoPJwtFactory,
                     ktorHttpClientFactory,
                 )
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RefreshAccessToken.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RefreshAccessToken.kt
@@ -35,11 +35,13 @@ internal class RefreshAccessToken(
 
     private suspend fun refresh(authorizedRequest: AuthorizedRequest): AuthorizedRequest {
         val refreshToken = requireNotNull(authorizedRequest.refreshToken)
-        val tokenResponse = tokenEndpointClient.refreshAccessToken(refreshToken).getOrThrow()
+        val (tokenResponse, newDpopNonce) =
+            tokenEndpointClient.refreshAccessToken(refreshToken, authorizedRequest.dpopNonce).getOrThrow()
         return authorizedRequest.withRefreshedAccessToken(
             refreshedAccessToken = tokenResponse.accessToken,
             newRefreshToken = tokenResponse.refreshToken,
             at = tokenResponse.timestamp,
+            newDpopNonce = newDpopNonce,
         )
     }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/DeferredIssuerExtensions.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/DeferredIssuerExtensions.kt
@@ -163,6 +163,7 @@ data class DeferredIssuanceStoredContextTO(
                     refreshToken = refreshToken?.toRefreshToken(),
                     credentialIdentifiers = emptyMap(),
                     timestamp = Instant.ofEpochSecond(authorizationTimestamp),
+                    dpopNonce = null,
                 ),
                 transactionId = TransactionId(transactionId),
             ),


### PR DESCRIPTION
This PR adds support for using `dpopNonce` provided by the authorization server, in the following interactions:
- When requesting access token (in the context of authorization code grant and / or pre-authorized code grant)
- When refreshing an access token (in the context of refresh grant).
- When pushing an authorization request to PAR endpoint

In the above cases, authorization server may reply with a (oaut2) error  `use_dpop_nonce` either because the `dopNonce` is missing or because the the value it is not the correct.

Library catches the above error, updates the `dpopNonce` of the client, to the new value provided by the server and repeats the call using the new `dpopNonce`. At this stage, if authorization server replies again with a `use_dpop_nonce`, library will not retry again.

Furthermore, authorization server at any of the aforementioned three interactions may choose to update the `dpopNonce`.
To satisfy this, library evaluates whether success (`200`) responses contain a `dpopNonce` header, and if present, the locally held `dpopNonce` is updated.

PS: On the client side, the `dpopNonce` is kept within the `AuthorizedRequest`. Since the library is stateless, all the above interactions require from the caller to provide an `AuthorizedRequest` and return a possibly updated `AuthorizedRequest`


Closes #330 