### PR TITLE
First alignment to OpenId4VCI d15

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.parallel=true
 
 # Project properties
 group=eu.europa.ec.eudi
-version=0.6.3-SNAPSHOT
+version=0.7.0-SNAPSHOT
 
 # Sonar
 systemProp.sonar.host.url=https://sonarcloud.io

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/ClaimPath.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/ClaimPath.kt
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.openid4vci
+
+import eu.europa.ec.eudi.openid4vci.ClaimPathElement.*
+import eu.europa.ec.eudi.openid4vci.internal.ClaimPathSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.*
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+//
+// That's a copy from sd-jwt-kt lib
+//
+
+/**
+ * The path is a non-empty [list][value] of [elements][ClaimPathElement],
+ * null values, or non-negative integers.
+ * It is used to [select][SelectPath] a particular claim in the credential or a set of claims.
+ *
+ * It is [serialized][ClaimPathSerializer] as a [JsonArray] which may contain
+ * string, `null`, or integer elements
+ */
+@Serializable(with = ClaimPathSerializer::class)
+@JvmInline
+value class ClaimPath(val value: List<ClaimPathElement>) {
+
+    init {
+        require(value.isNotEmpty())
+    }
+
+    override fun toString(): String = value.toString()
+
+    operator fun plus(other: ClaimPathElement): ClaimPath = ClaimPath(this.value + other)
+
+    operator fun plus(other: ClaimPath): ClaimPath = ClaimPath(this.value + other.value)
+
+    operator fun contains(that: ClaimPath): Boolean = value.foldIndexed(this.value.size <= that.value.size) { index, acc, thisElement ->
+        fun comp() = that.value.getOrNull(index)?.let { thatElement -> thatElement in thisElement } == true
+        acc and comp()
+    }
+
+    /**
+     * Appends a wild-card indicator [ClaimPathElement.AllArrayElements]
+     */
+    fun allArrayElements(): ClaimPath = this + AllArrayElements
+
+    /**
+     * Appends an indexed path [ClaimPathElement.ArrayElement]
+     */
+    fun arrayElement(i: Int): ClaimPath = this + ArrayElement(i)
+
+    /**
+     * Appends a named path [ClaimPathElement.Claim]
+     */
+    fun claim(name: String): ClaimPath = this + Claim(name)
+
+    /**
+     * Gets the ClaimPath of the parent element. Returns `null` to indicate the root element.
+     */
+    fun parent(): ClaimPath? = value.dropLast(1)
+        .takeIf { it.isNotEmpty() }
+        ?.let { ClaimPath(it) }
+
+    fun head(): ClaimPathElement = value.first()
+    fun tail(): ClaimPath? {
+        val tailElements = value.drop(1)
+        return if (tailElements.isEmpty()) return null
+        else ClaimPath(tailElements)
+    }
+
+    /**
+     * Gets the [head]
+     */
+    operator fun component1(): ClaimPathElement = head()
+
+    /**
+     * Gets the [tail]
+     */
+    operator fun component2(): ClaimPath? = tail()
+
+    companion object {
+        fun claim(name: String): ClaimPath = ClaimPath(listOf(Claim(name)))
+    }
+}
+
+/**
+ * Elements of a [ClaimPath]
+ * - [Claim] indicates that the respective [key][Claim.name] is to be selected
+ * - [AllArrayElements] indicates that all elements of the currently selected array(s) are to be selected, and
+ * - [ArrayElement] indicates that the respective [index][ArrayElement.index] in an array is to be selected
+ */
+sealed interface ClaimPathElement {
+
+    /**
+     * Indicates that all elements of the currently selected array(s) are to be selected
+     * It is serialized as a [JsonNull]
+     */
+    data object AllArrayElements : ClaimPathElement {
+        override fun toString(): String = "null"
+    }
+
+    /**
+     * Indicates that the respective [index][index] in an array is to be selected.
+     * It is serialized as an [integer][JsonPrimitive]
+     * @param index Non-negative index
+     */
+    @JvmInline
+    value class ArrayElement(val index: Int) : ClaimPathElement {
+        init {
+            require(index >= 0) { "Index should be non-negative" }
+        }
+
+        override fun toString(): String = index.toString()
+    }
+
+    /**
+     * Indicates that the respective [key][name] is to be selected.
+     * It is serialized as a [string][JsonPrimitive]
+     * @param name the attribute name
+     */
+    @JvmInline
+    value class Claim(val name: String) : ClaimPathElement {
+        override fun toString(): String = name
+    }
+
+    /**
+     * Indication of whether the current instance contains the other.
+     * @param that the element to compare with
+     * @return in case that the two elements are of the same type, and if they are equal (including attribute),
+     * then true is being returned. Also, an [AllArrayElements] contains [ArrayElement].
+     * In all other cases, a false is being returned.
+     */
+    operator fun contains(that: ClaimPathElement): Boolean = when (this) {
+        AllArrayElements -> when (that) {
+            AllArrayElements -> true
+            is ArrayElement -> true
+            is Claim -> false
+        }
+
+        is ArrayElement -> this == that
+        is Claim -> this == that
+    }
+}
+
+@OptIn(ExperimentalContracts::class)
+inline fun <T> ClaimPathElement.fold(
+    ifAllArrayElements: () -> T,
+    ifArrayElement: (Int) -> T,
+    ifClaim: (String) -> T,
+): T {
+    contract {
+        callsInPlace(ifAllArrayElements, InvocationKind.AT_MOST_ONCE)
+        callsInPlace(ifArrayElement, InvocationKind.AT_MOST_ONCE)
+        callsInPlace(ifClaim, InvocationKind.AT_MOST_ONCE)
+    }
+    return when (this) {
+        AllArrayElements -> ifAllArrayElements()
+        is ArrayElement -> ifArrayElement(index)
+        is ClaimPathElement.Claim -> ifClaim(name)
+    }
+}
+
+fun JsonArray.asClaimPath(): ClaimPath {
+    val elements = map {
+        require(it is JsonPrimitive)
+        it.asClaimPathElement()
+    }
+    return ClaimPath(elements)
+}
+
+fun JsonPrimitive.asClaimPathElement(): ClaimPathElement = when {
+    this is JsonNull -> AllArrayElements
+    isString -> Claim(content)
+    intOrNull != null -> ArrayElement(int)
+    else -> throw IllegalArgumentException("Only string, null, int can be used")
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
@@ -173,8 +173,6 @@ data class Claim(
         @SerialName("locale") val locale: Locale? = null,
     ) : Serializable
 }
