### PR TITLE
Improve guards around illegal states when using DPoP

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DPoP.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DPoP.kt
@@ -165,7 +165,7 @@ class DPoPJwtFactory(
  * Utility method to be used to set properly the DPoP header on the request under construction, targeted on the URL passed as [htu].
  * Based on the passed [accessToken] DPoP header will be added if it is of type DPoP.
  */
-fun HttpRequestBuilder.bearerOrDPoPAuth(
+internal fun HttpRequestBuilder.bearerOrDPoPAuth(
     accessToken: AccessToken,
     dpopJwt: String?,
 ) {
@@ -173,13 +173,11 @@ fun HttpRequestBuilder.bearerOrDPoPAuth(
         is AccessToken.Bearer -> {
             bearerAuth(accessToken)
         }
+
         is AccessToken.DPoP -> {
-            if (dpopJwt != null) {
-                header(DPoP, dpopJwt)
-                dpopAuth(accessToken)
-            } else {
-                bearerAuth(AccessToken.Bearer(accessToken.accessToken, accessToken.expiresIn))
-            }
+            checkNotNull(dpopJwt) { "dpopJwt must be provided when using DPoP access tokens" }
+            dpopAuth(accessToken)
+            header(DPoP, dpopJwt)
         }
     }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DPoP.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DPoP.kt
@@ -162,25 +162,38 @@ class DPoPJwtFactory(
 }
 
 /**
- * Utility method to be used to set properly the DPoP header on the request under construction, targeted on the URL passed as [htu].
+ * Utility method to be used to set properly the DPoP header on the request under construction, targeted on the URL passed as.
  * Based on the passed [accessToken] DPoP header will be added if it is of type DPoP.
  */
-internal fun HttpRequestBuilder.bearerOrDPoPAuth(
-    accessToken: AccessToken,
-    dpopJwt: String?,
-) {
+internal suspend fun HttpRequestBuilder.bearerOrDPoPAuth(accessToken: AccessToken, dPoPJwtFactory: DPoPJwtFactory?, dPoPNonce: Nonce?) {
     when (accessToken) {
         is AccessToken.Bearer -> {
             bearerAuth(accessToken)
         }
 
         is AccessToken.DPoP -> {
-            checkNotNull(dpopJwt) { "dpopJwt must be provided when using DPoP access tokens" }
+            checkNotNull(dPoPJwtFactory) { "dPoPJwtFactory is required when using DPoP access tokens" }
+            val dPoPProof = dPoPJwtFactory.createDPoPJwt(method.htm, url.build().toURI().toURL(), accessToken, dPoPNonce)
+                .getOrThrow()
+                .serialize()
             dpopAuth(accessToken)
-            header(DPoP, dpopJwt)
+            header(DPoP, dPoPProof)
         }
     }
 }
+
+private val HttpMethod.htm: Htm
+    get() = when (this) {
+        HttpMethod.Get -> Htm.GET
+        HttpMethod.Head -> Htm.HEAD
+        HttpMethod.Post -> Htm.POST
+        HttpMethod.Put -> Htm.PUT
+        HttpMethod.Delete -> Htm.DELETE
+        HttpMethod("CONNECT") -> Htm.CONNECT
+        HttpMethod.Options -> Htm.OPTIONS
+        HttpMethod("TRACE") -> Htm.TRACE
+        else -> throw IllegalArgumentException("Unsupported HTTP method: $this")
+    }
 
 private fun HttpRequestBuilder.dpopAuth(accessToken: AccessToken.DPoP) {
     header(HttpHeaders.Authorization, "$DPoP ${accessToken.accessToken}")

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
@@ -78,8 +78,10 @@ data class DeferredIssuanceContext(
     val authorizedTransaction: AuthorizedTransaction,
 ) {
     init {
-        require(authorizedTransaction.authorizedRequest.accessToken !is AccessToken.DPoP || null != config.dPoPSigner) {
-            "config.dPoPSigner is required when DPoP access tokens are used"
+        if (authorizedTransaction.authorizedRequest.accessToken !is AccessToken.DPoP) {
+            requireNotNull(config.dPoPSigner) {
+                "config.dPoPSigner is required when DPoP access tokens are used"
+            }
         }
     }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
@@ -76,7 +76,13 @@ data class AuthorizedTransaction(
 data class DeferredIssuanceContext(
     val config: DeferredIssuerConfig,
     val authorizedTransaction: AuthorizedTransaction,
-)
+) {
+    init {
+        require(authorizedTransaction.authorizedRequest.accessToken !is AccessToken.DPoP || null != config.dPoPSigner) {
+            "config.dPoPSigner is required when DPoP access tokens are used"
+        }
+    }
+}
 
 /**
  * A specialized issuer with the capability to [QueryForDeferredCredential]

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialEndpointClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialEndpointClient.kt
@@ -70,20 +70,19 @@ internal class CredentialEndpointClient(
         request: CredentialIssuanceRequest,
         retried: Boolean,
     ): Pair<SubmissionOutcomeInternal, Nonce?> {
-        val url = credentialEndpoint.value
-        val dPoPProof = if (accessToken is AccessToken.DPoP) {
-            checkNotNull(dPoPJwtFactory) { "dPoPJwtFactory is required when using DPoP access tokens" }
-            dPoPJwtFactory.createDPoPJwt(Htm.POST, url, accessToken, resourceServerDpopNonce).getOrThrow().serialize()
-        } else null
-
-        val response = httpClient.post(url) {
-            bearerOrDPoPAuth(accessToken, dPoPProof)
-            encryptRequest(
-                requestTO = CredentialRequestTO.from(request),
-                requestEncryptionSpec = request.encryptionSpecs.requestEncryptionSpec,
-                transferObjectToJwtClaims = { CredentialRequestTO.toJwtClaimsSet(it) },
-            )
-        }
+        val response = httpClient.request(
+            HttpRequestBuilder()
+                .apply {
+                    method = HttpMethod.Post
+                    url.takeFrom(credentialEndpoint.value)
+                    bearerOrDPoPAuth(accessToken, dPoPJwtFactory, resourceServerDpopNonce)
+                    encryptRequest(
+                        requestTO = CredentialRequestTO.from(request),
+                        requestEncryptionSpec = request.encryptionSpecs.requestEncryptionSpec,
+                        transferObjectToJwtClaims = { CredentialRequestTO.toJwtClaimsSet(it) },
+                    )
+                },
+        )
 
         return if (response.status.isSuccess()) {
             val submissionOutcome = responsePossiblyEncrypted(
@@ -146,12 +145,6 @@ internal class DeferredEndPointClient(
         exchangeEncryptionSpecification: ExchangeEncryptionSpecification,
         retried: Boolean,
     ): Pair<DeferredCredentialQueryOutcome, Nonce?> {
-        val url = deferredCredentialEndpoint.value
-        val dPoPProof = if (accessToken is AccessToken.DPoP) {
-            checkNotNull(dPoPJwtFactory) { "dPoPJwtFactory is required when using DPoP access tokens" }
-            dPoPJwtFactory.createDPoPJwt(Htm.POST, url, accessToken, resourceServerDpopNonce).getOrThrow().serialize()
-        } else null
-
         val deferredRequestTO = DeferredRequestTO(
             transactionId = transactionId.value,
             credentialResponseEncryption = exchangeEncryptionSpecification.responseEncryptionSpec?.let {
@@ -159,14 +152,19 @@ internal class DeferredEndPointClient(
             },
         )
 
-        val response = httpClient.post(url) {
-            bearerOrDPoPAuth(accessToken, dPoPProof)
-            encryptRequest(
-                requestTO = deferredRequestTO,
-                requestEncryptionSpec = exchangeEncryptionSpecification.requestEncryptionSpec,
-                transferObjectToJwtClaims = { DeferredRequestTO.toJwtClaimsSet(it) },
-            )
-        }
+        val response = httpClient.request(
+            HttpRequestBuilder()
+                .apply {
+                    method = HttpMethod.Post
+                    url.takeFrom(deferredCredentialEndpoint.value)
+                    bearerOrDPoPAuth(accessToken, dPoPJwtFactory, resourceServerDpopNonce)
+                    encryptRequest(
+                        requestTO = deferredRequestTO,
+                        requestEncryptionSpec = exchangeEncryptionSpecification.requestEncryptionSpec,
+                        transferObjectToJwtClaims = { DeferredRequestTO.toJwtClaimsSet(it) },
+                    )
+                },
+        )
 
         return if (response.status.isSuccess()) {
             val outcome =

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialEndpointClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialEndpointClient.kt
@@ -71,13 +71,13 @@ internal class CredentialEndpointClient(
         retried: Boolean,
     ): Pair<SubmissionOutcomeInternal, Nonce?> {
         val url = credentialEndpoint.value
-        val jwt = if (accessToken is AccessToken.DPoP && dPoPJwtFactory != null) {
-            dPoPJwtFactory.createDPoPJwt(Htm.POST, url, accessToken, resourceServerDpopNonce).getOrThrow()
-                .serialize()
+        val dPoPProof = if (accessToken is AccessToken.DPoP) {
+            checkNotNull(dPoPJwtFactory) { "dPoPJwtFactory is required when using DPoP access tokens" }
+            dPoPJwtFactory.createDPoPJwt(Htm.POST, url, accessToken, resourceServerDpopNonce).getOrThrow().serialize()
         } else null
 
         val response = httpClient.post(url) {
-            bearerOrDPoPAuth(accessToken, jwt)
+            bearerOrDPoPAuth(accessToken, dPoPProof)
             encryptRequest(
                 requestTO = CredentialRequestTO.from(request),
                 requestEncryptionSpec = request.encryptionSpecs.requestEncryptionSpec,
@@ -147,9 +147,9 @@ internal class DeferredEndPointClient(
         retried: Boolean,
     ): Pair<DeferredCredentialQueryOutcome, Nonce?> {
         val url = deferredCredentialEndpoint.value
-        val jwt = if (accessToken is AccessToken.DPoP && dPoPJwtFactory != null) {
-            dPoPJwtFactory.createDPoPJwt(Htm.POST, url, accessToken, resourceServerDpopNonce).getOrThrow()
-                .serialize()
+        val dPoPProof = if (accessToken is AccessToken.DPoP) {
+            checkNotNull(dPoPJwtFactory) { "dPoPJwtFactory is required when using DPoP access tokens" }
+            dPoPJwtFactory.createDPoPJwt(Htm.POST, url, accessToken, resourceServerDpopNonce).getOrThrow().serialize()
         } else null
 
         val deferredRequestTO = DeferredRequestTO(
@@ -160,7 +160,7 @@ internal class DeferredEndPointClient(
         )
 
         val response = httpClient.post(url) {
-            bearerOrDPoPAuth(accessToken, jwt)
+            bearerOrDPoPAuth(accessToken, dPoPProof)
             encryptRequest(
                 requestTO = deferredRequestTO,
                 requestEncryptionSpec = exchangeEncryptionSpecification.requestEncryptionSpec,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/NotificationEndPointClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/NotificationEndPointClient.kt
@@ -44,13 +44,13 @@ internal class NotificationEndPointClient(
         retried: Boolean,
     ): Nonce? {
         val url = notificationEndpoint.value
-        val jwt = if (accessToken is AccessToken.DPoP && dPoPJwtFactory != null) {
-            dPoPJwtFactory.createDPoPJwt(Htm.POST, url, accessToken, resourceServerDpopNonce).getOrThrow()
-                .serialize()
+        val dPoPProof = if (accessToken is AccessToken.DPoP) {
+            checkNotNull(dPoPJwtFactory) { "dPoPJwtFactory is required when using DPoP access tokens" }
+            dPoPJwtFactory.createDPoPJwt(Htm.POST, url, accessToken, resourceServerDpopNonce).getOrThrow().serialize()
         } else null
 
         val response = httpClient.post(url) {
-            bearerOrDPoPAuth(accessToken, jwt)
+            bearerOrDPoPAuth(accessToken, dPoPProof)
             contentType(ContentType.Application.Json)
             setBody(NotificationTO.from(event))
         }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/NotificationEndPointClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/NotificationEndPointClient.kt
@@ -43,17 +43,16 @@ internal class NotificationEndPointClient(
         event: CredentialIssuanceEvent,
         retried: Boolean,
     ): Nonce? {
-        val url = notificationEndpoint.value
-        val dPoPProof = if (accessToken is AccessToken.DPoP) {
-            checkNotNull(dPoPJwtFactory) { "dPoPJwtFactory is required when using DPoP access tokens" }
-            dPoPJwtFactory.createDPoPJwt(Htm.POST, url, accessToken, resourceServerDpopNonce).getOrThrow().serialize()
-        } else null
-
-        val response = httpClient.post(url) {
-            bearerOrDPoPAuth(accessToken, dPoPProof)
-            contentType(ContentType.Application.Json)
-            setBody(NotificationTO.from(event))
-        }
+        val response = httpClient.request(
+            HttpRequestBuilder()
+                .apply {
+                    method = HttpMethod.Post
+                    url.takeFrom(notificationEndpoint.value)
+                    bearerOrDPoPAuth(accessToken, dPoPJwtFactory, resourceServerDpopNonce)
+                    contentType(ContentType.Application.Json)
+                    setBody(NotificationTO.from(event))
+                },
+        )
 
         return if (response.status.isSuccess()) {
             response.dpopNonce() ?: resourceServerDpopNonce

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
@@ -667,9 +667,13 @@ class IssuanceSingleRequestTest {
         val mockedKtorHttpClientFactory = mockedHttpClient(
             credentialIssuerMetadataWellKnownMocker(),
             authServerWellKnownMocker(AuthServerMetadataVersion.NO_DPOP),
-            parPostMocker(),
+            parPostMocker {
+                assertNull(it.headers["DPoP"])
+            },
             nonceEndpointMocker(),
-            tokenPostMocker(dpopAccessToken = true),
+            tokenPostMocker(dpopAccessToken = false) {
+                assertNull(it.headers["DPoP"])
+            },
             singleIssuanceRequestMocker(
                 requestValidator = {
                     val headers = it.headers


### PR DESCRIPTION
Closes #507 

This PR:
1. Updates the above clients to check that a `DPoPJwtFactory` is configured when using DPoP Access Tokens
2. Updates `HttpRequestBuilder.bearerOrDPoPAuth()` to check that a DPoP Proof is used when a DPoP Access Token has been provided, instead of silently falling back to sending the DPoP Access Token as a Bearer Token.
3. Marks `HttpRequestBuilder.bearerOrDPoPAuth()` as internal.
4. Updates `DeferredIssuanceContext` to ensure that a DPoP Signer is provided when the used Access Token is DPoP.
