### PR TITLE
Ignore `ContentType` parameters when checking the `ContentType` during Credential Issuer Metadata resolution

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/DefaultCredentialIssuerMetadataResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/DefaultCredentialIssuerMetadataResolver.kt
@@ -58,7 +58,7 @@ internal class DefaultCredentialIssuerMetadataResolver(
     private suspend fun Url.requestUnsigned(): String {
         val response = getAcceptingContentTypes(ContentType.Application.Json)
         val contentType = response.headers[HttpHeaders.ContentType]?.let { ContentType.parse(it) }
-        require(contentType == ContentType.Application.Json) {
+        require(contentType?.withoutParameters() == ContentType.Application.Json) {
             "Credential issuer responded with invalid content type: " +
                 "expected ${ContentType.Application.Json} but was $contentType"
         }
@@ -68,7 +68,7 @@ internal class DefaultCredentialIssuerMetadataResolver(
     private suspend fun Url.requestSigned(issuerTrust: IssuerTrust, issuer: CredentialIssuerId): String {
         val response = getAcceptingContentTypes(CONTENT_TYPE_APPLICATION_JWT)
         val contentType = response.headers[HttpHeaders.ContentType]?.let { ContentType.parse(it) }
-        ensure(contentType == CONTENT_TYPE_APPLICATION_JWT) {
+        ensure(contentType?.withoutParameters() == CONTENT_TYPE_APPLICATION_JWT) {
             CredentialIssuerMetadataError.MissingSignedMetadata()
         }
         return parseAndVerifySignedMetadata(response.body<String>(), issuerTrust, issuer)
@@ -82,7 +82,7 @@ internal class DefaultCredentialIssuerMetadataResolver(
         val contentType = response.headers[HttpHeaders.ContentType]?.let { ContentType.parse(it) }
         requireNotNull(contentType) { "Credential issuer did not respond with a content type header" }
 
-        return when (contentType) {
+        return when (contentType.withoutParameters()) {
             CONTENT_TYPE_APPLICATION_JWT -> parseAndVerifySignedMetadata(
                 jwt = response.body<String>(),
                 issuerTrust = issuerTrust,

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/RequestMockers.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/RequestMockers.kt
@@ -64,15 +64,17 @@ internal fun oauthMetaDataHandler(oauth2ServerUrl: HttpsUrl, oauth2MetaDataResou
 
 internal fun credentialIssuerMetadataWellKnownMocker(
     issuerMetadataVersion: IssuerMetadataVersion = ENCRYPTION_NOT_SUPPORTED,
+    contentType: ContentType = ContentType.Application.Json,
 ): RequestMocker = RequestMocker(
     requestMatcher = endsWith("/.well-known/openid-credential-issuer", HttpMethod.Get),
     responseBuilder = {
+        require(contentType.withoutParameters() == ContentType.Application.Json) { "contentType must be application/json" }
         val content = issuerMetadataJsonContent(issuerMetadataVersion)
         respond(
             content = content,
             status = HttpStatusCode.OK,
             headers = headersOf(
-                HttpHeaders.ContentType to listOf("application/json"),
+                HttpHeaders.ContentType to listOf(contentType.toString()),
             ),
         )
     },

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/DefaultCredentialOfferRequestResolverTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/DefaultCredentialOfferRequestResolverTest.kt
@@ -29,10 +29,13 @@ import kotlin.test.assertNull
 internal class DefaultCredentialOfferRequestResolverTest {
 
     @Test
-    fun `resolve a credential offer passed by value that contains a pre-authorized code grant without transaction code`() =
-        runTest {
+    fun `resolve a credential offer passed by value that contains a pre-authorized code grant without transaction code`() = runTest {
+        suspend fun test(credentialIssuerMetadataContentType: ContentType) {
             val httpClient =
-                mockedHttpClient(credentialIssuerMetadataWellKnownMocker(), authServerWellKnownMocker())
+                mockedHttpClient(
+                    credentialIssuerMetadataWellKnownMocker(contentType = credentialIssuerMetadataContentType),
+                    authServerWellKnownMocker(),
+                )
             val resolver = DefaultCredentialOfferRequestResolver(httpClient, IssuerMetadataPolicy.IgnoreSigned)
             val credentialOfferJson =
                 """
@@ -72,11 +75,18 @@ internal class DefaultCredentialOfferRequestResolverTest {
             assertNull(preAuthorizedCode.txCode)
         }
 
+        test(ContentType.Application.Json)
+        test(ContentType.Application.Json.withCharset(Charsets.UTF_8))
+    }
+
     @Test
-    fun `resolve a credential offer passed by value that contains a pre-authorized code grant with transaction code`() =
-        runTest {
+    fun `resolve a credential offer passed by value that contains a pre-authorized code grant with transaction code`() = runTest {
+        suspend fun test(credentialIssuerMetadataContentType: ContentType) {
             val httpClient =
-                mockedHttpClient(credentialIssuerMetadataWellKnownMocker(), authServerWellKnownMocker())
+                mockedHttpClient(
+                    credentialIssuerMetadataWellKnownMocker(contentType = credentialIssuerMetadataContentType),
+                    authServerWellKnownMocker(),
+                )
             val resolver = DefaultCredentialOfferRequestResolver(httpClient, IssuerMetadataPolicy.IgnoreSigned)
             val credentialOfferJson =
                 """
@@ -123,4 +133,8 @@ internal class DefaultCredentialOfferRequestResolverTest {
             assertEquals(TxCodeInputMode.NUMERIC, txCode.inputMode)
             assertEquals(5, txCode.length)
         }
+
+        test(ContentType.Application.Json)
+        test(ContentType.Application.Json.withCharset(Charsets.UTF_8))
+    }
 }


### PR DESCRIPTION
During Credential Issuer Metadata resolution we check the `ContentType` of the response to determine whether the Credential Issuer responded with signed or unsigned Metadata.

As is, we consider all parameters during this check, meaning that we discard valid values like `application/json; charset=utf-8`.

This PR updates all affected check and ignores all `ContentType` parameters. We only care about the *base* `ContentType`.

Closes #476 