### PR TITLE
Replace runCatching

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialOfferRequestResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialOfferRequestResolver.kt
@@ -279,7 +279,7 @@ fun interface CredentialOfferRequestResolver {
     /**
      * Tries to parse a Credential Offer Endpoint [URL][uri], extract and validate a Credential Offer Request.
      */
-    suspend fun resolve(uri: String): Result<CredentialOffer> = runCatching {
+    suspend fun resolve(uri: String): Result<CredentialOffer> = runCatchingCancellable {
         val request = CredentialOfferRequest(uri).getOrThrow()
         resolve(request).getOrThrow()
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DPoP.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DPoP.kt
@@ -61,7 +61,7 @@ class DPoPJwtFactory(
         htu: URL,
         accessToken: AccessToken.DPoP? = null,
         nonce: Nonce? = null,
-    ): Result<SignedJWT> = runCatching {
+    ): Result<SignedJWT> = runCatchingCancellable {
         val jwtClaimsSet = DPoPUtils.createJWTClaimsSet(
             jti(),
             htm.name,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
@@ -122,7 +122,7 @@ interface DeferredIssuer : QueryForDeferredCredential {
             ctx: DeferredIssuanceContext,
             httpClient: HttpClient,
             responseEncryptionKey: JWK?,
-        ): Result<Pair<DeferredIssuanceContext?, DeferredCredentialQueryOutcome>> = runCatching {
+        ): Result<Pair<DeferredIssuanceContext?, DeferredCredentialQueryOutcome>> = runCatchingCancellable {
             val deferredIssuer = make(ctx.config, responseEncryptionKey, httpClient).getOrThrow()
             val (newAuthorized, outcome) = with(deferredIssuer) {
                 with(ctx.authorizedTransaction.authorizedRequest) {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
@@ -277,7 +277,7 @@ interface Issuer :
             httpClient: HttpClient,
             requestEncryptionSpecFactory: RequestEncryptionSpecFactory = RequestEncryptionSpecFactory.DEFAULT,
             responseEncryptionSpecFactory: ResponseEncryptionSpecFactory = ResponseEncryptionSpecFactory.DEFAULT,
-        ): Result<Issuer> = runCatching {
+        ): Result<Issuer> = runCatchingCancellable {
             val credentialOfferRequestResolver = CredentialOfferRequestResolver(httpClient, config.issuerMetadataPolicy)
             val credentialOffer = credentialOfferRequestResolver.resolve(credentialOfferUri).getOrThrow()
             make(config, credentialOffer, httpClient, requestEncryptionSpecFactory, responseEncryptionSpecFactory).getOrThrow()
@@ -307,7 +307,7 @@ interface Issuer :
             httpClient: HttpClient,
             requestEncryptionSpecFactory: RequestEncryptionSpecFactory = RequestEncryptionSpecFactory.DEFAULT,
             responseEncryptionSpecFactory: ResponseEncryptionSpecFactory = ResponseEncryptionSpecFactory.DEFAULT,
-        ): Result<Issuer> = runCatching {
+        ): Result<Issuer> = runCatchingCancellable {
             require(credentialConfigurationIdentifiers.isNotEmpty()) {
                 "At least one credential configuration identifier must be specified"
             }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/QueryForDeferredCredential.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/QueryForDeferredCredential.kt
@@ -82,7 +82,7 @@ fun interface QueryForDeferredCredential {
 
             override suspend fun AuthorizedRequest.queryForDeferredCredential(
                 transactionId: TransactionId,
-            ): Result<AuthorizedRequestAnd<DeferredCredentialQueryOutcome>> = runCatching {
+            ): Result<AuthorizedRequestAnd<DeferredCredentialQueryOutcome>> = runCatchingCancellable {
                 val refreshed = refreshIfNeeded(this)
                 val (outcome, newResourceServerDpopNonce) = placeDeferredCredentialRequest(refreshed, transactionId)
                 refreshed.withResourceServerDpopNonce(newResourceServerDpopNonce) to outcome

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Util.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Util.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.openid4vci
+
+import kotlinx.coroutines.CancellationException
+
+internal inline fun <R> runCatchingCancellable(block: () -> R): Result<R> {
+    return try {
+        Result.success(block())
+    } catch (ce: CancellationException) {
+        throw ce
+    } catch (e: Throwable) {
+        Result.failure(e)
+    }
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/AuthorizeIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/AuthorizeIssuanceImpl.kt
@@ -39,7 +39,7 @@ internal class AuthorizeIssuanceImpl(
 ) : AuthorizeIssuance {
 
     override suspend fun prepareAuthorizationRequest(walletState: String?): Result<AuthorizationRequestPrepared> =
-        runCatching {
+        runCatchingCancellable {
             requireNotNull(authorizationEndpointClient) {
                 "Authorization server does not support Authorization Code Flow"
             }
@@ -84,7 +84,7 @@ internal class AuthorizeIssuanceImpl(
         authorizationCode: AuthorizationCode,
         serverState: String,
         authDetailsOption: AccessTokenOption,
-    ): Result<AuthorizedRequest> = runCatching {
+    ): Result<AuthorizedRequest> = runCatchingCancellable {
         ensure(serverState == state) { InvalidAuthorizationState() }
         val credConfigIdsAsAuthDetails = identifiersSentAsAuthDetails.filter(authDetailsOption)
         val (tokenResponse, newDpopNonce) =
@@ -109,7 +109,7 @@ internal class AuthorizeIssuanceImpl(
     override suspend fun authorizeWithPreAuthorizationCode(
         txCode: String?,
         authDetailsOption: AccessTokenOption,
-    ): Result<AuthorizedRequest> = runCatching {
+    ): Result<AuthorizedRequest> = runCatchingCancellable {
         val offeredGrants = requireNotNull(credentialOffer.grants) {
             "Grant not specified in credential offer."
         }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/DefaultAuthorizationServerMetadataResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/DefaultAuthorizationServerMetadataResolver.kt
@@ -21,6 +21,7 @@ import eu.europa.ec.eudi.openid4vci.AuthorizationServerMetadataResolutionExcepti
 import eu.europa.ec.eudi.openid4vci.AuthorizationServerMetadataResolver
 import eu.europa.ec.eudi.openid4vci.CIAuthorizationServerMetadata
 import eu.europa.ec.eudi.openid4vci.HttpsUrl
+import eu.europa.ec.eudi.openid4vci.runCatchingCancellable
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
@@ -40,7 +41,7 @@ internal class DefaultAuthorizationServerMetadataResolver(
      * The well-known location __/.well-known/oauth-authorization-server__ is used.
      */
     private suspend fun fetchOauthServerMetadata(issuer: HttpsUrl): Result<CIAuthorizationServerMetadata> =
-        runCatching {
+        runCatchingCancellable {
             val url = issuer.wellKnownUrl(
                 wellKnownPath = "/.well-known/oauth-authorization-server",
             )

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/DefaultCredentialIssuerMetadataResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/DefaultCredentialIssuerMetadataResolver.kt
@@ -45,7 +45,7 @@ internal class DefaultCredentialIssuerMetadataResolver(
     override suspend fun resolve(
         issuer: CredentialIssuerId,
         policy: IssuerMetadataPolicy,
-    ): Result<CredentialIssuerMetadata> = runCatching {
+    ): Result<CredentialIssuerMetadata> = runCatchingCancellable {
         val wellKnownUrl = issuer.wellKnown()
         val json = when (policy) {
             IssuerMetadataPolicy.IgnoreSigned -> wellKnownUrl.requestUnsigned()
@@ -107,7 +107,7 @@ internal class DefaultCredentialIssuerMetadataResolver(
         jwt: String,
         issuerTrust: IssuerTrust,
         issuer: CredentialIssuerId,
-    ): Result<String> = runCatching {
+    ): Result<String> = runCatchingCancellable {
         val signedJwt = SignedJWT.parse(jwt)
         val processor = DefaultJWTProcessor<SecurityContext>()
             .apply {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/DefaultCredentialOfferRequestResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/DefaultCredentialOfferRequestResolver.kt
@@ -84,7 +84,7 @@ internal class DefaultCredentialOfferRequestResolver(
     private val httpClient: HttpClient,
     private val issuerMetadataPolicy: IssuerMetadataPolicy,
 ) : CredentialOfferRequestResolver {
-    override suspend fun resolve(request: CredentialOfferRequest): Result<CredentialOffer> = runCatching {
+    override suspend fun resolve(request: CredentialOfferRequest): Result<CredentialOffer> = runCatchingCancellable {
         val credentialOffer = fetchOffer(request)
         val credentialIssuerId = CredentialIssuerId(credentialOffer.credentialIssuerIdentifier)
             .getOrElse { CredentialOfferRequestValidationError.InvalidCredentialIssuerId(it).raise() }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RefreshAccessToken.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RefreshAccessToken.kt
@@ -17,6 +17,7 @@ package eu.europa.ec.eudi.openid4vci.internal
 
 import eu.europa.ec.eudi.openid4vci.AuthorizedRequest
 import eu.europa.ec.eudi.openid4vci.internal.http.TokenEndpointClient
+import eu.europa.ec.eudi.openid4vci.runCatchingCancellable
 import java.time.Clock
 
 internal class RefreshAccessToken(
@@ -24,7 +25,7 @@ internal class RefreshAccessToken(
     private val tokenEndpointClient: TokenEndpointClient,
 ) {
 
-    suspend fun AuthorizedRequest.refreshIfNeeded(): Result<AuthorizedRequest> = runCatching {
+    suspend fun AuthorizedRequest.refreshIfNeeded(): Result<AuthorizedRequest> = runCatchingCancellable {
         val at = clock.instant()
         when {
             !isAccessTokenExpired(at) -> this

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -51,7 +51,7 @@ internal class RequestIssuanceImpl(
     override suspend fun AuthorizedRequest.request(
         requestPayload: IssuanceRequestPayload,
         proofsSpecification: ProofsSpecification,
-    ): Result<AuthorizedRequestAnd<SubmissionOutcome>> = runCatching {
+    ): Result<AuthorizedRequestAnd<SubmissionOutcome>> = runCatchingCancellable {
         val (proofs, proofsDpopNonce) = buildProofs(proofsSpecification, requestPayload.credentialConfigurationIdentifier, grant)
         val credentialRequest = buildRequest(requestPayload, proofs, credentialIdentifiers.orEmpty())
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/AuthorizationEndpointClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/AuthorizationEndpointClient.kt
@@ -149,7 +149,7 @@ internal class AuthorizationEndpointClient(
         credentialsConfigurationIds: List<CredentialConfigurationIdentifier>,
         state: String,
         issuerState: String?,
-    ): Result<Triple<PKCEVerifier, HttpsUrl, Nonce?>> = runCatching {
+    ): Result<Triple<PKCEVerifier, HttpsUrl, Nonce?>> = runCatchingCancellable {
         require(scopes.isNotEmpty() || credentialsConfigurationIds.isNotEmpty()) {
             "No scopes or authorization details provided. Cannot submit par."
         }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/ChallengeEndpointClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/ChallengeEndpointClient.kt
@@ -17,6 +17,7 @@ package eu.europa.ec.eudi.openid4vci.internal.http
 
 import eu.europa.ec.eudi.openid4vci.AttestationBasedClientAuthenticationSpec
 import eu.europa.ec.eudi.openid4vci.Nonce
+import eu.europa.ec.eudi.openid4vci.runCatchingCancellable
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.expectSuccess
@@ -32,7 +33,7 @@ internal class ChallengeEndpointClient(
     private val challengeEndpoint: URL,
     private val httpClient: HttpClient,
 ) {
-    suspend fun getChallenge(): Result<Nonce> = runCatching {
+    suspend fun getChallenge(): Result<Nonce> = runCatchingCancellable {
         val challenge = httpClient.post(challengeEndpoint) {
             expectSuccess = true
             accept(ContentType.Application.Json)

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialEndpointClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialEndpointClient.kt
@@ -60,7 +60,7 @@ internal class CredentialEndpointClient(
         resourceServerDpopNonce: Nonce?,
         request: CredentialIssuanceRequest,
     ): Result<Pair<SubmissionOutcomeInternal, Nonce?>> =
-        runCatching {
+        runCatchingCancellable {
             placeIssuanceRequestInternal(accessToken, resourceServerDpopNonce, request, false)
         }
 
@@ -129,7 +129,7 @@ internal class DeferredEndPointClient(
         transactionId: TransactionId,
         exchangeEncryptionSpecification: ExchangeEncryptionSpecification,
     ): Result<Pair<DeferredCredentialQueryOutcome, Nonce?>> =
-        runCatching {
+        runCatchingCancellable {
             placeDeferredCredentialRequestInternal(
                 accessToken,
                 resourceServerDpopNonce,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/NonceEndpointClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/NonceEndpointClient.kt
@@ -18,6 +18,7 @@ package eu.europa.ec.eudi.openid4vci.internal.http
 import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError
 import eu.europa.ec.eudi.openid4vci.CredentialIssuerEndpoint
 import eu.europa.ec.eudi.openid4vci.Nonce
+import eu.europa.ec.eudi.openid4vci.runCatchingCancellable
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
@@ -38,7 +39,7 @@ internal class NonceEndpointClient(
 ) {
 
     suspend fun getNonce(): Result<CNonceAndDPoPNonce> =
-        runCatching {
+        runCatchingCancellable {
             requestNonce()
         }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/NotificationEndPointClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/NotificationEndPointClient.kt
@@ -33,7 +33,7 @@ internal class NotificationEndPointClient(
         resourceServerDpopNonce: Nonce?,
         event: CredentialIssuanceEvent,
     ): Result<Nonce?> =
-        runCatching {
+        runCatchingCancellable {
             notifyIssuerInternal(accessToken, resourceServerDpopNonce, event, false)
         }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/TokenEndpointClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/TokenEndpointClient.kt
@@ -140,7 +140,7 @@ internal class TokenEndpointClient(
         pkceVerifier: PKCEVerifier,
         credConfigIdsAsAuthDetails: List<CredentialConfigurationIdentifier> = emptyList(),
         dpopNonce: Nonce?,
-    ): Result<Pair<TokenResponse, Nonce?>> = runCatching {
+    ): Result<Pair<TokenResponse, Nonce?>> = runCatchingCancellable {
         // Append authorization_details form param if needed
         val authDetails = credConfigIdsAsAuthDetails.takeIf { it.isNotEmpty() }?.let {
             authorizationDetailsFormParam(credConfigIdsAsAuthDetails)
@@ -171,7 +171,7 @@ internal class TokenEndpointClient(
         txCode: String?,
         credConfigIdsAsAuthDetails: List<CredentialConfigurationIdentifier> = emptyList(),
         dpopNonce: Nonce?,
-    ): Result<Pair<TokenResponse, Nonce?>> = runCatching {
+    ): Result<Pair<TokenResponse, Nonce?>> = runCatchingCancellable {
         // Append authorization_details form param if needed
         val authDetails = credConfigIdsAsAuthDetails.takeIf { it.isNotEmpty() }?.let {
             authorizationDetailsFormParam(credConfigIdsAsAuthDetails)

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/TokenEndpointClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/TokenEndpointClient.kt
@@ -197,7 +197,7 @@ internal class TokenEndpointClient(
     suspend fun refreshAccessToken(
         refreshToken: RefreshToken,
         dpopNonce: Nonce?,
-    ): Result<Pair<TokenResponse, Nonce?>> = runCatching {
+    ): Result<Pair<TokenResponse, Nonce?>> = runCatchingCancellable {
         val params = TokenEndpointForm.refreshAccessToken(clientAuthentication.id, refreshToken)
         placeTokenRequest(params, dpopNonce)
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/DeferredIssuerExtensions.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/DeferredIssuerExtensions.kt
@@ -37,7 +37,7 @@ suspend fun DeferredIssuer.Companion.queryForDeferredCredential(
     recreateClientAttestationPodSigner: ((String) -> Signer<JWK>)? = null,
     httpClient: HttpClient,
     responseEncryptionKey: JWK? = null,
-): Result<Pair<DeferredIssuanceStoredContextTO?, DeferredCredentialQueryOutcome>> = runCatching {
+): Result<Pair<DeferredIssuanceStoredContextTO?, DeferredCredentialQueryOutcome>> = runCatchingCancellable {
     val ctx = ctxTO.toDeferredIssuanceStoredContext(clock, recreatePopSigner, recreateClientAttestationPodSigner)
     val (newCtx, outcome) = queryForDeferredCredential(ctx, httpClient, responseEncryptionKey).getOrThrow()
     val newCtxTO =


### PR DESCRIPTION
This PR replaces usages of `runCatching` in suspend functions with `runCatchingCancellable`. `runCatchingCancellable` is a variant of `runCatching` that always propagates `CancellationException` to the caller.

Closes #437 