-typealias Namespace = String
-typealias ClaimName = String
 
 data class MsoMdocPolicy(val oneTimeUse: Boolean, val batchSize: Int?) : Serializable
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
@@ -57,7 +57,10 @@ enum class ProofType : Serializable {
 }
 
 sealed interface ProofTypeMeta : Serializable {
-    data class Jwt(val algorithms: List<JWSAlgorithm>) : ProofTypeMeta {
+    data class Jwt(
+        val algorithms: List<JWSAlgorithm>,
+        val keyAttestationRequirement: KeyAttestationRequirement,
+    ) : ProofTypeMeta {
         init {
             require(algorithms.isNotEmpty()) { "Supported algorithms in case of JWT cannot be empty" }
         }
@@ -68,6 +71,28 @@ sealed interface ProofTypeMeta : Serializable {
     }
 
     data class Unsupported(val type: String) : ProofTypeMeta
+}
+
+sealed interface KeyAttestationRequirement {
+
+    data object NotRequired : KeyAttestationRequirement {
+        private fun readResolve(): Any = NotRequired
+    }
+
+    data object RequiredNoConstraints : KeyAttestationRequirement {
+        private fun readResolve(): Any = RequiredNoConstraints
+    }
+
+    data class Required(
+        val keyStorageConstraints: List<String>,
+        val userAuthenticationConstraints: List<String>,
+    ) : KeyAttestationRequirement {
+        init {
+            require(keyStorageConstraints.isNotEmpty() || userAuthenticationConstraints.isNotEmpty()) {
+                "Either key storage or user authentication constraints must be provided"
+            }
+        }
+    }
 }
 
 fun ProofTypeMeta.type(): ProofType? = when (this) {
@@ -103,6 +128,7 @@ data class Display(
     val logo: Logo? = null,
     val description: String? = null,
     val backgroundColor: CssColor? = null,
+    val backgroundImage: URI? = null,
     val textColor: CssColor? = null,
 ) : Serializable {
 
@@ -124,6 +150,7 @@ sealed interface CredentialConfiguration : Serializable {
     val credentialSigningAlgorithmsSupported: List<String>
     val proofTypesSupported: ProofTypesSupported
     val display: List<Display>
+    val claims: List<Claim>?
 }
 
 /**
@@ -131,8 +158,8 @@ sealed interface CredentialConfiguration : Serializable {
  */
 @kotlinx.serialization.Serializable
 data class Claim(
+    @SerialName("path") val path: ClaimPath,
     @SerialName("mandatory") val mandatory: Boolean? = false,
-    @SerialName("value_type") val valueType: String? = null,
     @SerialName("display") val display: List<Display> = emptyList(),
 ) : Serializable {
 
@@ -148,12 +175,6 @@ data class Claim(
 }
 typealias Namespace = String
 typealias ClaimName = String
-typealias MsoMdocClaims = Map<Namespace, Map<ClaimName, Claim>>
-
-fun MsoMdocClaims.toClaimSet(): MsoMdocClaimSet = MsoMdocClaimSet(
-    mapValues { (_, claims) -> claims.keys.toList() }
-        .flatMap { (nameSpace, claims) -> claims.map { claimName -> nameSpace to claimName } },
-)
 
 data class MsoMdocPolicy(val oneTimeUse: Boolean, val batchSize: Int?) : Serializable
 
@@ -170,8 +191,7 @@ data class MsoMdocCredential(
     override val proofTypesSupported: ProofTypesSupported = ProofTypesSupported.Empty,
     override val display: List<Display> = emptyList(),
     val docType: String,
-    val claims: MsoMdocClaims = emptyMap(),
-    val order: List<ClaimName> = emptyList(),
+    override val claims: List<Claim> = emptyList(),
 ) : CredentialConfiguration
 
 data class SdJwtVcCredential(
@@ -181,14 +201,12 @@ data class SdJwtVcCredential(
     override val proofTypesSupported: ProofTypesSupported = ProofTypesSupported.Empty,
     override val display: List<Display> = emptyList(),
     val type: String,
-    val claims: Map<ClaimName, Claim?>?,
-    val order: List<ClaimName> = emptyList(),
+    override val claims: List<Claim> = emptyList(),
 ) : CredentialConfiguration
 
 data class W3CJsonLdCredentialDefinition(
     val context: List<URL>,
     val type: List<String>,
-    val credentialSubject: Map<ClaimName, Claim?>?,
 )
 
 /**
@@ -200,10 +218,8 @@ data class W3CJsonLdDataIntegrityCredential(
     override val credentialSigningAlgorithmsSupported: List<String> = emptyList(),
     override val proofTypesSupported: ProofTypesSupported = ProofTypesSupported.Empty,
     override val display: List<Display> = emptyList(),
-    val context: List<String> = emptyList(),
-    val type: List<String> = emptyList(),
     val credentialDefinition: W3CJsonLdCredentialDefinition,
-    val order: List<ClaimName> = emptyList(),
+    override val claims: List<Claim> = emptyList(),
 ) : CredentialConfiguration
 
 /**
@@ -215,9 +231,8 @@ data class W3CJsonLdSignedJwtCredential(
     override val credentialSigningAlgorithmsSupported: List<String> = emptyList(),
     override val proofTypesSupported: ProofTypesSupported = ProofTypesSupported.Empty,
     override val display: List<Display> = emptyList(),
-    val context: List<String> = emptyList(),
     val credentialDefinition: W3CJsonLdCredentialDefinition,
-    val order: List<ClaimName> = emptyList(),
+    override val claims: List<Claim> = emptyList(),
 ) : CredentialConfiguration
 
 /**
@@ -230,11 +245,10 @@ data class W3CSignedJwtCredential(
     override val proofTypesSupported: ProofTypesSupported = ProofTypesSupported.Empty,
     override val display: List<Display> = emptyList(),
     val credentialDefinition: CredentialDefinition,
-    val order: List<ClaimName> = emptyList(),
+    override val claims: List<Claim> = emptyList(),
 ) : CredentialConfiguration {
 
     data class CredentialDefinition(
         val type: List<String>,
-        val credentialSubject: Map<ClaimName, Claim?>?,
     )
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialIssuerMetadataResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialIssuerMetadataResolver.kt
@@ -74,6 +74,7 @@ data class CredentialIssuerMetadata(
     val credentialIssuerIdentifier: CredentialIssuerId,
     val authorizationServers: List<HttpsUrl> = listOf(credentialIssuerIdentifier.value),
     val credentialEndpoint: CredentialIssuerEndpoint,
+    val nonceEndpoint: CredentialIssuerEndpoint? = null,
     val deferredCredentialEndpoint: CredentialIssuerEndpoint? = null,
     val notificationEndpoint: CredentialIssuerEndpoint? = null,
     val credentialResponseEncryption: CredentialResponseEncryption = CredentialResponseEncryption.NotSupported,
@@ -168,6 +169,11 @@ sealed class CredentialIssuerMetadataValidationError(cause: Throwable) : Credent
      * The URL of the Credential Endpoint is not valid.
      */
     class InvalidCredentialEndpoint(cause: Throwable) : CredentialIssuerMetadataValidationError(cause)
+
+    /**
+     * The URL of the Nonce Endpoint is not valid.
+     */
+    class InvalidNonceEndpoint(cause: Throwable) : CredentialIssuerMetadataValidationError(cause)
 
     /**
      * The URL of the Deferred Credential Endpoint is not valid.

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialIssuerMetadataResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialIssuerMetadataResolver.kt
@@ -19,7 +19,6 @@ import com.nimbusds.jose.EncryptionMethod
 import com.nimbusds.jose.JWEAlgorithm
 import eu.europa.ec.eudi.openid4vci.internal.DefaultCredentialIssuerMetadataResolver
 import java.io.Serializable
-import java.net.URI
 import java.net.URL
 
 sealed interface CredentialResponseEncryption : Serializable {
@@ -90,25 +89,9 @@ data class CredentialIssuerMetadata(
     inline fun <reified T : CredentialConfiguration> findByFormat(predicate: (T) -> Boolean): Map<CredentialConfigurationIdentifier, T> {
         return credentialConfigurationsSupported.mapNotNull { (k, v) -> if (v is T && predicate(v)) k to v else null }.toMap()
     }
-
-    /**
-     * The display properties of the Credential Issuer.
-     */
-    data class Display(
-        val name: String? = null,
-        val locale: String? = null,
-        val logo: Logo? = null,
-    ) : Serializable {
-        /**
-         * Logo information.
-         */
-        data class Logo(
-            val uri: URI? = null,
-            val alternativeText: String? = null,
-        ) : Serializable
-    }
 }
 
+@Suppress("not used")
 fun CredentialIssuerMetadata.findMsoMdoc(docType: String): MsoMdocCredential? =
     findByFormat<MsoMdocCredential> { it.docType == docType }.values.firstOrNull()
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
@@ -53,25 +53,9 @@ data class DeferredIssuerConfig(
  * @param transactionId the id returned by deferred endpoint
  */
 data class AuthorizedTransaction(
-    val authorizedRequest: AuthorizedRequest.NoProofRequired,
+    val authorizedRequest: AuthorizedRequest,
     val transactionId: TransactionId,
-) {
-    constructor(authorizedRequest: AuthorizedRequest, transactionId: TransactionId) : this(
-        authorizedRequest = when (authorizedRequest) {
-            is AuthorizedRequest.NoProofRequired -> authorizedRequest
-            is AuthorizedRequest.ProofRequired -> AuthorizedRequest.NoProofRequired(
-                accessToken = authorizedRequest.accessToken,
-                refreshToken = authorizedRequest.refreshToken,
-                credentialIdentifiers = authorizedRequest.credentialIdentifiers,
-                timestamp = authorizedRequest.timestamp,
-                authorizationServerDpopNonce = authorizedRequest.authorizationServerDpopNonce,
-                resourceServerDpopNonce = authorizedRequest.resourceServerDpopNonce,
-                grant = authorizedRequest.grant,
-            )
-        },
-        transactionId = transactionId,
-    )
-}
+)
 
 /**
  * Represents what a wallet needs to keep to be
@@ -128,7 +112,6 @@ interface DeferredIssuer : QueryForDeferredCredential {
             val newCtx = when (outcome) {
                 is DeferredCredentialQueryOutcome.IssuancePending, is DeferredCredentialQueryOutcome.Errored -> {
                     if (newAuthorized != ctx.authorizedTransaction.authorizedRequest) {
-                        check(newAuthorized is AuthorizedRequest.NoProofRequired)
                         val newAuthorizedTransaction = ctx.authorizedTransaction.copy(authorizedRequest = newAuthorized)
                         ctx.copy(authorizedTransaction = newAuthorizedTransaction)
                     } else {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
@@ -159,10 +159,17 @@ interface Issuer :
                         dPoPJwtFactory,
                         ktorHttpClientFactory,
                     )
+                val nonceEndpointClient = credentialOffer.credentialIssuerMetadata.nonceEndpoint?.let {
+                    NonceEndpointClient(
+                        credentialOffer.credentialIssuerMetadata.nonceEndpoint,
+                        ktorHttpClientFactory,
+                    )
+                }
                 RequestIssuanceImpl(
                     credentialOffer,
                     config,
                     credentialEndpointClient,
+                    nonceEndpointClient,
                     credentialOffer.credentialIssuerMetadata.batchCredentialIssuance,
                     responseEncryptionSpec,
                 )

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Types.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Types.kt
@@ -63,6 +63,7 @@ value class CredentialConfigurationIdentifier(val value: String) {
     init {
         require(value.isNotEmpty()) { "value cannot be empty" }
     }
+    override fun toString(): String = value
 }
 
 @JvmInline
@@ -71,6 +72,7 @@ value class CredentialIdentifier(val value: String) {
     init {
         require(value.isNotEmpty()) { "value cannot be empty" }
     }
+    override fun toString(): String = value
 }
 
 /**
@@ -146,6 +148,7 @@ value class RefreshToken(val refreshToken: String) : java.io.Serializable {
     init {
         require(refreshToken.isNotEmpty()) { "Refresh Token must not be empty" }
     }
+    override fun toString(): String = refreshToken
 }
 
 /**
@@ -156,21 +159,20 @@ value class AuthorizationCode(val code: String) {
     init {
         require(code.isNotEmpty()) { "Authorization code must not be empty" }
     }
+    override fun toString(): String = code
 }
 
 /**
- * A c_nonce related information as provided from issuance server.
+ * A c_nonce as provided from issuance server's nonce endpoint.
  *
  * @param value The c_nonce value
- * @param expiresInSeconds  Nonce time to live in seconds.
  */
-data class CNonce(
-    val value: String,
-    val expiresInSeconds: Long? = 5,
-) : java.io.Serializable {
+@JvmInline
+value class CNonce(val value: String) : java.io.Serializable {
     init {
         require(value.isNotEmpty()) { "Value cannot be empty" }
     }
+    override fun toString(): String = value
 }
 
 /**
@@ -183,6 +185,7 @@ value class TransactionId(val value: String) {
     init {
         require(value.isNotEmpty()) { "Value cannot be empty" }
     }
+    override fun toString(): String = value
 }
 
 /**
@@ -195,6 +198,7 @@ value class NotificationId(val value: String) {
     init {
         require(value.isNotEmpty()) { "Value cannot be empty" }
     }
+    override fun toString(): String = value
 }
 
 /**
@@ -265,6 +269,7 @@ value class Scope(val value: String) {
     init {
         require(value.isNotEmpty()) { "Scope value cannot be empty" }
     }
+    override fun toString(): String = value
 }
 
 typealias CIAuthorizationServerMetadata = ReadOnlyAuthorizationServerMetadata
@@ -307,4 +312,9 @@ value class CoseCurve(val value: Int) {
  * Nonce (single use) value provided either by the Authorization or Resource server.
  */
 @JvmInline
-value class Nonce(val value: String)
+value class Nonce(val value: String) {
+    init {
+        require(value.isNotEmpty()) { "Nonce value cannot be empty" }
+    }
+    override fun toString(): String = value
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Types.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Types.kt
@@ -31,7 +31,7 @@ import java.time.Duration
 import java.time.Instant
 
 const val FORMAT_MSO_MDOC = "mso_mdoc"
-const val FORMAT_SD_JWT_VC = "vc+sd-jwt"
+const val FORMAT_SD_JWT_VC = "dc+sd-jwt"
 const val FORMAT_W3C_JSONLD_DATA_INTEGRITY = "ldp_vc"
 const val FORMAT_W3C_JSONLD_SIGNED_JWT = "jwt_vc_json-ld"
 const val FORMAT_W3C_SIGNED_JWT = "jwt_vc_json"

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialIssuanceRequest.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialIssuanceRequest.kt
@@ -16,19 +16,12 @@
 package eu.europa.ec.eudi.openid4vci.internal
 
 import eu.europa.ec.eudi.openid4vci.*
-import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.InvalidIssuanceRequest
-
-internal sealed interface CredentialType {
-    data class MsoMdocDocType(val doctype: String, val claimSet: MsoMdocClaimSet?) : CredentialType
-
-    data class SdJwtVcType(val type: String, val claims: GenericClaimSet?) : CredentialType
-
-    data class W3CSignedJwtType(val type: List<String>, val claims: GenericClaimSet?) : CredentialType
-}
 
 internal sealed interface CredentialConfigurationReference {
-    data class ById(val credentialIdentifier: CredentialIdentifier) : CredentialConfigurationReference
-    data class ByFormat(val credential: CredentialType) : CredentialConfigurationReference
+    data class ByCredentialId(val credentialIdentifier: CredentialIdentifier) : CredentialConfigurationReference
+    data class ByCredentialConfigurationId(
+        val credentialConfigurationId: CredentialConfigurationIdentifier,
+    ) : CredentialConfigurationReference
 }
 
 /**
@@ -41,129 +34,26 @@ internal data class CredentialIssuanceRequest(
 ) {
 
     companion object {
-        internal fun byId(
+        internal fun byCredentialId(
             credentialIdentifier: CredentialIdentifier,
             proofs: List<Proof>,
             responseEncryptionSpec: IssuanceResponseEncryptionSpec?,
         ): CredentialIssuanceRequest =
             CredentialIssuanceRequest(
-                CredentialConfigurationReference.ById(credentialIdentifier),
+                CredentialConfigurationReference.ByCredentialId(credentialIdentifier),
                 proofs,
                 responseEncryptionSpec,
             )
 
-        internal fun formatBased(
-            credentialConfiguration: CredentialConfiguration,
-            claimSet: ClaimSet?,
+        internal fun byCredentialConfigurationId(
+            credentialConfigurationId: CredentialConfigurationIdentifier,
             proofs: List<Proof>,
             responseEncryptionSpec: IssuanceResponseEncryptionSpec?,
-        ): CredentialIssuanceRequest {
-            val cd = when (credentialConfiguration) {
-                is MsoMdocCredential -> msoMdoc(credentialConfiguration, claimSet.ensureClaimSet())
-                is SdJwtVcCredential -> sdJwtVc(credentialConfiguration, claimSet.ensureClaimSet())
-                is W3CSignedJwtCredential -> w3cSignedJwt(credentialConfiguration, claimSet.ensureClaimSet())
-                is W3CJsonLdSignedJwtCredential -> error("Format $FORMAT_W3C_JSONLD_SIGNED_JWT not supported")
-                is W3CJsonLdDataIntegrityCredential -> error("Format $FORMAT_W3C_JSONLD_DATA_INTEGRITY not supported")
-            }
-
-            return CredentialIssuanceRequest(
-                CredentialConfigurationReference.ByFormat(cd),
+        ): CredentialIssuanceRequest =
+            CredentialIssuanceRequest(
+                CredentialConfigurationReference.ByCredentialConfigurationId(credentialConfigurationId),
                 proofs,
                 responseEncryptionSpec,
             )
-        }
     }
-}
-
-private inline fun <reified C : ClaimSet> ClaimSet?.ensureClaimSet(): C? =
-    if (this != null) {
-        ensure(this is C) { InvalidIssuanceRequest("Invalid Claim Set provided for issuance") }
-        this
-    } else null
-
-private fun msoMdoc(
-    credentialConfiguration: MsoMdocCredential,
-    claimSet: MsoMdocClaimSet?,
-): CredentialType.MsoMdocDocType {
-    fun MsoMdocClaimSet.validate() {
-        if (isNotEmpty()) {
-            val supportedClaims = credentialConfiguration.claims
-            ensure(supportedClaims.isNotEmpty()) {
-                InvalidIssuanceRequest(
-                    "Issuer does not support claims for credential [MsoMdoc-${credentialConfiguration.docType}]",
-                )
-            }
-
-            // TODO [d15]: Remove when requests are adapted to d15
-//            forEach { (nameSpace, claimName) ->
-//                val supportedClaimNames = supportedClaims[nameSpace]
-//                ensureNotNull(supportedClaimNames) {
-//                    InvalidIssuanceRequest("Namespace $nameSpace not supported by issuer")
-//                }
-//                ensure(claimName in supportedClaimNames) {
-//                    InvalidIssuanceRequest("Requested claim name $claimName is not supported by issuer")
-//                }
-//            }
-        }
-    }
-
-    val validClaimSet = claimSet?.apply { validate() }
-    return CredentialType.MsoMdocDocType(
-        doctype = credentialConfiguration.docType,
-        claimSet = validClaimSet,
-    )
-}
-
-private fun sdJwtVc(
-    credentialConfiguration: SdJwtVcCredential,
-    claimSet: GenericClaimSet?,
-): CredentialType.SdJwtVcType {
-    fun GenericClaimSet.validate() {
-        if (claims.isNotEmpty()) {
-            val supportedClaims = credentialConfiguration.claims
-            ensure(supportedClaims.isNotEmpty()) {
-                InvalidIssuanceRequest(
-                    "Issuer does not support claims for credential " +
-                        "[$FORMAT_SD_JWT_VC-${credentialConfiguration.type}]",
-                )
-            }
-            // TODO [d15]: Remove when requests are adapted to d15
-//            ensure(supportedClaims.keys.containsAll(claims)) {
-//                InvalidIssuanceRequest("Claim names requested are not supported by issuer")
-//            }
-        }
-    }
-
-    val validClaimSet = claimSet?.apply { validate() }
-    return CredentialType.SdJwtVcType(
-        type = credentialConfiguration.type,
-        claims = validClaimSet,
-    )
-}
-
-private fun w3cSignedJwt(
-    credentialConfiguration: W3CSignedJwtCredential,
-    claimSet: GenericClaimSet?,
-): CredentialType.W3CSignedJwtType {
-    fun GenericClaimSet.validate() {
-        if (claims.isNotEmpty()) {
-            val supportedClaims = credentialConfiguration.claims
-            ensure(supportedClaims.isNotEmpty()) {
-                InvalidIssuanceRequest(
-                    "Issuer does not support claims for credential " +
-                        "[$FORMAT_W3C_SIGNED_JWT-${credentialConfiguration.credentialDefinition.type}]",
-                )
-            }
-            // TODO [d15]: Remove when requests are adapted to d15
-//            ensure(supportedClaims.keys.containsAll(claims)) {
-//                InvalidIssuanceRequest("Claim names requested are not supported by issuer")
-//            }
-        }
-    }
-
-    val validClaimSet = claimSet?.apply { validate() }
-    return CredentialType.W3CSignedJwtType(
-        type = credentialConfiguration.credentialDefinition.type,
-        claims = validClaimSet,
-    )
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialIssuanceRequest.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialIssuanceRequest.kt
@@ -94,15 +94,16 @@ private fun msoMdoc(
                 )
             }
 
-            forEach { (nameSpace, claimName) ->
-                val supportedClaimNames = supportedClaims[nameSpace]
-                ensureNotNull(supportedClaimNames) {
-                    InvalidIssuanceRequest("Namespace $nameSpace not supported by issuer")
-                }
-                ensure(claimName in supportedClaimNames) {
-                    InvalidIssuanceRequest("Requested claim name $claimName is not supported by issuer")
-                }
-            }
+            // TODO [d15]: Remove when requests are adapted to d15
+//            forEach { (nameSpace, claimName) ->
+//                val supportedClaimNames = supportedClaims[nameSpace]
+//                ensureNotNull(supportedClaimNames) {
+//                    InvalidIssuanceRequest("Namespace $nameSpace not supported by issuer")
+//                }
+//                ensure(claimName in supportedClaimNames) {
+//                    InvalidIssuanceRequest("Requested claim name $claimName is not supported by issuer")
+//                }
+//            }
         }
     }
 
@@ -120,15 +121,16 @@ private fun sdJwtVc(
     fun GenericClaimSet.validate() {
         if (claims.isNotEmpty()) {
             val supportedClaims = credentialConfiguration.claims
-            ensure(!supportedClaims.isNullOrEmpty()) {
+            ensure(supportedClaims.isNotEmpty()) {
                 InvalidIssuanceRequest(
                     "Issuer does not support claims for credential " +
                         "[$FORMAT_SD_JWT_VC-${credentialConfiguration.type}]",
                 )
             }
-            ensure(supportedClaims.keys.containsAll(claims)) {
-                InvalidIssuanceRequest("Claim names requested are not supported by issuer")
-            }
+            // TODO [d15]: Remove when requests are adapted to d15
+//            ensure(supportedClaims.keys.containsAll(claims)) {
+//                InvalidIssuanceRequest("Claim names requested are not supported by issuer")
+//            }
         }
     }
 
@@ -145,16 +147,17 @@ private fun w3cSignedJwt(
 ): CredentialType.W3CSignedJwtType {
     fun GenericClaimSet.validate() {
         if (claims.isNotEmpty()) {
-            val supportedClaims = credentialConfiguration.credentialDefinition.credentialSubject
-            ensure(!supportedClaims.isNullOrEmpty()) {
+            val supportedClaims = credentialConfiguration.claims
+            ensure(supportedClaims.isNotEmpty()) {
                 InvalidIssuanceRequest(
                     "Issuer does not support claims for credential " +
                         "[$FORMAT_W3C_SIGNED_JWT-${credentialConfiguration.credentialDefinition.type}]",
                 )
             }
-            ensure(supportedClaims.keys.containsAll(claims)) {
-                InvalidIssuanceRequest("Claim names requested are not supported by issuer")
-            }
+            // TODO [d15]: Remove when requests are adapted to d15
+//            ensure(supportedClaims.keys.containsAll(claims)) {
+//                InvalidIssuanceRequest("Claim names requested are not supported by issuer")
+//            }
         }
     }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProofBuilder.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProofBuilder.kt
@@ -32,7 +32,7 @@ internal abstract class ProofBuilder<POP_SIGNER : PopSigner, out PROOF : Proof>(
     val clock: Clock,
     val iss: ClientId?,
     val aud: CredentialIssuerId,
-    val nonce: CNonce,
+    val nonce: CNonce?,
     val popSigner: POP_SIGNER,
 ) {
 
@@ -44,7 +44,7 @@ internal abstract class ProofBuilder<POP_SIGNER : PopSigner, out PROOF : Proof>(
             clock: Clock,
             iss: ClientId?,
             aud: CredentialIssuerId,
-            nonce: CNonce,
+            nonce: CNonce?,
             popSigner: PopSigner,
         ): ProofBuilder<*, *> {
             return when (popSigner) {
@@ -60,7 +60,7 @@ internal abstract class ProofBuilder<POP_SIGNER : PopSigner, out PROOF : Proof>(
             client: Client,
             grant: Grant,
             aud: CredentialIssuerId,
-            nonce: CNonce,
+            nonce: CNonce?,
             popSigner: PopSigner,
         ): ProofBuilder<*, *> =
             invoke(proofTypesSupported, clock, iss(client, grant), aud, nonce, popSigner)
@@ -82,7 +82,7 @@ internal class JwtProofBuilder(
     clock: Clock,
     iss: ClientId?,
     aud: CredentialIssuerId,
-    nonce: CNonce,
+    nonce: CNonce?,
     popSigner: PopSigner.Jwt,
 ) : ProofBuilder<PopSigner.Jwt, Proof.Jwt>(clock, iss, aud, nonce, popSigner) {
 
@@ -109,7 +109,7 @@ internal class JwtProofBuilder(
         JWTClaimsSet.Builder().apply {
             iss?.let { issuer(it) }
             audience(aud.toString())
-            claim("nonce", nonce.value)
+            nonce?.let { claim("nonce", nonce.value) }
             issueTime(Date.from(clock.instant()))
         }.build()
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -138,9 +138,8 @@ internal class RequestIssuanceImpl(
 
         return when (requestPayload) {
             is IssuanceRequestPayload.ConfigurationBased -> {
-                CredentialIssuanceRequest.formatBased(
-                    credentialCfg,
-                    requestPayload.claimSet,
+                CredentialIssuanceRequest.byCredentialConfigurationId(
+                    requestPayload.credentialConfigurationIdentifier,
                     proofs,
                     responseEncryptionSpec,
                 )
@@ -148,7 +147,11 @@ internal class RequestIssuanceImpl(
 
             is IssuanceRequestPayload.IdentifierBased -> {
                 requestPayload.ensureAuthorized(authorizationDetails)
-                CredentialIssuanceRequest.byId(requestPayload.credentialIdentifier, proofs, responseEncryptionSpec)
+                CredentialIssuanceRequest.byCredentialId(
+                    requestPayload.credentialIdentifier,
+                    proofs,
+                    responseEncryptionSpec,
+                )
             }
         }
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/Serialization.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/Serialization.kt
@@ -90,28 +90,6 @@ internal object ProofSerializer : KSerializer<Proof> {
     }
 }
 
-internal object ClaimSetSerializer : KSerializer<MsoMdocClaimSet> {
-
-    val internal = serializer<Map<Namespace, Map<ClaimName, JsonObject>>>()
-    override val descriptor: SerialDescriptor = internal.descriptor
-
-    override fun deserialize(decoder: Decoder): MsoMdocClaimSet = internal.deserialize(decoder).asMsoMdocClaimSet()
-
-    override fun serialize(encoder: Encoder, value: MsoMdocClaimSet) {
-        internal.serialize(encoder, value.toJson())
-    }
-
-    private fun Map<Namespace, Map<ClaimName, JsonObject>>.asMsoMdocClaimSet() =
-        flatMap { (nameSpace, cs) -> cs.map { (claimName, _) -> nameSpace to claimName } }
-            .let(::MsoMdocClaimSet)
-
-    private fun MsoMdocClaimSet.toJson(): Map<Namespace, Map<ClaimName, JsonObject>> =
-        groupBy { (nameSpace, _) -> nameSpace }
-            .mapValues { (_, vs) -> vs.associate { (_, claimName) -> claimName to emptyJsonObject } }
-
-    private val emptyJsonObject = JsonObject(emptyMap())
-}
-
 @OptIn(ExperimentalSerializationApi::class)
 internal object GrantedAuthorizationDetailsSerializer :
     KSerializer<Map<CredentialConfigurationIdentifier, List<CredentialIdentifier>>> {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialIssuerMetadataJsonParser.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialIssuerMetadataJsonParser.kt
@@ -495,7 +495,7 @@ private data class ClaimTO(
 ) {
     fun toDomain(): Claim =
         Claim(
-            mandatory = mandatory ?: false,
+            mandatory = mandatory == true,
             path = path.asClaimPath(),
             display = display?.map { it.toClaimDisplay() } ?: emptyList(),
         )
@@ -511,12 +511,12 @@ private data class DisplayTO(
     @SerialName("logo") val logo: LogoObject? = null,
 ) {
     /**
-     * Converts a [DisplayTO] to a [CredentialIssuerMetadata.Display] instance.
+     * Converts a [DisplayTO] to a [Display] instance.
      */
-    fun toDomain(): CredentialIssuerMetadata.Display {
-        fun LogoObject.toLogo(): CredentialIssuerMetadata.Display.Logo =
-            CredentialIssuerMetadata.Display.Logo(uri?.let { URI.create(it) }, alternativeText)
-        return CredentialIssuerMetadata.Display(name, locale, logo?.toLogo())
+    fun toDomain(): Display {
+        fun LogoObject.toLogo(): Display.Logo =
+            Display.Logo(uri?.let { URI.create(it) }, alternativeText)
+        return Display(name ?: "", locale?.let { Locale.forLanguageTag(it) }, logo?.toLogo())
     }
 
     fun toClaimDisplay(): Claim.Display =

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/NonceEndpointClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/NonceEndpointClient.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.openid4vci.internal.http
+
+import eu.europa.ec.eudi.openid4vci.CNonce
+import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError
+import eu.europa.ec.eudi.openid4vci.CredentialIssuerEndpoint
+import eu.europa.ec.eudi.openid4vci.KtorHttpClientFactory
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CNonceResponse(
+    @SerialName("c_nonce") val cNonce: String,
+)
+
+internal class NonceEndpointClient(
+    private val nonceEndpoint: CredentialIssuerEndpoint,
+    private val ktorHttpClientFactory: KtorHttpClientFactory,
+) {
+
+    suspend fun getNonce(): Result<CNonce> =
+        runCatching {
+            requestNonce()
+        }
+
+    private suspend fun requestNonce(): CNonce =
+        ktorHttpClientFactory().use { client ->
+            val url = nonceEndpoint.value
+            val response = client.post(url)
+
+            if (response.status.isSuccess()) {
+                val cNonceResponse = response.body<CNonceResponse>()
+                CNonce(cNonceResponse.cNonce)
+            } else {
+                throw CredentialIssuanceError.CNonceRequestFailed("Nonce request failed")
+            }
+        }
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/TokenEndpointClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/TokenEndpointClient.kt
@@ -40,8 +40,6 @@ internal sealed interface TokenResponseTO {
      *
      * @param accessToken The access token.
      * @param expiresIn Token time to live.
-     * @param cNonce    c_nonce returned from token endpoint.
-     * @param cNonceExpiresIn c_nonce time to live.
      */
     @Serializable
     data class Success(
@@ -49,8 +47,6 @@ internal sealed interface TokenResponseTO {
         @SerialName("access_token") val accessToken: String,
         @SerialName("refresh_token") val refreshToken: String? = null,
         @SerialName("expires_in") val expiresIn: Long? = null,
-        @SerialName("c_nonce") val cNonce: String? = null,
-        @SerialName("c_nonce_expires_in") val cNonceExpiresIn: Long? = null,
         @Serializable(with = GrantedAuthorizationDetailsSerializer::class)
         @SerialName(
             "authorization_details",
@@ -79,7 +75,6 @@ internal sealed interface TokenResponseTO {
                         useDPoP = DPoP.equals(other = tokenType, ignoreCase = true),
                     ),
                     refreshToken = refreshToken?.let { RefreshToken(it) },
-                    cNonce = cNonce?.let { CNonce(it, cNonceExpiresIn) },
                     authorizationDetails = authorizationDetails ?: emptyMap(),
                     timestamp = clock.instant(),
                 )
@@ -130,8 +125,7 @@ internal class TokenEndpointClient(
      * @param pkceVerifier  The code verifier that was used when submitting the Pushed Authorization Request.
      * @param credConfigIdsAsAuthDetails The list of [CredentialConfigurationIdentifier]s that have been passed to authorization server
      * as authorization details, part of a Rich Authorization Request.
-     * @return The result of the request as a pair of the access token and the optional c_nonce information returned
-     *      from token endpoint.
+     * @return The result of the request as a pair of the access token and the optional DPoP nonce returned by the endpoint.
      */
     suspend fun requestAccessTokenAuthFlow(
         authorizationCode: AuthorizationCode,
@@ -160,8 +154,9 @@ internal class TokenEndpointClient(
      *
      * @param preAuthorizedCode The pre-authorization code.
      * @param txCode  Extra transaction code to be passed if specified as required in the credential offer.
-     * @return The result of the request as a pair of the access token and the optional c_nonce information returned
-     *      from token endpoint.
+     * @param credConfigIdsAsAuthDetails  A list of credential configuration ids to be sent as 'authorization_details'.
+     * @param dpopNonce  A DPoP nonce.
+     * @return The result of the request as a pair of the access token and the optional DPoP nonce returned by the endpoint.
      */
     suspend fun requestAccessTokenPreAuthFlow(
         preAuthorizedCode: PreAuthorizedCode,

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/DefaultCredentialIssuerMetadataResolverTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/DefaultCredentialIssuerMetadataResolverTest.kt
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 internal class DefaultCredentialIssuerMetadataResolverTest {
 
@@ -86,7 +87,7 @@ internal class DefaultCredentialIssuerMetadataResolverTest {
     }
 
     @Test
-    internal fun `fails with when response encryption algorithms are not asymmetric`() = runTest {
+    internal fun `fails when response encryption algorithms are not asymmetric`() = runTest {
         val credentialIssuerId = CredentialIssuerId("https://issuer.com").getOrThrow()
         val resolver = resolver(
             credentialIssuerMetaDataHandler(
@@ -112,9 +113,48 @@ internal class DefaultCredentialIssuerMetadataResolverTest {
         )
         val metaData = assertDoesNotThrow { resolver.resolve(credentialIssuerId).getOrThrow() }
         assertEquals(credentialIssuerMetadata(), metaData)
-        println("End")
+    }
+
+    @Test
+    internal fun `valid key attestation requirements`() = runTest {
+        val credentialIssuerId = SampleIssuer.Id
+
+        val resolver = resolver(
+            credentialIssuerMetaDataHandler(
+                credentialIssuerId,
+                "eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_valid.json",
+            ),
+        )
+        val credentialConfigs = assertDoesNotThrow {
+            resolver.resolve(credentialIssuerId).getOrThrow()
+        }.credentialConfigurationsSupported
+
+        assertTrue("Expected ") {
+            val proofs = credentialConfigs.jwtProofTypeSupported("UniversityDegree_JWT")
+            proofs != null && proofs.all { it.keyAttestationRequirement is KeyAttestationRequirement.NotRequired }
+        }
+
+        assertTrue("Expected ") {
+            val proofs = credentialConfigs.jwtProofTypeSupported("MobileDrivingLicense_msoMdoc")
+            proofs != null && proofs.all { it.keyAttestationRequirement is KeyAttestationRequirement.RequiredNoConstraints }
+        }
+
+        assertTrue("Expected ") {
+            val proofs = credentialConfigs.jwtProofTypeSupported("UniversityDegree_LDP_VC")
+            proofs != null && proofs.all { it.keyAttestationRequirement is KeyAttestationRequirement.Required }
+        }
+
+        assertTrue("Expected ") {
+            val proofs = credentialConfigs.jwtProofTypeSupported("UniversityDegree_JWT_VC_JSON-LD")
+            proofs != null && proofs.all { it.keyAttestationRequirement is KeyAttestationRequirement.Required }
+        }
     }
 }
+
+private fun Map<CredentialConfigurationIdentifier, CredentialConfiguration>.jwtProofTypeSupported(
+    credentialConfigId: String,
+): List<ProofTypeMeta.Jwt>? =
+    this[CredentialConfigurationIdentifier(credentialConfigId)]?.proofTypesSupported?.values?.filterIsInstance<ProofTypeMeta.Jwt>()
 
 private fun resolver(request: RequestMocker, expectSuccessOnly: Boolean = false) =
     CredentialIssuerMetadataResolver(

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceBatchRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceBatchRequestTest.kt
@@ -21,9 +21,7 @@ import io.ktor.http.*
 import io.ktor.http.content.*
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.add
-import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.*
 import kotlin.test.Test
 import kotlin.test.assertIs
 import kotlin.test.fail
@@ -44,11 +42,17 @@ class IssuanceBatchRequestTest {
                         encryptedResponseDataBuilder(it) {
                             Json.encodeToString(
                                 CredentialResponseSuccessTO(
-                                    credentials = buildJsonArray {
-                                        add("issued_credential_content_mso_mdoc0")
-                                        add("issued_credential_content_mso_mdoc1")
-                                        add("issued_credential_content_mso_mdoc2")
-                                    },
+                                    credentials = listOf(
+                                        buildJsonObject {
+                                            put("credential", JsonPrimitive("issued_credential_content_mso_mdoc0"))
+                                        },
+                                        buildJsonObject {
+                                            put("credential", JsonPrimitive("issued_credential_content_mso_mdoc1"))
+                                        },
+                                        buildJsonObject {
+                                            put("credential", JsonPrimitive("issued_credential_content_mso_mdoc2"))
+                                        },
+                                    ),
                                     cNonce = "wlbQc6pCJp",
                                     cNonceExpiresInSeconds = 86400,
                                 ),
@@ -99,12 +103,4 @@ class IssuanceBatchRequestTest {
 fun reqs() =
     IssuanceRequestPayload.ConfigurationBased(
         CredentialConfigurationIdentifier(PID_MsoMdoc),
-        MsoMdocClaimSet(
-            claims = listOf(
-                "org.iso.18013.5.1" to "given_name",
-                "org.iso.18013.5.1" to "family_name",
-                "org.iso.18013.5.1" to "given_name",
-                "org.iso.18013.5.1" to "birth_date",
-            ),
-        ),
     ) to (0..2).map { CryptoGenerator.rsaProofSigner() }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceDeferredRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceDeferredRequestTest.kt
@@ -49,7 +49,6 @@ class IssuanceDeferredRequestTest {
 
             val requestPayload = IssuanceRequestPayload.ConfigurationBased(
                 CredentialConfigurationIdentifier(PID_SdJwtVC),
-                null,
             )
             val popSigner = CryptoGenerator.rsaProofSigner()
             val (newAuthorizedRequest, outcome) =
@@ -92,7 +91,6 @@ class IssuanceDeferredRequestTest {
             assertIs<AuthorizedRequest.NoProofRequired>(authorizedRequest)
             val requestPayload = IssuanceRequestPayload.ConfigurationBased(
                 CredentialConfigurationIdentifier(PID_SdJwtVC),
-                null,
             )
             val popSigner = CryptoGenerator.rsaProofSigner()
             val (newAuthorizedRequest, outcome) =
@@ -154,7 +152,6 @@ class IssuanceDeferredRequestTest {
             assertIs<AuthorizedRequest.NoProofRequired>(authorizedRequest)
             val requestPayload = IssuanceRequestPayload.ConfigurationBased(
                 CredentialConfigurationIdentifier(PID_SdJwtVC),
-                null,
             )
             val popSigner = CryptoGenerator.rsaProofSigner()
             val (newAuthorized, outcome) =

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceDeferredRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceDeferredRequestTest.kt
@@ -27,10 +27,11 @@ class IssuanceDeferredRequestTest {
     @Test
     fun `when issuer responds with invalid_transaction_id, response should be of type Errored`() = runTest {
         val mockedKtorHttpClientFactory = mockedKtorHttpClientFactory(
-            oidcWellKnownMocker(),
+            oiciWellKnownMocker(),
             authServerWellKnownMocker(),
             parPostMocker(),
             tokenPostMocker(),
+            nonceEndpointMocker(),
             singleIssuanceRequestMocker(
                 responseBuilder = { respondToIssuanceRequestWithDeferredResponseDataBuilder(it) },
             ),
@@ -45,8 +46,6 @@ class IssuanceDeferredRequestTest {
             )
 
         with(issuer) {
-            assertIs<AuthorizedRequest.NoProofRequired>(authorizedRequest)
-
             val requestPayload = IssuanceRequestPayload.ConfigurationBased(
                 CredentialConfigurationIdentifier(PID_SdJwtVC),
             )
@@ -69,10 +68,11 @@ class IssuanceDeferredRequestTest {
     @Test
     fun `when issuer responds with issuance_pending, response should be of type IssuancePending`() = runTest {
         val mockedKtorHttpClientFactory = mockedKtorHttpClientFactory(
-            oidcWellKnownMocker(),
+            oiciWellKnownMocker(),
             authServerWellKnownMocker(),
             parPostMocker(),
             tokenPostMocker(),
+            nonceEndpointMocker(),
             singleIssuanceRequestMocker(
                 responseBuilder = { respondToIssuanceRequestWithDeferredResponseDataBuilder(it) },
             ),
@@ -88,7 +88,6 @@ class IssuanceDeferredRequestTest {
             )
 
         with(issuer) {
-            assertIs<AuthorizedRequest.NoProofRequired>(authorizedRequest)
             val requestPayload = IssuanceRequestPayload.ConfigurationBased(
                 CredentialConfigurationIdentifier(PID_SdJwtVC),
             )
@@ -111,10 +110,11 @@ class IssuanceDeferredRequestTest {
     @Test
     fun `when deferred request is valid, credential must be issued`() = runTest {
         val mockedKtorHttpClientFactory = mockedKtorHttpClientFactory(
-            oidcWellKnownMocker(),
+            oiciWellKnownMocker(),
             authServerWellKnownMocker(),
             parPostMocker(),
             tokenPostMocker(),
+            nonceEndpointMocker(),
             singleIssuanceRequestMocker(
                 responseBuilder = { respondToIssuanceRequestWithDeferredResponseDataBuilder(it) },
             ),
@@ -149,7 +149,6 @@ class IssuanceDeferredRequestTest {
             )
 
         with(issuer) {
-            assertIs<AuthorizedRequest.NoProofRequired>(authorizedRequest)
             val requestPayload = IssuanceRequestPayload.ConfigurationBased(
                 CredentialConfigurationIdentifier(PID_SdJwtVC),
             )

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceIssuerMetadataVersionTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceIssuerMetadataVersionTest.kt
@@ -37,7 +37,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
-class IssuanceEncryptedResponsesTest {
+class IssuanceIssuerMetadataVersionTest {
 
     @Test
     fun `when encryption algorithm is not supported by issuer then throw ResponseEncryptionAlgorithmNotSupportedByIssuer`() =
@@ -46,7 +46,7 @@ class IssuanceEncryptedResponsesTest {
                 authServerWellKnownMocker(),
                 parPostMocker(),
                 tokenPostMocker(),
-                oidcWellKnownMocker(EncryptedResponses.REQUIRED),
+                oiciWellKnownMocker(IssuerMetadataVersion.ENCRYPTION_REQUIRED),
             )
             val issuanceResponseEncryptionSpec = IssuanceResponseEncryptionSpec(
                 jwk = randomRSAEncryptionKey(2048),
@@ -72,7 +72,7 @@ class IssuanceEncryptedResponsesTest {
                 authServerWellKnownMocker(),
                 parPostMocker(),
                 tokenPostMocker(),
-                oidcWellKnownMocker(EncryptedResponses.REQUIRED),
+                oiciWellKnownMocker(IssuerMetadataVersion.ENCRYPTION_REQUIRED),
             )
             val issuanceResponseEncryptionSpec = IssuanceResponseEncryptionSpec(
                 jwk = randomRSAEncryptionKey(2048),
@@ -98,7 +98,7 @@ class IssuanceEncryptedResponsesTest {
                 authServerWellKnownMocker(),
                 parPostMocker(),
                 tokenPostMocker(),
-                oidcWellKnownMocker(EncryptedResponses.NOT_SUPPORTED),
+                oiciWellKnownMocker(IssuerMetadataVersion.ENCRYPTION_NOT_SUPPORTED),
             )
             val issuanceResponseEncryptionSpec = IssuanceResponseEncryptionSpec(
                 jwk = randomRSAEncryptionKey(2048),
@@ -127,7 +127,7 @@ class IssuanceEncryptedResponsesTest {
                 authServerWellKnownMocker(),
                 parPostMocker(),
                 tokenPostMocker(),
-                oidcWellKnownMocker(EncryptedResponses.SUPPORTED_NOT_REQUIRED),
+                oiciWellKnownMocker(IssuerMetadataVersion.ENCRYPTION_SUPPORTED_NOT_REQUIRED),
             )
 
             assertFailsWith<WalletRequiresCredentialResponseEncryptionButNoCryptoMaterialCanBeGenerated>(
@@ -151,7 +151,8 @@ class IssuanceEncryptedResponsesTest {
                 authServerWellKnownMocker(),
                 parPostMocker(),
                 tokenPostMocker(),
-                oidcWellKnownMocker(EncryptedResponses.NOT_SUPPORTED),
+                nonceEndpointMocker(),
+                oiciWellKnownMocker(IssuerMetadataVersion.ENCRYPTION_NOT_SUPPORTED),
                 singleIssuanceRequestMocker(
                     requestValidator = {
                         val textContent = it.body as TextContent
@@ -174,10 +175,10 @@ class IssuanceEncryptedResponsesTest {
             )
 
             with(issuer) {
-                val noProofRequired = authorizedRequest as AuthorizedRequest.NoProofRequired
                 val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-                noProofRequired.request(requestPayload).getOrThrow()
+                val popSigners = listOf(CryptoGenerator.rsaProofSigner())
+                authorizedRequest.request(requestPayload, popSigners).getOrThrow()
             }
         }
 
@@ -188,8 +189,23 @@ class IssuanceEncryptedResponsesTest {
                 authServerWellKnownMocker(),
                 parPostMocker(),
                 tokenPostMocker(),
-                oidcWellKnownMocker(EncryptedResponses.SUPPORTED_NOT_REQUIRED),
+                nonceEndpointMocker(),
+                oiciWellKnownMocker(IssuerMetadataVersion.ENCRYPTION_SUPPORTED_NOT_REQUIRED),
                 singleIssuanceRequestMocker(
+                    responseBuilder = {
+                        encryptedResponseDataBuilder(it) {
+                            Json.encodeToString(
+                                CredentialResponseSuccessTO(
+                                    credentials = listOf(
+                                        buildJsonObject {
+                                            put("credential", "issued_credential")
+                                        },
+                                    ),
+                                    notificationId = "fgh126lbHjtspVbn",
+                                ),
+                            )
+                        }
+                    },
                     requestValidator = {
                         val textContent = it.body as TextContent
                         val issuanceRequestTO = Json.decodeFromString<CredentialRequestTO>(textContent.text)
@@ -211,10 +227,10 @@ class IssuanceEncryptedResponsesTest {
             )
 
             with(issuer) {
-                val noProofRequired = authorizedRequest as AuthorizedRequest.NoProofRequired
                 val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-                noProofRequired.request(requestPayload).getOrThrow()
+                val popSigners = listOf(CryptoGenerator.rsaProofSigner())
+                authorizedRequest.request(requestPayload, popSigners).getOrThrow()
             }
         }
 
@@ -225,7 +241,8 @@ class IssuanceEncryptedResponsesTest {
                 authServerWellKnownMocker(),
                 parPostMocker(),
                 tokenPostMocker(),
-                oidcWellKnownMocker(EncryptedResponses.SUPPORTED_NOT_REQUIRED),
+                nonceEndpointMocker(),
+                oiciWellKnownMocker(IssuerMetadataVersion.ENCRYPTION_SUPPORTED_NOT_REQUIRED),
                 singleIssuanceRequestMocker(
                     requestValidator = {
                         val textContent = it.body as TextContent
@@ -243,10 +260,10 @@ class IssuanceEncryptedResponsesTest {
             )
 
             with(issuer) {
-                val noProofRequired = authorizedRequest as AuthorizedRequest.NoProofRequired
                 val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-                noProofRequired.request(requestPayload).getOrThrow()
+                val popSigners = listOf(CryptoGenerator.rsaProofSigner())
+                authorizedRequest.request(requestPayload, popSigners).getOrThrow()
             }
         }
 
@@ -257,7 +274,9 @@ class IssuanceEncryptedResponsesTest {
                 authServerWellKnownMocker(),
                 parPostMocker(),
                 tokenPostMocker(),
-                oidcWellKnownMocker(EncryptedResponses.REQUIRED),
+                nonceEndpointMocker(),
+                nonceEndpointMocker(),
+                oiciWellKnownMocker(IssuerMetadataVersion.ENCRYPTION_REQUIRED),
                 singleIssuanceRequestMocker(
                     responseBuilder = {
                         encryptedResponseDataBuilder(it) {
@@ -269,8 +288,6 @@ class IssuanceEncryptedResponsesTest {
                                         },
                                     ),
                                     notificationId = "fgh126lbHjtspVbn",
-                                    cNonce = "wlbQc6pCJp",
-                                    cNonceExpiresInSeconds = 86400,
                                 ),
                             )
                         }
@@ -316,10 +333,10 @@ class IssuanceEncryptedResponsesTest {
             )
 
             with(issuer) {
-                assertIs<AuthorizedRequest.NoProofRequired>(authorizedRequest)
                 val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-                val (_, outcome) = authorizedRequest.request(requestPayload).getOrThrow()
+                val popSigners = listOf(CryptoGenerator.rsaProofSigner())
+                val (_, outcome) = authorizedRequest.request(requestPayload, popSigners).getOrThrow()
                 assertIs<SubmissionOutcome.Success>(outcome)
             }
         }
@@ -331,7 +348,8 @@ class IssuanceEncryptedResponsesTest {
                 authServerWellKnownMocker(),
                 parPostMocker(),
                 tokenPostMocker(),
-                oidcWellKnownMocker(EncryptedResponses.REQUIRED),
+                nonceEndpointMocker(),
+                oiciWellKnownMocker(IssuerMetadataVersion.ENCRYPTION_REQUIRED),
                 singleIssuanceRequestMocker(
                     responseBuilder = {
                         encryptedResponseDataBuilder(it) {
@@ -342,8 +360,6 @@ class IssuanceEncryptedResponsesTest {
                                             put("credential", "${PID_MsoMdoc}_issued_credential")
                                         },
                                     ),
-                                    cNonce = "wlbQc6pCJp",
-                                    cNonceExpiresInSeconds = 86400,
                                 ),
                             )
                         }
@@ -380,7 +396,8 @@ class IssuanceEncryptedResponsesTest {
 
             with(issuer) {
                 val payload = IssuanceRequestPayload.ConfigurationBased(CredentialConfigurationIdentifier(PID_MsoMdoc))
-                authorizedRequest.request(payload).getOrThrow()
+                val popSigners = listOf(CryptoGenerator.rsaProofSigner())
+                authorizedRequest.request(payload, popSigners).getOrThrow()
             }
         }
 
@@ -391,7 +408,8 @@ class IssuanceEncryptedResponsesTest {
                 authServerWellKnownMocker(),
                 parPostMocker(),
                 tokenPostMocker(),
-                oidcWellKnownMocker(EncryptedResponses.REQUIRED),
+                nonceEndpointMocker(),
+                oiciWellKnownMocker(IssuerMetadataVersion.ENCRYPTION_REQUIRED),
                 singleIssuanceRequestMocker(
                     responseBuilder = {
                         encryptedResponseDataBuilder(it) {
@@ -402,8 +420,6 @@ class IssuanceEncryptedResponsesTest {
                                             put("credential", "${PID_MsoMdoc}_issued_credential")
                                         },
                                     ),
-                                    cNonce = "wlbQc6pCJp",
-                                    cNonceExpiresInSeconds = 86400,
                                 ),
                             )
                         }
@@ -427,7 +443,7 @@ class IssuanceEncryptedResponsesTest {
             val (_, outcome) = with(issuer) {
                 authorizedRequest.request(
                     IssuanceRequestPayload.ConfigurationBased(CredentialConfigurationIdentifier(PID_MsoMdoc)),
-                    emptyList(),
+                    listOf(CryptoGenerator.rsaProofSigner()),
                 ).getOrThrow()
             }
             assertIs<SubmissionOutcome.Success>(outcome)
@@ -437,10 +453,11 @@ class IssuanceEncryptedResponsesTest {
     fun `when issuance request mandates encrypted responses and deferred response is not encrypted, throw InvalidResponseContentType`() =
         runTest {
             val mockedKtorHttpClientFactory = mockedKtorHttpClientFactory(
-                oidcWellKnownMocker(EncryptedResponses.REQUIRED),
+                oiciWellKnownMocker(IssuerMetadataVersion.ENCRYPTION_REQUIRED),
                 authServerWellKnownMocker(),
                 parPostMocker(),
                 tokenPostMocker(),
+                nonceEndpointMocker(),
                 singleIssuanceRequestMocker(
                     responseBuilder = {
                         encryptedResponseDataBuilder(it) {
@@ -466,12 +483,12 @@ class IssuanceEncryptedResponsesTest {
             )
 
             with(issuer) {
-                assertIs<AuthorizedRequest.NoProofRequired>(authorizedRequest)
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(
                     CredentialConfigurationIdentifier(PID_SdJwtVC),
                 )
+                val popSigners = listOf(CryptoGenerator.rsaProofSigner())
                 val (newAuthorizedRequest, outcome) =
-                    authorizedRequest.request(requestPayload).getOrThrow()
+                    authorizedRequest.request(requestPayload, popSigners).getOrThrow()
                 assertIs<SubmissionOutcome.Deferred>(outcome)
 
                 assertFailsWith<CredentialIssuanceError.InvalidResponseContentType>(
@@ -490,10 +507,11 @@ class IssuanceEncryptedResponsesTest {
             encryptionMethod = EncryptionMethod.A128CBC_HS256,
         )
         val mockedKtorHttpClientFactory = mockedKtorHttpClientFactory(
-            oidcWellKnownMocker(EncryptedResponses.REQUIRED),
+            oiciWellKnownMocker(IssuerMetadataVersion.ENCRYPTION_REQUIRED),
             authServerWellKnownMocker(),
             parPostMocker(),
             tokenPostMocker(),
+            nonceEndpointMocker(),
             singleIssuanceRequestMocker(
                 responseBuilder = {
                     encryptedResponseDataBuilder(it) {
@@ -505,9 +523,7 @@ class IssuanceEncryptedResponsesTest {
                 responseBuilder = {
                     val responseJson = """
                             {                     
-                              "credentials": [{ "credential": "credential_content" }],
-                              "c_nonce": "ERE%@^TGWYEYWEY",
-                              "c_nonce_expires_in": 34
+                              "credentials": [{ "credential": "credential_content" }]
                             }
                     """.trimIndent()
                     respond(
@@ -533,12 +549,12 @@ class IssuanceEncryptedResponsesTest {
         )
 
         with(issuer) {
-            assertIs<AuthorizedRequest.NoProofRequired>(authorizedRequest)
             val requestPayload = IssuanceRequestPayload.ConfigurationBased(
                 CredentialConfigurationIdentifier(PID_SdJwtVC),
             )
+            val popSigners = listOf(CryptoGenerator.rsaProofSigner())
             val (newAuthorizedRequest, outcome) =
-                authorizedRequest.request(requestPayload).getOrThrow()
+                authorizedRequest.request(requestPayload, popSigners).getOrThrow()
             assertIs<SubmissionOutcome.Deferred>(outcome)
 
             val (_, deferredOutcome) =

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceNotificationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceNotificationTest.kt
@@ -72,7 +72,7 @@ class IssuanceNotificationTest {
             when (authorizedRequest) {
                 is AuthorizedRequest.NoProofRequired -> {
                     val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
-                    val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, null)
+                    val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
                     val popSigner = CryptoGenerator.rsaProofSigner()
                     val (newAuthorizedRequest, outcome) =
                         authorizedRequest.request(requestPayload, listOf(popSigner)).getOrThrow()

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceNotificationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceNotificationTest.kt
@@ -30,13 +30,12 @@ class IssuanceNotificationTest {
     fun `when issuance response contains notification_id, it is present in and can be used for notifications`() = runTest {
         val credential = "issued_credential_content_sd_jwt_vc"
         val mockedKtorHttpClientFactory = mockedKtorHttpClientFactory(
-            oidcWellKnownMocker(),
+            oiciWellKnownMocker(),
             authServerWellKnownMocker(),
             parPostMocker(),
             tokenPostMocker(),
-            singleIssuanceRequestMocker(
-                credential = credential,
-            ),
+            nonceEndpointMocker(),
+            singleIssuanceRequestMocker(credential),
             RequestMocker(
                 requestMatcher = endsWith("/notification", HttpMethod.Post),
                 responseBuilder = {
@@ -69,36 +68,31 @@ class IssuanceNotificationTest {
             ktorHttpClientFactory = mockedKtorHttpClientFactory,
         )
         with(issuer) {
-            when (authorizedRequest) {
-                is AuthorizedRequest.NoProofRequired -> {
-                    val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
-                    val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-                    val popSigner = CryptoGenerator.rsaProofSigner()
-                    val (newAuthorizedRequest, outcome) =
-                        authorizedRequest.request(requestPayload, listOf(popSigner)).getOrThrow()
-                    assertIs<SubmissionOutcome.Success>(outcome)
+            val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
+            val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
+            val popSigner = CryptoGenerator.rsaProofSigner()
+            val (newAuthorizedRequest, outcome) =
+                authorizedRequest.request(requestPayload, listOf(popSigner)).getOrThrow()
+            assertIs<SubmissionOutcome.Success>(outcome)
 
-                    val issuedCredential = outcome.credentials.firstOrNull()
-                    assertIs<IssuedCredential>(issuedCredential)
-                    val notId = outcome.notificationId
-                    assertNotNull(notId)
+            val issuedCredential = outcome.credentials.firstOrNull()
+            assertIs<IssuedCredential>(issuedCredential)
+            val notId = outcome.notificationId
+            assertNotNull(notId)
 
-                    newAuthorizedRequest.notify(
-                        CredentialIssuanceEvent.Accepted(
-                            id = notId,
-                            description = "Credential received and validated",
-                        ),
-                    )
-                }
-                else -> fail("State should be Authorized.NoProofRequired when no c_nonce returned from token endpoint")
-            }
+            newAuthorizedRequest.notify(
+                CredentialIssuanceEvent.Accepted(
+                    id = notId,
+                    description = "Credential received and validated",
+                ),
+            )
         }
     }
 
     @Test
     fun `when notification request failed, a Result failure is returned`() = runTest {
         val mockedKtorHttpClientFactory = mockedKtorHttpClientFactory(
-            oidcWellKnownMocker(),
+            oiciWellKnownMocker(),
             authServerWellKnownMocker(),
             parPostMocker(),
             tokenPostMocker(),

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
@@ -162,6 +162,7 @@ class IssuanceSingleRequestTest {
             }
         }
 
+    @Ignore("To be removed when credential request is aligned with draft 15")
     @Test
     fun `when issuance request contains unsupported claims exception CredentialIssuanceException is thrown`() =
         runTest {

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/MockData.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/MockData.kt
@@ -80,7 +80,14 @@ internal fun universityDegreeJwt() = W3CSignedJwtCredential(
     "UniversityDegree_JWT",
     listOf(CryptographicBindingMethod.DID("did:example")),
     listOf("ES256K"),
-    ProofTypesSupported(setOf(ProofTypeMeta.Jwt(listOf(JWSAlgorithm.RS256, JWSAlgorithm.ES256)))),
+    ProofTypesSupported(
+        setOf(
+            ProofTypeMeta.Jwt(
+                listOf(JWSAlgorithm.RS256, JWSAlgorithm.ES256),
+                KeyAttestationRequirement.NotRequired,
+            ),
+        ),
+    ),
     listOf(
         Display(
             "University Credential",
@@ -91,37 +98,34 @@ internal fun universityDegreeJwt() = W3CSignedJwtCredential(
             ),
             null,
             "#12107c",
+            URI.create("https://examplestate.com/public/background.png"),
             "#FFFFFF",
         ),
     ),
     W3CSignedJwtCredential.CredentialDefinition(
         listOf("VerifiableCredential", "UniversityDegreeCredential"),
-        mapOf(
-            "given_name" to Claim(
-                display = listOf(
-                    Claim.Display(
-                        "Given Name", Locale.forLanguageTag("en-US"),
-                    ),
-                ),
+    ),
+    listOf(
+        Claim(
+            path = ClaimPath.claim("given_name"),
+            display = listOf(
+                Claim.Display("Given Name", Locale.forLanguageTag("en-US")),
             ),
-            "family_name" to Claim(
-                display = listOf(
-                    Claim.Display(
-                        "Surname", Locale.forLanguageTag("en-US"),
-                    ),
-                ),
+        ),
+        Claim(
+            path = ClaimPath.claim("family_name"),
+            display = listOf(
+                Claim.Display("Surname", Locale.forLanguageTag("en-US")),
             ),
-            "degree" to Claim(),
-            "gpa" to Claim(
-                display = listOf(
-                    Claim.Display(
-                        "name", Locale.forLanguageTag("GPA"),
-                    ),
-                ),
+        ),
+        Claim(path = ClaimPath.claim("degree")),
+        Claim(
+            path = ClaimPath.claim("gpa"),
+            display = listOf(
+                Claim.Display("name", Locale.forLanguageTag("GPA")),
             ),
         ),
     ),
-    emptyList(),
 )
 
 /**
@@ -131,7 +135,17 @@ internal fun universityDegreeLdpVc() = W3CJsonLdDataIntegrityCredential(
     "UniversityDegree_LDP_VC",
     listOf(CryptographicBindingMethod.DID("did:example")),
     listOf("Ed25519Signature2018"),
-    ProofTypesSupported(setOf(ProofTypeMeta.Jwt(listOf(JWSAlgorithm.RS256, JWSAlgorithm.ES256)))),
+    ProofTypesSupported(
+        setOf(
+            ProofTypeMeta.Jwt(
+                listOf(JWSAlgorithm.RS256, JWSAlgorithm.ES256),
+                KeyAttestationRequirement.Required(
+                    listOf("iso_18045_high", "iso_18045_enhanced-basic"),
+                    emptyList(),
+                ),
+            ),
+        ),
+    ),
     listOf(
         Display(
             "University Credential",
@@ -142,16 +156,9 @@ internal fun universityDegreeLdpVc() = W3CJsonLdDataIntegrityCredential(
             ),
             null,
             "#12107c",
+            null,
             "#FFFFFF",
         ),
-    ),
-    listOf(
-        "https://www.w3.org/2018/credentials/v1",
-        "https://www.w3.org/2018/credentials/examples/v1",
-    ),
-    listOf(
-        "VerifiableCredential_LDP_VC",
-        "UniversityDegreeCredential_LDP_VC",
     ),
     W3CJsonLdCredentialDefinition(
         listOf(
@@ -159,39 +166,45 @@ internal fun universityDegreeLdpVc() = W3CJsonLdDataIntegrityCredential(
             URI("https://www.w3.org/2018/credentials/examples/v1").toURL(),
         ),
         listOf("VerifiableCredential_LDP_VC", "UniversityDegreeCredential_LDP_VC"),
-        mapOf(
-            "given_name" to Claim(
-                display = listOf(
-                    Claim.Display(
-                        "Given Name", Locale.forLanguageTag("en-US"),
-                    ),
-                ),
+    ),
+    listOf(
+        Claim(
+            path = ClaimPath.claim("given_name"),
+            display = listOf(
+                Claim.Display("Given Name", Locale.forLanguageTag("en-US")),
             ),
-            "family_name" to Claim(
-                display = listOf(
-                    Claim.Display(
-                        "Surname", Locale.forLanguageTag("en-US"),
-                    ),
-                ),
+        ),
+        Claim(
+            path = ClaimPath.claim("family_name"),
+            display = listOf(
+                Claim.Display("Surname", Locale.forLanguageTag("en-US")),
             ),
-            "degree" to Claim(),
-            "gpa" to Claim(
-                display = listOf(
-                    Claim.Display(
-                        "name", Locale.forLanguageTag("GPA"),
-                    ),
-                ),
+        ),
+        Claim(path = ClaimPath.claim("degree")),
+        Claim(
+            path = ClaimPath.claim("gpa"),
+            display = listOf(
+                Claim.Display("name", Locale.forLanguageTag("GPA")),
             ),
         ),
     ),
-    emptyList(),
 )
 
 internal fun universityDegreeJwtVcJsonLD() = W3CJsonLdSignedJwtCredential(
     "UniversityDegree_JWT_VC_JSON-LD",
     listOf(CryptographicBindingMethod.DID("did:example")),
     listOf("Ed25519Signature2018"),
-    ProofTypesSupported(setOf(ProofTypeMeta.Jwt(listOf(JWSAlgorithm.RS256, JWSAlgorithm.ES256)))),
+    ProofTypesSupported(
+        setOf(
+            ProofTypeMeta.Jwt(
+                listOf(JWSAlgorithm.RS256, JWSAlgorithm.ES256),
+                KeyAttestationRequirement.Required(
+                    listOf("iso_18045_high", "iso_18045_enhanced-basic"),
+                    listOf("iso_18045_high", "iso_18045_enhanced-basic"),
+                ),
+            ),
+        ),
+    ),
     listOf(
         Display(
             "University Credential",
@@ -202,12 +215,9 @@ internal fun universityDegreeJwtVcJsonLD() = W3CJsonLdSignedJwtCredential(
             ),
             null,
             "#12107c",
+            null,
             "#FFFFFF",
         ),
-    ),
-    listOf(
-        "https://www.w3.org/2018/credentials/v1",
-        "https://www.w3.org/2018/credentials/examples/v1",
     ),
     W3CJsonLdCredentialDefinition(
         listOf(
@@ -215,32 +225,28 @@ internal fun universityDegreeJwtVcJsonLD() = W3CJsonLdSignedJwtCredential(
             URI("https://www.w3.org/2018/credentials/examples/v1").toURL(),
         ),
         listOf("VerifiableCredential_JWT_VC_JSON-LD", "UniversityDegreeCredential_JWT_VC_JSON-LD"),
-        mapOf(
-            "given_name" to Claim(
-                display = listOf(
-                    Claim.Display(
-                        "Given Name", Locale.forLanguageTag("en-US"),
-                    ),
-                ),
+    ),
+    listOf(
+        Claim(
+            path = ClaimPath.claim("given_name"),
+            display = listOf(
+                Claim.Display("Given Name", Locale.forLanguageTag("en-US")),
             ),
-            "family_name" to Claim(
-                display = listOf(
-                    Claim.Display(
-                        "Surname", Locale.forLanguageTag("en-US"),
-                    ),
-                ),
+        ),
+        Claim(
+            path = ClaimPath.claim("family_name"),
+            display = listOf(
+                Claim.Display("Surname", Locale.forLanguageTag("en-US")),
             ),
-            "degree" to Claim(),
-            "gpa" to Claim(
-                display = listOf(
-                    Claim.Display(
-                        "name", Locale.forLanguageTag("GPA"),
-                    ),
-                ),
+        ),
+        Claim(path = ClaimPath.claim("degree")),
+        Claim(
+            path = ClaimPath.claim("gpa"),
+            display = listOf(
+                Claim.Display("name", Locale.forLanguageTag("GPA")),
             ),
         ),
     ),
-    emptyList(),
 )
 
 /**
@@ -253,7 +259,14 @@ internal fun mobileDrivingLicense() = MsoMdocCredential(
     emptyList(),
     emptyList(),
     null,
-    ProofTypesSupported(setOf(ProofTypeMeta.Jwt(listOf(JWSAlgorithm.RS256, JWSAlgorithm.ES256)))),
+    ProofTypesSupported(
+        setOf(
+            ProofTypeMeta.Jwt(
+                listOf(JWSAlgorithm.RS256, JWSAlgorithm.ES256),
+                KeyAttestationRequirement.RequiredNoConstraints,
+            ),
+        ),
+    ),
     listOf(
         Display(
             "Mobile Driving License",
@@ -264,32 +277,29 @@ internal fun mobileDrivingLicense() = MsoMdocCredential(
             ),
             null,
             "#12107c",
+            URI.create("https://examplestate.com/public/background.png"),
             "#FFFFFF",
         ),
     ),
     "org.iso.18013.5.1.mDL",
-    mapOf(
-        "org.iso.18013.5.1" to mapOf(
-            "given_name" to Claim(
-                display = listOf(
-                    Claim.Display(
-                        "Given Name",
-                        Locale.forLanguageTag("en-US"),
-                    ),
-                ),
+    listOf(
+        Claim(
+            path = ClaimPath.claim("org.iso.18013.5.1").claim("given_name"),
+            display = listOf(
+                Claim.Display("Given Name", Locale.forLanguageTag("en-US")),
             ),
-            "family_name" to Claim(
-                display = listOf(
-                    Claim.Display(
-                        "Surname",
-                        Locale.forLanguageTag("en-US"),
-                    ),
-                ),
-            ),
-            "birth_date" to Claim(),
         ),
-        "org.iso.18013.5.1.aamva" to mapOf(
-            "organ_donor" to Claim(),
+        Claim(
+            path = ClaimPath.claim("org.iso.18013.5.1").claim("family_name"),
+            display = listOf(
+                Claim.Display("Surname", Locale.forLanguageTag("en-US")),
+            ),
+        ),
+        Claim(
+            path = ClaimPath.claim("org.iso.18013.5.1").claim("birth_date"),
+        ),
+        Claim(
+            path = ClaimPath.claim("org.iso.18013.5.1.aamva").claim("organ_donor"),
         ),
     ),
 )
@@ -301,6 +311,7 @@ internal fun credentialIssuerMetadata() = CredentialIssuerMetadata(
     SampleIssuer.Id,
     listOf(SampleAuthServer.Url),
     CredentialIssuerEndpoint("https://credential-issuer.example.com/credentials").getOrThrow(),
+    CredentialIssuerEndpoint("https://credential-issuer.example.com/nonce").getOrThrow(),
     CredentialIssuerEndpoint("https://credential-issuer.example.com/credentials/deferred").getOrThrow(),
     CredentialIssuerEndpoint("https://credential-issuer.example.com/notification").getOrThrow(),
     CredentialResponseEncryption.Required(

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/MockData.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/MockData.kt
@@ -336,10 +336,10 @@ internal fun credentialIssuerMetadata() = CredentialIssuerMetadata(
         CredentialConfigurationIdentifier("UniversityDegree_JWT_VC_JSON-LD") to universityDegreeJwtVcJsonLD(),
     ),
     listOf(
-        CredentialIssuerMetadata.Display(
-            "credential-issuer.example.com",
-            "en-US",
-            CredentialIssuerMetadata.Display.Logo(URI.create("https://credential-issuer.example.com/logo.png"), "Credential Issuer Logo"),
+        Display(
+            name = "credential-issuer.example.com",
+            locale = Locale.forLanguageTag("en-US"),
+            logo = Display.Logo(URI.create("https://credential-issuer.example.com/logo.png"), "Credential Issuer Logo"),
         ),
     ),
 )

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/RequestMockers.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/RequestMockers.kt
@@ -191,7 +191,7 @@ private fun MockRequestHandleScope.defaultIssuanceResponseDataBuilder(request: H
         respond(
             content = """
                     {                                  
-                      "credential": "$credential",
+                      "credentials": [ {"credential": "$credential"} ],
                       "notification_id": "valbQc6p55LS",
                       "c_nonce": "wlbQc6pCJp",
                       "c_nonce_expires_in": 86400
@@ -259,7 +259,7 @@ fun MockRequestHandleScope.defaultIssuanceResponseDataBuilder(
         respond(
             content = """
                     {                     
-                      "credential": "credential_content",
+                      "credentials": [ { "credential": "credential_content"} ],
                       "c_nonce": "ERE%@^TGWYEYWEY",
                       "c_nonce_expires_in": 34
                     }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/RichAuthorizationRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/RichAuthorizationRequestTest.kt
@@ -35,7 +35,7 @@ class RichAuthorizationRequestTest {
     fun `when AuthorizationDetailsInTokenRequest is Include in pre-authorization flow expect authorization_details`() = runTest {
         val mockedKtorHttpClientFactory = mockedKtorHttpClientFactory(
             authServerWellKnownMocker(),
-            oidcWellKnownMocker(),
+            oiciWellKnownMocker(),
             parPostMocker {
                 fail("No pushed authorization request should have been sent in case of pre-authorized code flow")
             },
@@ -76,7 +76,7 @@ class RichAuthorizationRequestTest {
     fun `when config is FAVOR_SCOPES, auth details option is Include and all credentials have scopes no authorization_details expected`() =
         runTest {
             val mockedKtorHttpClientFactory = mockedKtorHttpClientFactory(
-                oidcWellKnownMocker(),
+                oiciWellKnownMocker(),
                 authServerWellKnownMocker(),
                 parPostMocker { request ->
                     val form = with(request) { parPostApplyAssertionsAndGetFormData(false) }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
@@ -54,6 +54,13 @@ val CredentialOfferWithJwtVcJson_NO_GRANTS = """
         }
 """.trimIndent()
 
+val CredentialOfferWithMDLMdoc_NO_GRANTS = """
+        {
+          "credential_issuer": "$CREDENTIAL_ISSUER_PUBLIC_URL",
+          "credential_configuration_ids": ["$MDL_MsoMdoc"]
+        }
+""".trimIndent()
+
 val CredentialOfferMixedDocTypes_PRE_AUTH_GRANT = """
         {
           "credential_issuer": "$CREDENTIAL_ISSUER_PUBLIC_URL",

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/DeferredIssuerExtensions.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/DeferredIssuerExtensions.kt
@@ -182,7 +182,7 @@ data class DeferredIssuanceStoredContextTO(
                 responseEncryptionSpec = responseEncryptionSpec?.let { responseEncryption(it) },
             ),
             authorizedTransaction = AuthorizedTransaction(
-                authorizedRequest = AuthorizedRequest.NoProofRequired(
+                authorizedRequest = AuthorizedRequest(
                     accessToken = accessToken.toAccessToken(),
                     refreshToken = refreshToken?.toRefreshToken(),
                     credentialIdentifiers = emptyMap(),
@@ -215,7 +215,7 @@ data class DeferredIssuanceStoredContextTO(
                 credentialIssuerId = dCtx.config.credentialIssuerId.toString(),
                 clientId = dCtx.config.client.id,
                 clientAttestationJwt = dCtx.config.client.ifAttested { attestationJWT.jwt.serialize() },
-                clientAttestationPopType = dCtx.config.client.ifAttested { popJwtSpec.typ.toString() },
+                clientAttestationPopType = dCtx.config.client.ifAttested { popJwtSpec.typ },
                 clientAttestationPopDuration = dCtx.config.client.ifAttested { popJwtSpec.duration.inWholeSeconds },
                 clientAttestationPopAlgorithm = dCtx.config.client.ifAttested { popJwtSpec.signingAlgorithm.toJSONString() },
                 clientAttestationPopKeyId = dCtx.config.client.ifAttested { checkNotNull(clientAttestationPopKeyId) },

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingAuthorizationFlow.kt
@@ -92,7 +92,7 @@ private suspend fun submit(
 ): AuthorizedRequestAnd<List<IssuedCredential>> {
     with(issuer) {
         val proofSigners = popSigners(credentialConfigurationId, proofsNo = 1)
-        val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, null)
+        val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
         val (newAuthorized, outcome) =
             authorized.request(requestPayload, proofSigners).getOrThrow()
         return when (outcome) {

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingPreAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingPreAuthorizationFlow.kt
@@ -71,7 +71,7 @@ private suspend fun submit(
 ): AuthorizedRequestAnd<List<IssuedCredential>> {
     with(issuer) {
         val proofSigners = popSigners(credentialConfigurationId, proofsNo = 1)
-        val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, null)
+        val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
         val (newAuthorized, outcome) =
             authorized.request(requestPayload, proofSigners).getOrThrow()
 

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/WalletInitiatedIssuanceUsingAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/WalletInitiatedIssuanceUsingAuthorizationFlow.kt
@@ -82,7 +82,7 @@ private suspend fun Issuer.submitCredentialRequest(
 ): AuthorizedRequestAnd<List<IssuedCredential>> {
     issuanceLog("Requesting issuance of '$credentialConfigurationId'")
     val proofSigners = popSigners(credentialConfigurationId, proofsNo = 1)
-    val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId, null)
+    val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
     val (newAuthorized, outcome) =
         authorizedRequest.request(requestPayload, proofSigners).getOrThrow()
 

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/DefaultCredentialOfferRequestResolverTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/DefaultCredentialOfferRequestResolverTest.kt
@@ -30,7 +30,7 @@ internal class DefaultCredentialOfferRequestResolverTest {
 
     @Test
     fun `resolve a credential offer passed by value that contains a pre-authorized code grant without transaction code`() = runTest {
-        mockedKtorHttpClientFactory(oidcWellKnownMocker(), authServerWellKnownMocker())
+        mockedKtorHttpClientFactory(oiciWellKnownMocker(), authServerWellKnownMocker())
             .invoke()
             .use { httpClient ->
                 val resolver = DefaultCredentialOfferRequestResolver(httpClient)
@@ -69,7 +69,7 @@ internal class DefaultCredentialOfferRequestResolverTest {
 
     @Test
     fun `resolve a credential offer passed by value that contains a pre-authorized code grant with transaction code`() = runTest {
-        mockedKtorHttpClientFactory(oidcWellKnownMocker(), authServerWellKnownMocker())
+        mockedKtorHttpClientFactory(oiciWellKnownMocker(), authServerWellKnownMocker())
             .invoke()
             .use { httpClient ->
                 val resolver = DefaultCredentialOfferRequestResolver(httpClient)

--- a/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_no_asymmetric_algs.json
+++ b/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_no_asymmetric_algs.json
@@ -1,8 +1,10 @@
 {
   "credential_issuer": "https://credential-issuer.example.com",
-  "authorization_servers": ["https://keycloak-eudi.netcompany-intrasoft.com/realms/pid-issuer-realm"],
+  "authorization_servers": [
+    "https://keycloak-eudi.netcompany-intrasoft.com/realms/pid-issuer-realm"
+  ],
   "credential_endpoint": "https://credential-issuer.example.com/credentials",
-  "batch_credential_endpoint": "https://credential-issuer.example.com/credentials/batch",
+  "nonce_endpoint": "https://credential-issuer.example.com/nonce",
   "deferred_credential_endpoint": "https://credential-issuer.example.com/credentials/deferred",
   "notification_endpoint": "https://credential-issuer.example.com/notification",
   "credential_response_encryption": {
@@ -15,6 +17,9 @@
       "XC20P"
     ],
     "encryption_required": true
+  },
+  "batch_credential_issuance": {
+    "batch_size": 2
   },
   "credential_identifiers_supported": true,
   "credential_configurations_supported": {
@@ -31,34 +36,7 @@
         "type": [
           "VerifiableCredential",
           "UniversityDegreeCredential"
-        ],
-        "credentialSubject": {
-          "given_name": {
-            "display": [
-              {
-                "name": "Given Name",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "family_name": {
-            "display": [
-              {
-                "name": "Surname",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "degree": {},
-          "gpa": {
-            "display": [
-              {
-                "name": "name",
-                "locale": "GPA"
-              }
-            ]
-          }
-        }
+        ]
       },
       "proof_types_supported": {
         "jwt": {
@@ -79,6 +57,46 @@
           "background_color": "#12107c",
           "text_color": "#FFFFFF"
         }
+      ],
+      "claims": [
+        {
+          "path": [
+            "given_name"
+          ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [
+            "family_name"
+          ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [
+            "degree"
+          ]
+        },
+        {
+          "path": [
+            "gpa"
+          ],
+          "display": [
+            {
+              "name": "name",
+              "locale": "GPA"
+            }
+          ]
+        }
       ]
     },
     "MobileDrivingLicense_msoMdoc": {
@@ -93,6 +111,14 @@
         "ES384",
         "ES512"
       ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ]
+        }
+      },
       "display": [
         {
           "name": "Mobile Driving License",
@@ -105,42 +131,48 @@
           "text_color": "#FFFFFF"
         }
       ],
-      "claims": {
-        "org.iso.18013.5.1": {
-          "given_name": {
-            "display": [
-              {
-                "name": "Given Name",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "family_name": {
-            "display": [
-              {
-                "name": "Surname",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "birth_date": {}
+      "claims": [
+        {
+          "path": [
+            "org.iso.18013.5.1",
+            "given_name"
+          ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
         },
-        "org.iso.18013.5.1.aamva": {
-          "organ_donor": {}
+        {
+          "path": [
+            "org.iso.18013.5.1",
+            "family_name"
+          ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [
+            "org.iso.18013.5.1",
+            "birth_date"
+          ]
+        },
+        {
+          "path": [
+            "org.iso.18013.5.1.aamva",
+            "organ_donor"
+          ]
         }
-      }
+      ]
     },
     "UniversityDegree_LDP_VC": {
       "format": "ldp_vc",
       "scope": "UniversityDegree_LDP_VC",
-      "@context": [
-        "https://www.w3.org/2018/credentials/v1",
-        "https://www.w3.org/2018/credentials/examples/v1"
-      ],
-      "type": [
-        "VerifiableCredential_LDP_VC",
-        "UniversityDegreeCredential_LDP_VC"
-      ],
       "cryptographic_binding_methods_supported": [
         "did:example"
       ],
@@ -155,33 +187,14 @@
         "type": [
           "VerifiableCredential_LDP_VC",
           "UniversityDegreeCredential_LDP_VC"
-        ],
-        "credentialSubject": {
-          "given_name": {
-            "display": [
-              {
-                "name": "Given Name",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "family_name": {
-            "display": [
-              {
-                "name": "Surname",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "degree": {},
-          "gpa": {
-            "display": [
-              {
-                "name": "name",
-                "locale": "GPA"
-              }
-            ]
-          }
+        ]
+      },
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ]
         }
       },
       "display": [
@@ -195,15 +208,51 @@
           "background_color": "#12107c",
           "text_color": "#FFFFFF"
         }
+      ],
+      "claims": [
+        {
+          "path": [
+            "given_name"
+          ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [
+            "family_name"
+          ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [
+            "degree"
+          ]
+        },
+        {
+          "path": [
+            "gpa"
+          ],
+          "display": [
+            {
+              "name": "name",
+              "locale": "GPA"
+            }
+          ]
+        }
       ]
     },
     "UniversityDegree_JWT_VC_JSON-LD": {
       "format": "jwt_vc_json-ld",
       "scope": "UniversityDegree_JWT_VC_JSON-LD",
-      "@context": [
-        "https://www.w3.org/2018/credentials/v1",
-        "https://www.w3.org/2018/credentials/examples/v1"
-      ],
       "cryptographic_binding_methods_supported": [
         "did:example"
       ],
@@ -218,33 +267,14 @@
         "type": [
           "VerifiableCredential_JWT_VC_JSON-LD",
           "UniversityDegreeCredential_JWT_VC_JSON-LD"
-        ],
-        "credentialSubject": {
-          "given_name": {
-            "display": [
-              {
-                "name": "Given Name",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "family_name": {
-            "display": [
-              {
-                "name": "Surname",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "degree": {},
-          "gpa": {
-            "display": [
-              {
-                "name": "name",
-                "locale": "GPA"
-              }
-            ]
-          }
+        ]
+      },
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ]
         }
       },
       "display": [
@@ -258,13 +288,57 @@
           "background_color": "#12107c",
           "text_color": "#FFFFFF"
         }
+      ],
+      "claims": [
+        {
+          "path": [
+            "given_name"
+          ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [
+            "family_name"
+          ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [
+            "degree"
+          ]
+        },
+        {
+          "path": [
+            "gpa"
+          ],
+          "display": [
+            {
+              "name": "name",
+              "locale": "GPA"
+            }
+          ]
+        }
       ]
     }
   },
   "display": [
     {
       "name": "credential-issuer.example.com",
-      "locale": "en-US"
+      "locale": "en-US",
+      "logo": {
+        "uri": "https://credential-issuer.example.com/logo.png",
+        "alt_text": "Credential Issuer Logo"
+      }
     }
   ]
 }

--- a/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_valid.json
+++ b/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_valid.json
@@ -1,7 +1,10 @@
 {
   "credential_issuer": "https://credential-issuer.example.com",
-  "authorization_servers": ["https://keycloak-eudi.netcompany-intrasoft.com/realms/pid-issuer-realm"],
+  "authorization_servers": [
+    "https://keycloak-eudi.netcompany-intrasoft.com/realms/pid-issuer-realm"
+  ],
   "credential_endpoint": "https://credential-issuer.example.com/credentials",
+  "nonce_endpoint": "https://credential-issuer.example.com/nonce",
   "deferred_credential_endpoint": "https://credential-issuer.example.com/credentials/deferred",
   "notification_endpoint": "https://credential-issuer.example.com/notification",
   "credential_response_encryption": {
@@ -37,34 +40,7 @@
         "type": [
           "VerifiableCredential",
           "UniversityDegreeCredential"
-        ],
-        "credentialSubject": {
-          "given_name": {
-            "display": [
-              {
-                "name": "Given Name",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "family_name": {
-            "display": [
-              {
-                "name": "Surname",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "degree": {},
-          "gpa": {
-            "display": [
-              {
-                "name": "name",
-                "locale": "GPA"
-              }
-            ]
-          }
-        }
+        ]
       },
       "proof_types_supported": {
         "jwt": {
@@ -83,7 +59,50 @@
             "alt_text": "a square logo of a university"
           },
           "background_color": "#12107c",
+          "background_image": {
+            "uri": "https://examplestate.com/public/background.png"
+          },
           "text_color": "#FFFFFF"
+        }
+      ],
+      "claims": [
+        {
+          "path": [
+            "given_name"
+          ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [
+            "family_name"
+          ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [
+            "degree"
+          ]
+        },
+        {
+          "path": [
+            "gpa"
+          ],
+          "display": [
+            {
+              "name": "name",
+              "locale": "GPA"
+            }
+          ]
         }
       ]
     },
@@ -104,7 +123,8 @@
           "proof_signing_alg_values_supported": [
             "RS256",
             "ES256"
-          ]
+          ],
+          "key_attestations_required": {}
         }
       },
       "display": [
@@ -116,45 +136,42 @@
             "alt_text": "a square figure of a mobile driving license"
           },
           "background_color": "#12107c",
+          "background_image": {
+            "uri": "https://examplestate.com/public/background.png"
+          },
           "text_color": "#FFFFFF"
         }
       ],
-      "claims": {
-        "org.iso.18013.5.1": {
-          "given_name": {
-            "display": [
-              {
-                "name": "Given Name",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "family_name": {
-            "display": [
-              {
-                "name": "Surname",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "birth_date": {}
+      "claims": [
+        {
+          "path": [ "org.iso.18013.5.1", "given_name" ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
         },
-        "org.iso.18013.5.1.aamva": {
-          "organ_donor": {}
+        {
+          "path": [ "org.iso.18013.5.1", "family_name" ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1", "birth_date" ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
         }
-      }
+      ]
     },
     "UniversityDegree_LDP_VC": {
       "format": "ldp_vc",
       "scope": "UniversityDegree_LDP_VC",
-      "@context": [
-        "https://www.w3.org/2018/credentials/v1",
-        "https://www.w3.org/2018/credentials/examples/v1"
-      ],
-      "type": [
-        "VerifiableCredential_LDP_VC",
-        "UniversityDegreeCredential_LDP_VC"
-      ],
       "cryptographic_binding_methods_supported": [
         "did:example"
       ],
@@ -169,41 +186,17 @@
         "type": [
           "VerifiableCredential_LDP_VC",
           "UniversityDegreeCredential_LDP_VC"
-        ],
-        "credentialSubject": {
-          "given_name": {
-            "display": [
-              {
-                "name": "Given Name",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "family_name": {
-            "display": [
-              {
-                "name": "Surname",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "degree": {},
-          "gpa": {
-            "display": [
-              {
-                "name": "name",
-                "locale": "GPA"
-              }
-            ]
-          }
-        }
+        ]
       },
       "proof_types_supported": {
         "jwt": {
           "proof_signing_alg_values_supported": [
             "RS256",
             "ES256"
-          ]
+          ],
+          "key_attestations_required": {
+            "key_storage": ["iso_18045_high", "iso_18045_enhanced-basic"]
+          }
         }
       },
       "display": [
@@ -217,15 +210,51 @@
           "background_color": "#12107c",
           "text_color": "#FFFFFF"
         }
+      ],
+      "claims": [
+        {
+          "path": [
+            "given_name"
+          ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [
+            "family_name"
+          ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [
+            "degree"
+          ]
+        },
+        {
+          "path": [
+            "gpa"
+          ],
+          "display": [
+            {
+              "name": "name",
+              "locale": "GPA"
+            }
+          ]
+        }
       ]
     },
     "UniversityDegree_JWT_VC_JSON-LD": {
       "format": "jwt_vc_json-ld",
       "scope": "UniversityDegree_JWT_VC_JSON-LD",
-      "@context": [
-        "https://www.w3.org/2018/credentials/v1",
-        "https://www.w3.org/2018/credentials/examples/v1"
-      ],
       "cryptographic_binding_methods_supported": [
         "did:example"
       ],
@@ -240,41 +269,18 @@
         "type": [
           "VerifiableCredential_JWT_VC_JSON-LD",
           "UniversityDegreeCredential_JWT_VC_JSON-LD"
-        ],
-        "credentialSubject": {
-          "given_name": {
-            "display": [
-              {
-                "name": "Given Name",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "family_name": {
-            "display": [
-              {
-                "name": "Surname",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "degree": {},
-          "gpa": {
-            "display": [
-              {
-                "name": "name",
-                "locale": "GPA"
-              }
-            ]
-          }
-        }
+        ]
       },
       "proof_types_supported": {
         "jwt": {
           "proof_signing_alg_values_supported": [
             "RS256",
             "ES256"
-          ]
+          ],
+          "key_attestations_required": {
+            "key_storage": ["iso_18045_high", "iso_18045_enhanced-basic"],
+            "user_authentication": ["iso_18045_high", "iso_18045_enhanced-basic"]
+          }
         }
       },
       "display": [
@@ -287,6 +293,46 @@
           },
           "background_color": "#12107c",
           "text_color": "#FFFFFF"
+        }
+      ],
+      "claims": [
+        {
+          "path": [
+            "given_name"
+          ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [
+            "family_name"
+          ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [
+            "degree"
+          ]
+        },
+        {
+          "path": [
+            "gpa"
+          ],
+          "display": [
+            {
+              "name": "name",
+              "locale": "GPA"
+            }
+          ]
         }
       ]
     }

--- a/src/test/resources/well-known/openid-credential-issuer_encrypted_responses.json
+++ b/src/test/resources/well-known/openid-credential-issuer_encrypted_responses.json
@@ -23,7 +23,7 @@
   "credential_identifiers_supported": true,
   "credential_configurations_supported": {
     "eu.europa.ec.eudiw.pid_vc_sd_jwt": {
-      "format": "vc+sd-jwt",
+      "format": "dc+sd-jwt",
       "scope": "eu.europa.ec.eudiw.pid_vc_sd_jwt",
       "cryptographic_binding_methods_supported": [
         "jwk"

--- a/src/test/resources/well-known/openid-credential-issuer_encrypted_responses.json
+++ b/src/test/resources/well-known/openid-credential-issuer_encrypted_responses.json
@@ -4,6 +4,7 @@
     "https://auth-server.example.com"
   ],
   "credential_endpoint": "https://credential-issuer.example.com/credentials",
+  "nonce_endpoint": "https://credential-issuer.example.com/nonce",
   "deferred_credential_endpoint": "https://credential-issuer.example.com/credentials/deferred",
   "notification_endpoint": "https://credential-issuer.example.com/notification",
   "credential_response_encryption": {
@@ -39,8 +40,9 @@
         }
       },
       "vct": "eu.europa.ec.eudiw.pid.1",
-      "claims": {
-        "given_name": {
+      "claims": [
+        {
+          "path": [ "given_name" ],
           "display": [
             {
               "name": "Given Name",
@@ -48,7 +50,8 @@
             }
           ]
         },
-        "family_name": {
+        {
+          "path": [ "family_name" ],
           "display": [
             {
               "name": "Surname",
@@ -56,8 +59,10 @@
             }
           ]
         },
-        "birth_date": {}
-      },
+        {
+          "path": [ "birth_date" ]
+        }
+      ],
       "display": [
         {
           "name": "Personal Identification Data ",
@@ -98,33 +103,38 @@
             "alt_text": "a square figure of a mobile driving license"
           },
           "background_color": "#12107c",
+          "background_image": {
+            "uri": "https://examplestate.com/public/background.png"
+          },
           "text_color": "#FFFFFF"
         }
       ],
-      "claims": {
-        "org.iso.18013.5.1": {
-          "given_name": {
-            "display": [
-              {
-                "name": "Given Name",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "family_name": {
-            "display": [
-              {
-                "name": "Surname",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "birth_date": {}
+      "claims": [
+        {
+          "path": [ "org.iso.18013.5.1", "given_name" ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
         },
-        "org.iso.18013.5.1.aamva": {
-          "organ_donor": {}
+        {
+          "path": [ "org.iso.18013.5.1", "family_name" ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1", "birth_date" ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
         }
-      }
+      ]
     },
     "UniversityDegree_mso_mdoc": {
       "format": "mso_mdoc",
@@ -153,33 +163,38 @@
             "alt_text": "a square figure of a mobile driving license"
           },
           "background_color": "#12107c",
+          "background_image": {
+            "uri": "https://examplestate.com/public/background.png"
+          },
           "text_color": "#FFFFFF"
         }
       ],
-      "claims": {
-        "org.iso.18013.5.1": {
-          "given_name": {
-            "display": [
-              {
-                "name": "Given Name",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "family_name": {
-            "display": [
-              {
-                "name": "Surname",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "birth_date": {}
+      "claims": [
+        {
+          "path": [ "org.iso.18013.5.1", "given_name" ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
         },
-        "org.iso.18013.5.1.aamva": {
-          "organ_donor": {}
+        {
+          "path": [ "org.iso.18013.5.1", "family_name" ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1", "birth_date" ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
         }
-      }
+      ]
     },
     "UniversityDegree_jwt_vc_json": {
       "format": "jwt_vc_json",
@@ -194,34 +209,7 @@
         "type": [
           "VerifiableCredential",
           "UniversityDegreeCredential"
-        ],
-        "credentialSubject": {
-          "given_name": {
-            "display": [
-              {
-                "name": "Given Name",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "family_name": {
-            "display": [
-              {
-                "name": "Surname",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "degree": {},
-          "gpa": {
-            "mandatory": true,
-            "display": [
-              {
-                "name": "GPA"
-              }
-            ]
-          }
-        }
+        ]
       },
       "proof_types_supported": {
         "jwt": {
@@ -241,6 +229,38 @@
           },
           "background_color": "#12107c",
           "text_color": "#FFFFFF"
+        }
+      ],
+      "claims": [
+        {
+          "path": [ "given_name" ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "family_name" ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "degree" ]
+        },
+        {
+          "path": [ "gpa" ],
+          "display": [
+            {
+              "name": "name",
+              "locale": "GPA"
+            }
+          ]
         }
       ]
     },
@@ -265,33 +285,38 @@
             "alt_text": "a square figure of a mobile driving license"
           },
           "background_color": "#12107c",
+          "background_image": {
+            "uri": "https://examplestate.com/public/background.png"
+          },
           "text_color": "#FFFFFF"
         }
       ],
-      "claims": {
-        "org.iso.18013.5.1": {
-          "given_name": {
-            "display": [
-              {
-                "name": "Given Name",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "family_name": {
-            "display": [
-              {
-                "name": "Surname",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "birth_date": {}
+      "claims": [
+        {
+          "path": [ "org.iso.18013.5.1", "given_name" ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
         },
-        "org.iso.18013.5.1.aamva": {
-          "organ_donor": {}
+        {
+          "path": [ "org.iso.18013.5.1", "family_name" ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1", "birth_date" ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
         }
-      }
+      ]
     }
   },
   "display": [

--- a/src/test/resources/well-known/openid-credential-issuer_encryption_not_required.json
+++ b/src/test/resources/well-known/openid-credential-issuer_encryption_not_required.json
@@ -23,7 +23,7 @@
   "credential_identifiers_supported": true,
   "credential_configurations_supported": {
     "eu.europa.ec.eudiw.pid_vc_sd_jwt": {
-      "format": "vc+sd-jwt",
+      "format": "dc+sd-jwt",
       "scope": "eu.europa.ec.eudiw.pid_vc_sd_jwt",
       "cryptographic_binding_methods_supported": [
         "jwk"

--- a/src/test/resources/well-known/openid-credential-issuer_encryption_not_required.json
+++ b/src/test/resources/well-known/openid-credential-issuer_encryption_not_required.json
@@ -4,6 +4,7 @@
     "https://auth-server.example.com"
   ],
   "credential_endpoint": "https://credential-issuer.example.com/credentials",
+  "nonce_endpoint": "https://credential-issuer.example.com/nonce",
   "deferred_credential_endpoint": "https://credential-issuer.example.com/credentials/deferred",
   "notification_endpoint": "https://credential-issuer.example.com/notification",
   "credential_response_encryption": {
@@ -39,8 +40,9 @@
         }
       },
       "vct": "eu.europa.ec.eudiw.pid.1",
-      "claims": {
-        "given_name": {
+      "claims": [
+        {
+          "path": [ "given_name" ],
           "display": [
             {
               "name": "Given Name",
@@ -48,7 +50,8 @@
             }
           ]
         },
-        "family_name": {
+        {
+          "path": [ "family_name" ],
           "display": [
             {
               "name": "Surname",
@@ -56,8 +59,10 @@
             }
           ]
         },
-        "birth_date": {}
-      },
+        {
+          "path": [ "birth_date" ]
+        }
+      ],
       "display": [
         {
           "name": "Personal Identification Data ",
@@ -98,33 +103,38 @@
             "alt_text": "a square figure of a mobile driving license"
           },
           "background_color": "#12107c",
+          "background_image": {
+            "uri": "https://examplestate.com/public/background.png"
+          },
           "text_color": "#FFFFFF"
         }
       ],
-      "claims": {
-        "org.iso.18013.5.1": {
-          "given_name": {
-            "display": [
-              {
-                "name": "Given Name",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "family_name": {
-            "display": [
-              {
-                "name": "Surname",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "birth_date": {}
+      "claims": [
+        {
+          "path": [ "org.iso.18013.5.1", "given_name" ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
         },
-        "org.iso.18013.5.1.aamva": {
-          "organ_donor": {}
+        {
+          "path": [ "org.iso.18013.5.1", "family_name" ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1", "birth_date" ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
         }
-      }
+      ]
     },
     "UniversityDegree_mso_mdoc": {
       "format": "mso_mdoc",
@@ -153,33 +163,38 @@
             "alt_text": "a square figure of a mobile driving license"
           },
           "background_color": "#12107c",
+          "background_image": {
+            "uri": "https://examplestate.com/public/background.png"
+          },
           "text_color": "#FFFFFF"
         }
       ],
-      "claims": {
-        "org.iso.18013.5.1": {
-          "given_name": {
-            "display": [
-              {
-                "name": "Given Name",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "family_name": {
-            "display": [
-              {
-                "name": "Surname",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "birth_date": {}
+      "claims": [
+        {
+          "path": [ "org.iso.18013.5.1", "given_name" ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
         },
-        "org.iso.18013.5.1.aamva": {
-          "organ_donor": {}
+        {
+          "path": [ "org.iso.18013.5.1", "family_name" ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1", "birth_date" ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
         }
-      }
+      ]
     },
     "UniversityDegree_jwt_vc_json": {
       "format": "jwt_vc_json",
@@ -194,34 +209,7 @@
         "type": [
           "VerifiableCredential",
           "UniversityDegreeCredential"
-        ],
-        "credentialSubject": {
-          "given_name": {
-            "display": [
-              {
-                "name": "Given Name",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "family_name": {
-            "display": [
-              {
-                "name": "Surname",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "degree": {},
-          "gpa": {
-            "mandatory": true,
-            "display": [
-              {
-                "name": "GPA"
-              }
-            ]
-          }
-        }
+        ]
       },
       "proof_types_supported": {
         "jwt": {
@@ -241,6 +229,38 @@
           },
           "background_color": "#12107c",
           "text_color": "#FFFFFF"
+        }
+      ],
+      "claims": [
+        {
+          "path": [ "given_name" ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "family_name" ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "degree" ]
+        },
+        {
+          "path": [ "gpa" ],
+          "display": [
+            {
+              "name": "name",
+              "locale": "GPA"
+            }
+          ]
         }
       ]
     },
@@ -265,33 +285,38 @@
             "alt_text": "a square figure of a mobile driving license"
           },
           "background_color": "#12107c",
+          "background_image": {
+            "uri": "https://examplestate.com/public/background.png"
+          },
           "text_color": "#FFFFFF"
         }
       ],
-      "claims": {
-        "org.iso.18013.5.1": {
-          "given_name": {
-            "display": [
-              {
-                "name": "Given Name",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "family_name": {
-            "display": [
-              {
-                "name": "Surname",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "birth_date": {}
+      "claims": [
+        {
+          "path": [ "org.iso.18013.5.1", "given_name" ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
         },
-        "org.iso.18013.5.1.aamva": {
-          "organ_donor": {}
+        {
+          "path": [ "org.iso.18013.5.1", "family_name" ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1", "birth_date" ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
         }
-      }
+      ]
     }
   },
   "display": [

--- a/src/test/resources/well-known/openid-credential-issuer_encryption_not_supported.json
+++ b/src/test/resources/well-known/openid-credential-issuer_encryption_not_supported.json
@@ -13,7 +13,7 @@
   "credential_identifiers_supported": true,
   "credential_configurations_supported": {
     "eu.europa.ec.eudiw.pid_vc_sd_jwt": {
-      "format": "vc+sd-jwt",
+      "format": "dc+sd-jwt",
       "scope": "eu.europa.ec.eudiw.pid_vc_sd_jwt",
       "cryptographic_binding_methods_supported": [
         "jwk"

--- a/src/test/resources/well-known/openid-credential-issuer_encryption_not_supported.json
+++ b/src/test/resources/well-known/openid-credential-issuer_encryption_not_supported.json
@@ -4,6 +4,7 @@
     "https://auth-server.example.com"
   ],
   "credential_endpoint": "https://credential-issuer.example.com/credentials",
+  "nonce_endpoint": "https://credential-issuer.example.com/nonce",
   "deferred_credential_endpoint": "https://credential-issuer.example.com/credentials/deferred",
   "notification_endpoint": "https://credential-issuer.example.com/notification",
   "batch_credential_issuance": {
@@ -29,8 +30,9 @@
         }
       },
       "vct": "eu.europa.ec.eudiw.pid.1",
-      "claims": {
-        "given_name": {
+      "claims": [
+        {
+          "path": [ "given_name" ],
           "display": [
             {
               "name": "Given Name",
@@ -38,7 +40,8 @@
             }
           ]
         },
-        "family_name": {
+        {
+          "path": [ "family_name" ],
           "display": [
             {
               "name": "Surname",
@@ -46,8 +49,10 @@
             }
           ]
         },
-        "birth_date": {}
-      },
+        {
+          "path": [ "birth_date" ]
+        }
+      ],
       "display": [
         {
           "name": "Personal Identification Data ",
@@ -88,33 +93,38 @@
             "alt_text": "a square figure of a mobile driving license"
           },
           "background_color": "#12107c",
+          "background_image": {
+            "uri": "https://examplestate.com/public/background.png"
+          },
           "text_color": "#FFFFFF"
         }
       ],
-      "claims": {
-        "org.iso.18013.5.1": {
-          "given_name": {
-            "display": [
-              {
-                "name": "Given Name",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "family_name": {
-            "display": [
-              {
-                "name": "Surname",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "birth_date": {}
+      "claims": [
+        {
+          "path": [ "org.iso.18013.5.1", "given_name" ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
         },
-        "org.iso.18013.5.1.aamva": {
-          "organ_donor": {}
+        {
+          "path": [ "org.iso.18013.5.1", "family_name" ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1", "birth_date" ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
         }
-      }
+      ]
     },
     "UniversityDegree_mso_mdoc": {
       "format": "mso_mdoc",
@@ -143,33 +153,38 @@
             "alt_text": "a square figure of a mobile driving license"
           },
           "background_color": "#12107c",
+          "background_image": {
+            "uri": "https://examplestate.com/public/background.png"
+          },
           "text_color": "#FFFFFF"
         }
       ],
-      "claims": {
-        "org.iso.18013.5.1": {
-          "given_name": {
-            "display": [
-              {
-                "name": "Given Name",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "family_name": {
-            "display": [
-              {
-                "name": "Surname",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "birth_date": {}
+      "claims": [
+        {
+          "path": [ "org.iso.18013.5.1", "given_name" ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
         },
-        "org.iso.18013.5.1.aamva": {
-          "organ_donor": {}
+        {
+          "path": [ "org.iso.18013.5.1", "family_name" ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1", "birth_date" ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
         }
-      }
+      ]
     },
     "UniversityDegree_jwt_vc_json": {
       "format": "jwt_vc_json",
@@ -184,34 +199,7 @@
         "type": [
           "VerifiableCredential",
           "UniversityDegreeCredential"
-        ],
-        "credentialSubject": {
-          "given_name": {
-            "display": [
-              {
-                "name": "Given Name",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "family_name": {
-            "display": [
-              {
-                "name": "Surname",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "degree": {},
-          "gpa": {
-            "mandatory": true,
-            "display": [
-              {
-                "name": "GPA"
-              }
-            ]
-          }
-        }
+        ]
       },
       "proof_types_supported": {
         "jwt": {
@@ -231,6 +219,38 @@
           },
           "background_color": "#12107c",
           "text_color": "#FFFFFF"
+        }
+      ],
+      "claims": [
+        {
+          "path": [ "given_name" ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "family_name" ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "degree" ]
+        },
+        {
+          "path": [ "gpa" ],
+          "display": [
+            {
+              "name": "name",
+              "locale": "GPA"
+            }
+          ]
         }
       ]
     },
@@ -255,33 +275,38 @@
             "alt_text": "a square figure of a mobile driving license"
           },
           "background_color": "#12107c",
+          "background_image": {
+            "uri": "https://examplestate.com/public/background.png"
+          },
           "text_color": "#FFFFFF"
         }
       ],
-      "claims": {
-        "org.iso.18013.5.1": {
-          "given_name": {
-            "display": [
-              {
-                "name": "Given Name",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "family_name": {
-            "display": [
-              {
-                "name": "Surname",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "birth_date": {}
+      "claims": [
+        {
+          "path": [ "org.iso.18013.5.1", "given_name" ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
         },
-        "org.iso.18013.5.1.aamva": {
-          "organ_donor": {}
+        {
+          "path": [ "org.iso.18013.5.1", "family_name" ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1", "birth_date" ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
         }
-      }
+      ]
     }
   },
   "display": [

--- a/src/test/resources/well-known/openid-credential-issuer_no_nonce_endpoint.json
+++ b/src/test/resources/well-known/openid-credential-issuer_no_nonce_endpoint.json
@@ -1,0 +1,317 @@
+{
+  "credential_issuer": "https://credential-issuer.example.com",
+  "authorization_servers": [
+    "https://auth-server.example.com"
+  ],
+  "credential_endpoint": "https://credential-issuer.example.com/credentials",
+  "deferred_credential_endpoint": "https://credential-issuer.example.com/credentials/deferred",
+  "notification_endpoint": "https://credential-issuer.example.com/notification",
+  "batch_credential_issuance": {
+    "batch_size": 3
+  },
+  "credential_identifiers_supported": true,
+  "credential_configurations_supported": {
+    "eu.europa.ec.eudiw.pid_vc_sd_jwt": {
+      "format": "dc+sd-jwt",
+      "scope": "eu.europa.ec.eudiw.pid_vc_sd_jwt",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "RS256"
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ]
+        }
+      },
+      "vct": "eu.europa.ec.eudiw.pid.1",
+      "claims": [
+        {
+          "path": [ "given_name" ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "family_name" ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "birth_date" ]
+        }
+      ],
+      "display": [
+        {
+          "name": "Personal Identification Data ",
+          "locale": "en-US",
+          "logo": {
+            "uri": "https://examplestate.com/public/pid.png",
+            "alt_text": "a square logo of a university"
+          },
+          "background_color": "#12107c",
+          "text_color": "#FFFFFF"
+        }
+      ]
+    },
+    "eu.europa.ec.eudiw.pid_mso_mdoc": {
+      "format": "mso_mdoc",
+      "scope": "eu.europa.ec.eudiw.pid_mso_mdoc",
+      "doctype": "org.iso.18013.5.1.PID",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "RS256"
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ]
+        }
+      },
+      "display": [
+        {
+          "name": "Personal Identification Data",
+          "locale": "en-US",
+          "logo": {
+            "uri": "https://examplestate.com/public/pid.png",
+            "alt_text": "a square figure of a mobile driving license"
+          },
+          "background_color": "#12107c",
+          "background_image": {
+            "uri": "https://examplestate.com/public/background.png"
+          },
+          "text_color": "#FFFFFF"
+        }
+      ],
+      "claims": [
+        {
+          "path": [ "org.iso.18013.5.1", "given_name" ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1", "family_name" ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1", "birth_date" ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
+        }
+      ]
+    },
+    "UniversityDegree_mso_mdoc": {
+      "format": "mso_mdoc",
+      "scope": "UniversityDegree",
+      "doctype": "org.iso.18013.5.1.Degree",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "RS256"
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ]
+        }
+      },
+      "display": [
+        {
+          "name": "Mobile Driving License",
+          "locale": "en-US",
+          "logo": {
+            "uri": "https://examplestate.com/public/mdl.png",
+            "alt_text": "a square figure of a mobile driving license"
+          },
+          "background_color": "#12107c",
+          "background_image": {
+            "uri": "https://examplestate.com/public/background.png"
+          },
+          "text_color": "#FFFFFF"
+        }
+      ],
+      "claims": [
+        {
+          "path": [ "org.iso.18013.5.1", "given_name" ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1", "family_name" ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1", "birth_date" ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
+        }
+      ]
+    },
+    "UniversityDegree_jwt_vc_json": {
+      "format": "jwt_vc_json",
+      "scope": "UniversityDegree",
+      "cryptographic_binding_methods_supported": [
+        "did:example"
+      ],
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
+      "credential_definition": {
+        "type": [
+          "VerifiableCredential",
+          "UniversityDegreeCredential"
+        ]
+      },
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ]
+        }
+      },
+      "display": [
+        {
+          "name": "University Credential",
+          "locale": "en-US",
+          "logo": {
+            "url": "https://university.example.edu/public/logo.png",
+            "alt_text": "a square logo of a university"
+          },
+          "background_color": "#12107c",
+          "text_color": "#FFFFFF"
+        }
+      ],
+      "claims": [
+        {
+          "path": [ "given_name" ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "family_name" ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "degree" ]
+        },
+        {
+          "path": [ "gpa" ],
+          "display": [
+            {
+              "name": "name",
+              "locale": "GPA"
+            }
+          ]
+        }
+      ]
+    },
+    "MobileDrivingLicense_msoMdoc": {
+      "format": "mso_mdoc",
+      "scope": "MobileDrivingLicense_msoMdoc",
+      "doctype": "org.iso.18013.5.1.mDL",
+      "cryptographic_binding_methods_supported": [
+        "cose_key"
+      ],
+      "credential_signing_alg_values_supported": [
+        "ES256",
+        "ES384",
+        "ES512"
+      ],
+      "display": [
+        {
+          "name": "Mobile Driving License",
+          "locale": "en-US",
+          "logo": {
+            "uri": "https://examplestate.com/public/mdl.png",
+            "alt_text": "a square figure of a mobile driving license"
+          },
+          "background_color": "#12107c",
+          "background_image": {
+            "uri": "https://examplestate.com/public/background.png"
+          },
+          "text_color": "#FFFFFF"
+        }
+      ],
+      "claims": [
+        {
+          "path": [ "org.iso.18013.5.1", "given_name" ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1", "family_name" ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1", "birth_date" ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
+        }
+      ]
+    }
+  },
+  "display": [
+    {
+      "name": "credential-issuer.example.com",
+      "locale": "en-US"
+    }
+  ]
+}

--- a/src/test/resources/well-known/openid-credential-issuer_no_scopes.json
+++ b/src/test/resources/well-known/openid-credential-issuer_no_scopes.json
@@ -23,7 +23,7 @@
   "credential_identifiers_supported": true,
   "credential_configurations_supported": {
     "eu.europa.ec.eudiw.pid_vc_sd_jwt": {
-      "format": "vc+sd-jwt",
+      "format": "dc+sd-jwt",
       "scope": "eu.europa.ec.eudiw.pid_vc_sd_jwt",
       "cryptographic_binding_methods_supported": [
         "jwk"

--- a/src/test/resources/well-known/openid-credential-issuer_no_scopes.json
+++ b/src/test/resources/well-known/openid-credential-issuer_no_scopes.json
@@ -4,6 +4,7 @@
     "https://auth-server.example.com"
   ],
   "credential_endpoint": "https://credential-issuer.example.com/credentials",
+  "nonce_endpoint": "https://credential-issuer.example.com/nonce",
   "deferred_credential_endpoint": "https://credential-issuer.example.com/credentials/deferred",
   "notification_endpoint": "https://credential-issuer.example.com/notification",
   "credential_response_encryption": {
@@ -39,8 +40,9 @@
         }
       },
       "vct": "eu.europa.ec.eudiw.pid.1",
-      "claims": {
-        "given_name": {
+      "claims": [
+        {
+          "path": [ "given_name" ],
           "display": [
             {
               "name": "Given Name",
@@ -48,7 +50,8 @@
             }
           ]
         },
-        "family_name": {
+        {
+          "path": [ "family_name" ],
           "display": [
             {
               "name": "Surname",
@@ -56,8 +59,10 @@
             }
           ]
         },
-        "birth_date": {}
-      },
+        {
+          "path": [ "birth_date" ]
+        }
+      ],
       "display": [
         {
           "name": "Personal Identification Data ",
@@ -97,33 +102,38 @@
             "alt_text": "a square figure of a mobile driving license"
           },
           "background_color": "#12107c",
+          "background_image": {
+            "uri": "https://examplestate.com/public/background.png"
+          },
           "text_color": "#FFFFFF"
         }
       ],
-      "claims": {
-        "org.iso.18013.5.1": {
-          "given_name": {
-            "display": [
-              {
-                "name": "Given Name",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "family_name": {
-            "display": [
-              {
-                "name": "Surname",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "birth_date": {}
+      "claims": [
+        {
+          "path": [ "org.iso.18013.5.1", "given_name" ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
         },
-        "org.iso.18013.5.1.aamva": {
-          "organ_donor": {}
+        {
+          "path": [ "org.iso.18013.5.1", "family_name" ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1", "birth_date" ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
         }
-      }
+      ]
     },
     "UniversityDegree_mso_mdoc": {
       "format": "mso_mdoc",
@@ -151,33 +161,38 @@
             "alt_text": "a square figure of a mobile driving license"
           },
           "background_color": "#12107c",
+          "background_image": {
+            "uri": "https://examplestate.com/public/background.png"
+          },
           "text_color": "#FFFFFF"
         }
       ],
-      "claims": {
-        "org.iso.18013.5.1": {
-          "given_name": {
-            "display": [
-              {
-                "name": "Given Name",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "family_name": {
-            "display": [
-              {
-                "name": "Surname",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "birth_date": {}
+      "claims": [
+        {
+          "path": [ "org.iso.18013.5.1", "given_name" ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
         },
-        "org.iso.18013.5.1.aamva": {
-          "organ_donor": {}
+        {
+          "path": [ "org.iso.18013.5.1", "family_name" ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1", "birth_date" ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
         }
-      }
+      ]
     },
     "UniversityDegree_jwt_vc_json": {
       "format": "jwt_vc_json",
@@ -192,34 +207,7 @@
         "type": [
           "VerifiableCredential",
           "UniversityDegreeCredential"
-        ],
-        "credentialSubject": {
-          "given_name": {
-            "display": [
-              {
-                "name": "Given Name",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "family_name": {
-            "display": [
-              {
-                "name": "Surname",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "degree": {},
-          "gpa": {
-            "mandatory": true,
-            "display": [
-              {
-                "name": "GPA"
-              }
-            ]
-          }
-        }
+        ]
       },
       "proof_types_supported": {
         "jwt": {
@@ -239,6 +227,38 @@
           },
           "background_color": "#12107c",
           "text_color": "#FFFFFF"
+        }
+      ],
+      "claims": [
+        {
+          "path": [ "given_name" ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "family_name" ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "degree" ]
+        },
+        {
+          "path": [ "gpa" ],
+          "display": [
+            {
+              "name": "name",
+              "locale": "GPA"
+            }
+          ]
         }
       ]
     },
@@ -262,33 +282,38 @@
             "alt_text": "a square figure of a mobile driving license"
           },
           "background_color": "#12107c",
+          "background_image": {
+            "uri": "https://examplestate.com/public/background.png"
+          },
           "text_color": "#FFFFFF"
         }
       ],
-      "claims": {
-        "org.iso.18013.5.1": {
-          "given_name": {
-            "display": [
-              {
-                "name": "Given Name",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "family_name": {
-            "display": [
-              {
-                "name": "Surname",
-                "locale": "en-US"
-              }
-            ]
-          },
-          "birth_date": {}
+      "claims": [
+        {
+          "path": [ "org.iso.18013.5.1", "given_name" ],
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
         },
-        "org.iso.18013.5.1.aamva": {
-          "organ_donor": {}
+        {
+          "path": [ "org.iso.18013.5.1", "family_name" ],
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1", "birth_date" ]
+        },
+        {
+          "path": [ "org.iso.18013.5.1.aamva", "organ_donor" ]
         }
-      }
+      ]
     }
   },
   "display": [


### PR DESCRIPTION
This PR aligns the library to the bellow-mentioned changes of OpenId4VCI draft 15.

- [x] Closes #375 
- [x] Closes #374 
- [x] Closes #369 
- [x] Closes #372 
- [x] Closes #370
- [x] Closes #388  
- [x] Closes #390 
- [x] Update README file


Out of scope 
- `attestation` proof type
- `key_attestation` to the JWT Proof (JOSE header)
- wallet attestation