### PR TITLE
Downgrade Gradle Maven Publish plugin to 0.30.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ cbor = "0.9"
 java = "17"
 ktlint = "0.50.0"
 dokka = "2.0.0"
-maven-publish = "0.31.0"
+maven-publish = "0.30.0"
 logback = "1.5.18"
 
 [libraries]


### PR DESCRIPTION
Downgrades Gradle Maven Publish plugin to 0.30.0 till https://github.com/vanniktech/gradle-maven-publish-plugin/issues/920 is resolved.