### PR TITLE
Add an option for a Wallet to configure supported Proof types

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,7 +639,14 @@ val openId4VCIConfig = OpenId4VCIConfig(
         rsaConfig =  RsaConfig(rcaKeySize = 4096, supportedJWEAlgorithms = RSAEncrypter.SUPPORTED_ALGORITHMS.toList()), // the RSA key size and JWE algorithms supported
         supportedEncryptionMethods = ContentCryptoProvider.SUPPORTED_ENCRYPTION_METHODS.toList() // which JWE encryption methods are supported
     ),
-    supportedReuseMethods = setOf(ReuseMethod.ONCE_ONLY, ReuseMethod.LIMITED_TIME) // which reuse methods are supported
+    supportedReuseMethods = setOf(ReuseMethod.ONCE_ONLY, ReuseMethod.LIMITED_TIME), // which reuse methods are supported
+    proofs = ProofsConfig(
+        supportsNonDeviceBound = true,
+        deviceBound = DeviceBound(
+            algorithms = setOf(JWSAlgorithm.ES256, JWSAlgorithm.ES384, JWSAlgorithm.ES512),
+            proofs = setOf(Proof.JwtProofWithKeyAttestation, Proof.AttestationProof),
+        ),
+    ), //which proof types and signing algorithms are supported
 )
 val credentialOfferUri: String = "..." 
 val issuer = Issuer.make(openId4VCIConfig, credentialOfferUri).getOrThrow()

--- a/README.md
+++ b/README.md
@@ -598,6 +598,7 @@ data class OpenId4VCIConfig(
     val clock: Clock = Clock.systemDefaultZone(),
     val issuerMetadataPolicy: IssuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
     val supportedReuseMethods: Set<ReuseMethod> = emptySet(),
+    val proofs: ProofsConfig, 
 )
 ```
 
@@ -618,6 +619,7 @@ Options available:
   - `IssuerMetadataPolicy.PreferSigned`: presence of signed metadata is optional, if present values from signed metadata take precedence
   - `IssuerMetadataPolicy.IgnoreSigned`: signed metadata are ignored
 - supportedReuseMethods: A set of `ReuseMethod`s supported by the wallet for credential reuse. Defaults to `emptySet()`.
+- proofs: Proofs types supported by the Wallet. Wallet can choose whether to support non-device-bound attestations, and device-bound attestations alongside the supported proof types. 
 
 Trust between the Wallet and the Signer of the signed metadata advertised by the Credential Issuer is established using one of the following ways:
 - `IssuerTrust.ByPublicKey`: trusting the public key used to sign the metadata

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
@@ -104,8 +104,7 @@ data class OpenId4VCIConfig(
 ) {
 
     /**
-     * Creates a new [OpenId4VCIConfig] instance for a Wallet that uses [a Public OAuth 2.0 Client][ClientAuthentication.None], and all
-     * [Proof Types][ProofsConfig].
+     * Creates a new [OpenId4VCIConfig] instance for a Wallet that uses [a Public OAuth 2.0 Client][ClientAuthentication.None].
      */
     constructor(
         clientId: ClientId,
@@ -117,6 +116,7 @@ data class OpenId4VCIConfig(
         clock: Clock = Clock.systemDefaultZone(),
         issuerMetadataPolicy: IssuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
         supportedCredentialReusePolicies: CredentialReusePolicies? = null,
+        proofs: ProofsConfig,
     ) : this(
         ClientAuthentication.None(clientId, dPoPUsage),
         authFlowRedirectionURI,
@@ -126,7 +126,7 @@ data class OpenId4VCIConfig(
         clock,
         issuerMetadataPolicy,
         supportedCredentialReusePolicies,
-        ProofsConfig.All,
+        proofs,
     )
 }
 
@@ -338,18 +338,6 @@ data class ProofsConfig(
     val supportsDeviceBound: Boolean
         get() = null != deviceBound
 
-    companion object {
-        val All: ProofsConfig = ProofsConfig(
-            supportsNonDeviceBound = true,
-            deviceBound = DeviceBound(
-                null,
-                DeviceBound.Proof.JwtProofWithoutKeyAttestation,
-                DeviceBound.Proof.JwtProofWithKeyAttestation,
-                DeviceBound.Proof.AttestationProof,
-            ),
-        )
-    }
-
     /**
      * The Proofs a Wallet supports for device-bound attestations.
      *
@@ -357,13 +345,11 @@ data class ProofsConfig(
      * @property proofs The Proofs the Wallet supports for device-bound attestations.
      */
     data class DeviceBound(
-        val algorithms: Set<JWSAlgorithm>?,
+        val algorithms: Set<JWSAlgorithm>,
         val proofs: Set<Proof>,
     ) {
-        constructor(algorithms: Set<JWSAlgorithm>?, proof: Proof, vararg proofs: Proof) : this(algorithms, setOf(proof, *proofs))
-
         init {
-            require(null == algorithms || algorithms.isNotEmpty()) { "At least one algorithm must be supported" }
+            require(algorithms.isNotEmpty()) { "At least one algorithm must be supported" }
             require(proofs.isNotEmpty()) { "At least one proof must be supported" }
         }
 
@@ -373,4 +359,6 @@ data class ProofsConfig(
             data object AttestationProof : Proof
         }
     }
+
+    companion object
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
@@ -18,6 +18,7 @@ package eu.europa.ec.eudi.openid4vci
 import com.nimbusds.jose.CompressionAlgorithm
 import com.nimbusds.jose.EncryptionMethod
 import com.nimbusds.jose.JWEAlgorithm
+import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.crypto.ECDHEncrypter
 import com.nimbusds.jose.crypto.impl.ContentCryptoProvider
 import com.nimbusds.jose.jwk.Curve
@@ -88,6 +89,7 @@ sealed interface ClientAuthentication : java.io.Serializable {
  * @param clock Wallet's clock
  * @param issuerMetadataPolicy policy concerning signed metadata usage
  * @param supportedCredentialReusePolicies the reuse policies supported by the wallet, used to validate against credential issuer metadata.
+ * @param proofs proofs supported by the Wallet
  */
 data class OpenId4VCIConfig(
     val clientAuthentication: ClientAuthentication,
@@ -98,10 +100,12 @@ data class OpenId4VCIConfig(
     val clock: Clock = Clock.systemDefaultZone(),
     val issuerMetadataPolicy: IssuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
     val supportedCredentialReusePolicies: CredentialReusePolicies? = null,
+    val proofs: ProofsConfig,
 ) {
 
     /**
-     * Creates a new [OpenId4VCIConfig] instance for a Wallet that uses [a Public OAuth 2.0 Client][ClientAuthentication.None].
+     * Creates a new [OpenId4VCIConfig] instance for a Wallet that uses [a Public OAuth 2.0 Client][ClientAuthentication.None], and all
+     * [Proof Types][ProofsConfig].
      */
     constructor(
         clientId: ClientId,
@@ -122,6 +126,7 @@ data class OpenId4VCIConfig(
         clock,
         issuerMetadataPolicy,
         supportedCredentialReusePolicies,
+        ProofsConfig.All,
     )
 }
 
@@ -316,4 +321,54 @@ sealed interface IssuerMetadataPolicy {
      * Signed metadata are ignored. Only values conveyed using plain json elements are used.
      */
     data object IgnoreSigned : IssuerMetadataPolicy
+}
+
+/**
+ * Wallet supported Proofs.
+ *
+ * A Wallet has to configure whether it supports non-device-bound attestations, as well as the Proofs supported for device-bound attestations.
+ *
+ * @property supportsDeviceBound Whether the Wallet supports non-device-bound attestations.
+ * @property deviceBound Whether the Wallet supports device-bound attestations, and the Proofs it supports.
+ */
+data class ProofsConfig(
+    val supportsNonDeviceBound: Boolean,
+    val deviceBound: DeviceBound?,
+) {
+    val supportsDeviceBound: Boolean
+        get() = null != deviceBound
+
+    companion object {
+        val All: ProofsConfig = ProofsConfig(
+            supportsNonDeviceBound = true,
+            deviceBound = DeviceBound(null, DeviceBound.Proof.entries.toSet()),
+        )
+
+        val None: ProofsConfig = ProofsConfig(
+            supportsNonDeviceBound = false,
+            deviceBound = null,
+        )
+    }
+
+    /**
+     * The Proofs a Wallet supports for device-bound attestations.
+     *
+     * @property algorithms The JWS Algorithms the Wallet supports for device-bound attestations. Set to *null* if the Wallet supports all algorithms.
+     * @property proofs The Proofs the Wallet supports for device-bound attestations.
+     */
+    data class DeviceBound(
+        val algorithms: Set<JWSAlgorithm>?,
+        val proofs: Set<Proof>,
+    ) {
+        init {
+            require(null == algorithms || algorithms.isNotEmpty()) { "At least one algorithm must be supported" }
+            require(proofs.isNotEmpty()) { "At least one proof must be supported" }
+        }
+
+        enum class Proof {
+            JwtProofWithoutKeyAttestation,
+            JwtProofWithKeyAttestation,
+            AttestationProof,
+        }
+    }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
@@ -341,7 +341,12 @@ data class ProofsConfig(
     companion object {
         val All: ProofsConfig = ProofsConfig(
             supportsNonDeviceBound = true,
-            deviceBound = DeviceBound(null, DeviceBound.Proof.entries.toSet()),
+            deviceBound = DeviceBound(
+                null,
+                DeviceBound.Proof.JwtProofWithoutKeyAttestation,
+                DeviceBound.Proof.JwtProofWithKeyAttestation,
+                DeviceBound.Proof.AttestationProof,
+            ),
         )
     }
 
@@ -355,15 +360,17 @@ data class ProofsConfig(
         val algorithms: Set<JWSAlgorithm>?,
         val proofs: Set<Proof>,
     ) {
+        constructor(algorithms: Set<JWSAlgorithm>?, proof: Proof, vararg proofs: Proof) : this(algorithms, setOf(proof, *proofs))
+
         init {
             require(null == algorithms || algorithms.isNotEmpty()) { "At least one algorithm must be supported" }
             require(proofs.isNotEmpty()) { "At least one proof must be supported" }
         }
 
-        enum class Proof {
-            JwtProofWithoutKeyAttestation,
-            JwtProofWithKeyAttestation,
-            AttestationProof,
+        sealed interface Proof {
+            data object JwtProofWithoutKeyAttestation : Proof
+            data object JwtProofWithKeyAttestation : Proof
+            data object AttestationProof : Proof
         }
     }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
@@ -343,11 +343,6 @@ data class ProofsConfig(
             supportsNonDeviceBound = true,
             deviceBound = DeviceBound(null, DeviceBound.Proof.entries.toSet()),
         )
-
-        val None: ProofsConfig = ProofsConfig(
-            supportsNonDeviceBound = false,
-            deviceBound = null,
-        )
     }
 
     /**

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
@@ -398,7 +398,12 @@ data class ProofsConfig(
     companion object {
         val All: ProofsConfig = ProofsConfig(
             supportsNonDeviceBound = true,
-            deviceBound = DeviceBound(null, DeviceBound.Proof.entries.toSet()),
+            deviceBound = DeviceBound(
+                null,
+                DeviceBound.Proof.JwtProofWithoutKeyAttestation,
+                DeviceBound.Proof.JwtProofWithKeyAttestation,
+                DeviceBound.Proof.AttestationProof,
+            ),
         )
     }
 
@@ -412,15 +417,17 @@ data class ProofsConfig(
         val algorithms: Set<JWSAlgorithm>?,
         val proofs: Set<Proof>,
     ) {
+        constructor(algorithms: Set<JWSAlgorithm>?, proof: Proof, vararg proofs: Proof) : this(algorithms, setOf(proof, *proofs))
+
         init {
             require(null == algorithms || algorithms.isNotEmpty()) { "At least one algorithm must be supported" }
             require(proofs.isNotEmpty()) { "At least one proof must be supported" }
         }
 
-        enum class Proof {
-            JwtProofWithoutKeyAttestation,
-            JwtProofWithKeyAttestation,
-            AttestationProof,
+        sealed interface Proof {
+            data object JwtProofWithoutKeyAttestation : Proof
+            data object JwtProofWithKeyAttestation : Proof
+            data object AttestationProof : Proof
         }
     }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
@@ -87,8 +87,7 @@ data class OpenId4VCIConfig(
 ) {
 
     /**
-     * Creates a new [OpenId4VCIConfig] instance for a Wallet that uses [a Public OAuth 2.0 Client][ClientAuthentication.None], and all
-     * [Proof Types][ProofsConfig].
+     * Creates a new [OpenId4VCIConfig] instance for a Wallet that uses [a Public OAuth 2.0 Client][ClientAuthentication.None].
      */
     @Deprecated(message = "Replace with the primary constructor")
     constructor(
@@ -102,6 +101,7 @@ data class OpenId4VCIConfig(
         clock: Clock = Clock.systemDefaultZone(),
         issuerMetadataPolicy: IssuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
         supportedCredentialReusePolicies: CredentialReusePolicies? = null,
+        proofs: ProofsConfig,
     ) : this(
         ClientAuthentication.None(clientId),
         authFlowRedirectionURI,
@@ -113,11 +113,11 @@ data class OpenId4VCIConfig(
         clock,
         issuerMetadataPolicy,
         supportedCredentialReusePolicies,
-        ProofsConfig.All,
+        proofs,
     )
 
     /**
-     * Creates a new [OpenId4VCIConfig] instance for a Wallet that supports all [Proof Types][ProofsConfig].
+     * Creates a new [OpenId4VCIConfig] instance for a Wallet.
      */
     @Deprecated(message = "Replace with the primary constructor")
     constructor (
@@ -131,6 +131,7 @@ data class OpenId4VCIConfig(
         clock: Clock = Clock.systemDefaultZone(),
         issuerMetadataPolicy: IssuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
         supportedCredentialReusePolicies: CredentialReusePolicies? = null,
+        proofs: ProofsConfig,
     ) : this (
         clientAuthentication,
         authFlowRedirectionURI,
@@ -142,12 +143,11 @@ data class OpenId4VCIConfig(
         clock,
         issuerMetadataPolicy,
         supportedCredentialReusePolicies,
-        ProofsConfig.All,
+        proofs,
     )
 
     /**
-     * Creates a new [OpenId4VCIConfig] instance for a Wallet that uses [a Public OAuth 2.0 Client][ClientAuthentication.None], and
-     * supports all [Proof Types][ProofsConfig].
+     * Creates a new [OpenId4VCIConfig] instance for a Wallet that uses [a Public OAuth 2.0 Client][ClientAuthentication.None].
      */
     @Deprecated(message = "Replace with the primary constructor")
     constructor(
@@ -161,6 +161,7 @@ data class OpenId4VCIConfig(
         clock: Clock = Clock.systemDefaultZone(),
         issuerMetadataPolicy: IssuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
         supportedCredentialReusePolicies: CredentialReusePolicies? = null,
+        proofs: ProofsConfig,
     ) : this(
         ClientAuthentication.None(clientId),
         authFlowRedirectionURI,
@@ -172,7 +173,7 @@ data class OpenId4VCIConfig(
         clock,
         issuerMetadataPolicy,
         supportedCredentialReusePolicies,
-        ProofsConfig.All,
+        proofs,
     )
 
     @Deprecated(
@@ -395,18 +396,6 @@ data class ProofsConfig(
     val supportsDeviceBound: Boolean
         get() = null != deviceBound
 
-    companion object {
-        val All: ProofsConfig = ProofsConfig(
-            supportsNonDeviceBound = true,
-            deviceBound = DeviceBound(
-                null,
-                DeviceBound.Proof.JwtProofWithoutKeyAttestation,
-                DeviceBound.Proof.JwtProofWithKeyAttestation,
-                DeviceBound.Proof.AttestationProof,
-            ),
-        )
-    }
-
     /**
      * The Proofs a Wallet supports for device-bound attestations.
      *
@@ -414,13 +403,11 @@ data class ProofsConfig(
      * @property proofs The Proofs the Wallet supports for device-bound attestations.
      */
     data class DeviceBound(
-        val algorithms: Set<JWSAlgorithm>?,
+        val algorithms: Set<JWSAlgorithm>,
         val proofs: Set<Proof>,
     ) {
-        constructor(algorithms: Set<JWSAlgorithm>?, proof: Proof, vararg proofs: Proof) : this(algorithms, setOf(proof, *proofs))
-
         init {
-            require(null == algorithms || algorithms.isNotEmpty()) { "At least one algorithm must be supported" }
+            require(algorithms.isNotEmpty()) { "At least one algorithm must be supported" }
             require(proofs.isNotEmpty()) { "At least one proof must be supported" }
         }
 
@@ -430,4 +417,6 @@ data class ProofsConfig(
             data object AttestationProof : Proof
         }
     }
+
+    companion object
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
@@ -400,11 +400,6 @@ data class ProofsConfig(
             supportsNonDeviceBound = true,
             deviceBound = DeviceBound(null, DeviceBound.Proof.entries.toSet()),
         )
-
-        val None: ProofsConfig = ProofsConfig(
-            supportsNonDeviceBound = false,
-            deviceBound = null,
-        )
     }
 
     /**

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
@@ -18,6 +18,7 @@ package eu.europa.ec.eudi.openid4vci
 import com.nimbusds.jose.CompressionAlgorithm
 import com.nimbusds.jose.EncryptionMethod
 import com.nimbusds.jose.JWEAlgorithm
+import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.crypto.ECDHEncrypter
 import com.nimbusds.jose.crypto.RSAEncrypter
 import com.nimbusds.jose.crypto.impl.ContentCryptoProvider
@@ -69,6 +70,7 @@ sealed interface ClientAuthentication : java.io.Serializable {
  * @param clock Wallet's clock
  * @param issuerMetadataPolicy policy concerning signed metadata usage
  * @param supportedCredentialReusePolicies the reuse policies supported by the wallet, used to validate against credential issuer metadata.
+ * @param proofs proofs supported by the Wallet
  */
 data class OpenId4VCIConfig(
     val clientAuthentication: ClientAuthentication,
@@ -81,11 +83,14 @@ data class OpenId4VCIConfig(
     val clock: Clock = Clock.systemDefaultZone(),
     val issuerMetadataPolicy: IssuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
     val supportedCredentialReusePolicies: CredentialReusePolicies? = null,
+    val proofs: ProofsConfig,
 ) {
 
     /**
-     * Creates a new [OpenId4VCIConfig] instance for a Wallet that uses [a Public OAuth 2.0 Client][ClientAuthentication.None].
+     * Creates a new [OpenId4VCIConfig] instance for a Wallet that uses [a Public OAuth 2.0 Client][ClientAuthentication.None], and all
+     * [Proof Types][ProofsConfig].
      */
+    @Deprecated(message = "Replace with the primary constructor")
     constructor(
         clientId: ClientId,
         authFlowRedirectionURI: URI,
@@ -108,12 +113,13 @@ data class OpenId4VCIConfig(
         clock,
         issuerMetadataPolicy,
         supportedCredentialReusePolicies,
+        ProofsConfig.All,
     )
 
     /**
-     * Creates a new [OpenId4VCIConfig] instance for a Wallet.
+     * Creates a new [OpenId4VCIConfig] instance for a Wallet that supports all [Proof Types][ProofsConfig].
      */
-    @Deprecated(message = "Replace with the constructor that uses DPoPUsage.")
+    @Deprecated(message = "Replace with the primary constructor")
     constructor (
         clientAuthentication: ClientAuthentication,
         authFlowRedirectionURI: URI,
@@ -136,12 +142,14 @@ data class OpenId4VCIConfig(
         clock,
         issuerMetadataPolicy,
         supportedCredentialReusePolicies,
+        ProofsConfig.All,
     )
 
     /**
-     * Creates a new [OpenId4VCIConfig] instance for a Wallet that uses [a Public OAuth 2.0 Client][ClientAuthentication.None].
+     * Creates a new [OpenId4VCIConfig] instance for a Wallet that uses [a Public OAuth 2.0 Client][ClientAuthentication.None], and
+     * supports all [Proof Types][ProofsConfig].
      */
-    @Deprecated(message = "Replace with the constructor that uses DPoPUsage.")
+    @Deprecated(message = "Replace with the primary constructor")
     constructor(
         clientId: ClientId,
         authFlowRedirectionURI: URI,
@@ -164,6 +172,7 @@ data class OpenId4VCIConfig(
         clock,
         issuerMetadataPolicy,
         supportedCredentialReusePolicies,
+        ProofsConfig.All,
     )
 
     @Deprecated(
@@ -369,4 +378,54 @@ sealed interface IssuerMetadataPolicy {
      * Signed metadata are ignored. Only values conveyed using plain json elements are used.
      */
     data object IgnoreSigned : IssuerMetadataPolicy
+}
+
+/**
+ * Wallet supported Proofs.
+ *
+ * A Wallet has to configure whether it supports non-device-bound attestations, as well as the Proofs supported for device-bound attestations.
+ *
+ * @property supportsDeviceBound Whether the Wallet supports non-device-bound attestations.
+ * @property deviceBound Whether the Wallet supports device-bound attestations, and the Proofs it supports.
+ */
+data class ProofsConfig(
+    val supportsNonDeviceBound: Boolean,
+    val deviceBound: DeviceBound?,
+) {
+    val supportsDeviceBound: Boolean
+        get() = null != deviceBound
+
+    companion object {
+        val All: ProofsConfig = ProofsConfig(
+            supportsNonDeviceBound = true,
+            deviceBound = DeviceBound(null, DeviceBound.Proof.entries.toSet()),
+        )
+
+        val None: ProofsConfig = ProofsConfig(
+            supportsNonDeviceBound = false,
+            deviceBound = null,
+        )
+    }
+
+    /**
+     * The Proofs a Wallet supports for device-bound attestations.
+     *
+     * @property algorithms The JWS Algorithms the Wallet supports for device-bound attestations. Set to *null* if the Wallet supports all algorithms.
+     * @property proofs The Proofs the Wallet supports for device-bound attestations.
+     */
+    data class DeviceBound(
+        val algorithms: Set<JWSAlgorithm>?,
+        val proofs: Set<Proof>,
+    ) {
+        init {
+            require(null == algorithms || algorithms.isNotEmpty()) { "At least one algorithm must be supported" }
+            require(proofs.isNotEmpty()) { "At least one proof must be supported" }
+        }
+
+        enum class Proof {
+            JwtProofWithoutKeyAttestation,
+            JwtProofWithKeyAttestation,
+            AttestationProof,
+        }
+    }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -509,12 +509,12 @@ private fun ProofsConfig.ensureCompatibleWith(supportedProofTypes: ProofTypesSup
                 val supportsAnySigningAlgorithm =
                     if (null == deviceBoundConfig.algorithms) true
                     else jwtProof.algorithms.any { it in deviceBoundConfig.algorithms }
-                val proofType = when (jwtProof.keyAttestationRequirement) {
+                val requiredProofType = when (jwtProof.keyAttestationRequirement) {
                     KeyAttestationRequirement.NotRequired -> ProofsConfig.DeviceBound.Proof.JwtProofWithoutKeyAttestation
                     is KeyAttestationRequirement.Required -> ProofsConfig.DeviceBound.Proof.JwtProofWithKeyAttestation
                 }
-                val supportsProofType = proofType in deviceBoundConfig.proofs
-                supportsAnySigningAlgorithm && supportsProofType
+                val supportsRequiredProofType = requiredProofType in deviceBoundConfig.proofs
+                supportsAnySigningAlgorithm && supportsRequiredProofType
             } ?: false
 
             val supportsAttestationProofs = supportedProofTypes[ProofType.ATTESTATION]?.let { attestationProof ->
@@ -522,8 +522,8 @@ private fun ProofsConfig.ensureCompatibleWith(supportedProofTypes: ProofTypesSup
                 val supportsAnySigningAlgorithm =
                     if (null == deviceBoundConfig.algorithms) true
                     else attestationProof.algorithms.any { it in deviceBoundConfig.algorithms }
-                val supportsProofType = ProofsConfig.DeviceBound.Proof.AttestationProof in deviceBoundConfig.proofs
-                supportsAnySigningAlgorithm && supportsProofType
+                val supportsRequiredProofType = ProofsConfig.DeviceBound.Proof.AttestationProof in deviceBoundConfig.proofs
+                supportsAnySigningAlgorithm && supportsRequiredProofType
             } ?: false
 
             require(supportsJwtProofs || supportsAttestationProofs) { "Wallet doesn't support any of the advertised Proofs" }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -506,9 +506,7 @@ private fun ProofsConfig.ensureCompatibleWith(supportedProofTypes: ProofTypesSup
 
             val supportsJwtProofs = supportedProofTypes[ProofType.JWT]?.let { jwtProof ->
                 check(jwtProof is ProofTypeMeta.Jwt)
-                val supportsAnySigningAlgorithm =
-                    if (null == deviceBoundConfig.algorithms) true
-                    else jwtProof.algorithms.any { it in deviceBoundConfig.algorithms }
+                val supportsAnySigningAlgorithm = jwtProof.algorithms.any { it in deviceBoundConfig.algorithms }
                 val requiredProofType = when (jwtProof.keyAttestationRequirement) {
                     KeyAttestationRequirement.NotRequired -> ProofsConfig.DeviceBound.Proof.JwtProofWithoutKeyAttestation
                     is KeyAttestationRequirement.Required -> ProofsConfig.DeviceBound.Proof.JwtProofWithKeyAttestation
@@ -519,9 +517,7 @@ private fun ProofsConfig.ensureCompatibleWith(supportedProofTypes: ProofTypesSup
 
             val supportsAttestationProofs = supportedProofTypes[ProofType.ATTESTATION]?.let { attestationProof ->
                 check(attestationProof is ProofTypeMeta.Attestation)
-                val supportsAnySigningAlgorithm =
-                    if (null == deviceBoundConfig.algorithms) true
-                    else attestationProof.algorithms.any { it in deviceBoundConfig.algorithms }
+                val supportsAnySigningAlgorithm = attestationProof.algorithms.any { it in deviceBoundConfig.algorithms }
                 val supportsRequiredProofType = ProofsConfig.DeviceBound.Proof.AttestationProof in deviceBoundConfig.proofs
                 supportsAnySigningAlgorithm && supportsRequiredProofType
             } ?: false

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -109,6 +109,7 @@ internal class RequestIssuanceImpl(
         grant: Grant,
     ): Pair<List<Proof>, Nonce?> {
         val credentialConfiguration = credentialSupportedById(credentialConfigId)
+        config.proofs.ensureCompatibleWith(credentialConfiguration.proofTypesSupported)
         val proofRequirement = proofsSpecification.ensureCompatibleWith(credentialConfiguration)
 
         return when (proofsSpecification) {
@@ -492,4 +493,40 @@ internal sealed interface SubmissionOutcomeInternal {
             is Success -> copy(selectedCredentialReusePolicy = selectedCredentialReusePolicy)
             is Deferred, is Failed -> this
         }
+}
+
+private fun ProofsConfig.ensureCompatibleWith(supportedProofTypes: ProofTypesSupported) {
+    when (supportedProofTypes) {
+        ProofTypesSupported.Empty -> {
+            require(supportsNonDeviceBound) { "Wallet doesn't support non-device-bound attestations" }
+        }
+
+        else -> {
+            val deviceBoundConfig = requireNotNull(deviceBound) { "Wallet doesn't support device-bound attestations" }
+
+            val supportsJwtProofs = supportedProofTypes[ProofType.JWT]?.let { jwtProof ->
+                check(jwtProof is ProofTypeMeta.Jwt)
+                val supportsAnySigningAlgorithm =
+                    if (null == deviceBoundConfig.algorithms) true
+                    else jwtProof.algorithms.any { it in deviceBoundConfig.algorithms }
+                val proofType = when (jwtProof.keyAttestationRequirement) {
+                    KeyAttestationRequirement.NotRequired -> ProofsConfig.DeviceBound.Proof.JwtProofWithoutKeyAttestation
+                    is KeyAttestationRequirement.Required -> ProofsConfig.DeviceBound.Proof.JwtProofWithKeyAttestation
+                }
+                val supportsProofType = proofType in deviceBoundConfig.proofs
+                supportsAnySigningAlgorithm && supportsProofType
+            } ?: false
+
+            val supportsAttestationProofs = supportedProofTypes[ProofType.ATTESTATION]?.let { attestationProof ->
+                check(attestationProof is ProofTypeMeta.Attestation)
+                val supportsAnySigningAlgorithm =
+                    if (null == deviceBoundConfig.algorithms) true
+                    else attestationProof.algorithms.any { it in deviceBoundConfig.algorithms }
+                val supportsProofType = ProofsConfig.DeviceBound.Proof.AttestationProof in deviceBoundConfig.proofs
+                supportsAnySigningAlgorithm && supportsProofType
+            } ?: false
+
+            require(supportsJwtProofs || supportsAttestationProofs) { "Wallet doesn't support any of the advertised Proofs" }
+        }
+    }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CredentialReusePolicyTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CredentialReusePolicyTest.kt
@@ -321,7 +321,7 @@ internal class CredentialReusePolicyTest {
                     CredentialResponseEncryptionPolicy.SUPPORTED,
                 ),
                 supportedCredentialReusePolicies = CredentialReusePolicies.Supported(setOf(EudiReusePolicyType.RotatingBatch)),
-                proofs = ProofsConfig.All,
+                proofs = ProofsConfig.EC,
             )
         }
     }
@@ -338,7 +338,7 @@ internal class CredentialReusePolicyTest {
                     CredentialResponseEncryptionPolicy.SUPPORTED,
                 ),
                 supportedCredentialReusePolicies = CredentialReusePolicies.Supported(setOf(EudiReusePolicyType.OnceOnly)),
-                proofs = ProofsConfig.All,
+                proofs = ProofsConfig.EC,
             )
         }
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CredentialReusePolicyTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CredentialReusePolicyTest.kt
@@ -321,6 +321,7 @@ internal class CredentialReusePolicyTest {
                     CredentialResponseEncryptionPolicy.SUPPORTED,
                 ),
                 supportedCredentialReusePolicies = CredentialReusePolicies.Supported(setOf(EudiReusePolicyType.RotatingBatch)),
+                proofs = ProofsConfig.All,
             )
         }
     }
@@ -337,6 +338,7 @@ internal class CredentialReusePolicyTest {
                     CredentialResponseEncryptionPolicy.SUPPORTED,
                 ),
                 supportedCredentialReusePolicies = CredentialReusePolicies.Supported(setOf(EudiReusePolicyType.OnceOnly)),
+                proofs = ProofsConfig.All,
             )
         }
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CredentialReusePolicyTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CredentialReusePolicyTest.kt
@@ -316,7 +316,7 @@ internal class CredentialReusePolicyTest {
                 encryptionSupportConfig = EncryptionSupportConfig.invoke(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
                 dPoPUsage = DPoPUsage.Never,
                 supportedCredentialReusePolicies = CredentialReusePolicies.Supported(setOf(EudiReusePolicyType.RotatingBatch)),
-                proofs = ProofsConfig.All,
+                proofs = ProofsConfig.EC,
             )
         }
     }
@@ -330,7 +330,7 @@ internal class CredentialReusePolicyTest {
                 encryptionSupportConfig = EncryptionSupportConfig.invoke(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
                 dPoPUsage = DPoPUsage.Never,
                 supportedCredentialReusePolicies = CredentialReusePolicies.Supported(setOf(EudiReusePolicyType.OnceOnly)),
-                proofs = ProofsConfig.All,
+                proofs = ProofsConfig.EC,
             )
         }
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CredentialReusePolicyTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CredentialReusePolicyTest.kt
@@ -316,6 +316,7 @@ internal class CredentialReusePolicyTest {
                 encryptionSupportConfig = EncryptionSupportConfig.invoke(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
                 dPoPUsage = DPoPUsage.Never,
                 supportedCredentialReusePolicies = CredentialReusePolicies.Supported(setOf(EudiReusePolicyType.RotatingBatch)),
+                proofs = ProofsConfig.All,
             )
         }
     }
@@ -329,6 +330,7 @@ internal class CredentialReusePolicyTest {
                 encryptionSupportConfig = EncryptionSupportConfig.invoke(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
                 dPoPUsage = DPoPUsage.Never,
                 supportedCredentialReusePolicies = CredentialReusePolicies.Supported(setOf(EudiReusePolicyType.OnceOnly)),
+                proofs = ProofsConfig.All,
             )
         }
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
@@ -15,6 +15,7 @@
  */
 package eu.europa.ec.eudi.openid4vci
 
+import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.JWSObject
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator
@@ -1153,5 +1154,142 @@ class IssuanceSingleRequestTest {
                 }
                 authorizedRequest.request(requestPayload, proofSpec).getOrThrow()
             }
+        }
+
+    @Test
+    fun `when wallet does not support non device bound attestation, issuance fails`() =
+        runTest {
+            val mockedHttpClient = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                tokenPostMocker(),
+            )
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                config = OpenId4VCIConfiguration.copy(proofs = ProofsConfig.None),
+                credentialOfferStr = CredentialOfferWithMDLMdoc_NO_GRANTS,
+                httpClient = mockedHttpClient,
+            )
+
+            val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
+            with(issuer) {
+                val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
+                val exception = assertFailsWith<IllegalArgumentException> {
+                    authorizedRequest.request(requestPayload, ProofsSpecification.NoProofs).getOrThrow()
+                }
+                assertEquals("Wallet doesn't support non-device-bound attestations", exception.message)
+            }
+        }
+
+    @Test
+    fun `when wallet does not support device bound attestation, issuance fails`() =
+        runTest {
+            val mockedHttpClient = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                tokenPostMocker(),
+            )
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                config = OpenId4VCIConfiguration.copy(proofs = ProofsConfig.None),
+                credentialOfferStr = CredentialOfferWithSdJwtVc_NO_GRANTS,
+                httpClient = mockedHttpClient,
+            )
+
+            val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
+            with(issuer) {
+                val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
+                val exception = assertFailsWith<IllegalArgumentException> {
+                    authorizedRequest.request(requestPayload, noKeyAttestationJwtProofsSpec()).getOrThrow()
+                }
+                assertEquals("Wallet doesn't support device-bound attestations", exception.message)
+            }
+        }
+
+    @Test
+    fun `when wallet does supports device bound attestation, but none of the advertised algorithms, issuance fails`() =
+        runTest {
+            val mockedHttpClient = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                tokenPostMocker(),
+            )
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                config = OpenId4VCIConfiguration.copy(
+                    proofs = ProofsConfig(
+                        supportsNonDeviceBound = false,
+                        deviceBound = ProofsConfig.DeviceBound(
+                            algorithms = setOf(
+                                JWSAlgorithm.ES512,
+                            ),
+                            proofs = setOf(ProofsConfig.DeviceBound.Proof.JwtProofWithoutKeyAttestation),
+                        ),
+                    ),
+                ),
+                credentialOfferStr = CredentialOfferWithSdJwtVc_NO_GRANTS,
+                httpClient = mockedHttpClient,
+            )
+
+            val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
+            with(issuer) {
+                val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
+                val exception = assertFailsWith<IllegalArgumentException> {
+                    authorizedRequest.request(requestPayload, noKeyAttestationJwtProofsSpec()).getOrThrow()
+                }
+                assertEquals("Wallet doesn't support any of the advertised Proofs", exception.message)
+            }
+        }
+
+    @Test
+    fun `when wallet does not support the required device bound attestation proof, issuance fails`() =
+        runTest {
+            suspend fun test(
+                supportedProofType: ProofsConfig.DeviceBound.Proof,
+                credentialOffer: String,
+                proofsSpecification: ProofsSpecification,
+            ) {
+                val mockedHttpClient = mockedHttpClient(
+                    credentialIssuerMetadataWellKnownMocker(IssuerMetadataVersion.ATTESTATION_PROOF_SUPPORTED),
+                    authServerWellKnownMocker(),
+                    parPostMocker(),
+                    tokenPostMocker(),
+                )
+                val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                    config = OpenId4VCIConfiguration.copy(
+                        proofs = ProofsConfig(
+                            supportsNonDeviceBound = false,
+                            deviceBound = ProofsConfig.DeviceBound(
+                                algorithms = null,
+                                proofs = setOf(supportedProofType),
+                            ),
+                        ),
+                    ),
+                    credentialOfferStr = credentialOffer,
+                    httpClient = mockedHttpClient,
+                )
+
+                val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
+                with(issuer) {
+                    val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
+                    val exception = assertFailsWith<IllegalArgumentException> {
+                        authorizedRequest.request(requestPayload, proofsSpecification).getOrThrow()
+                    }
+                    assertEquals("Wallet doesn't support any of the advertised Proofs", exception.message)
+                }
+            }
+
+            // Wallet supports Jwt Proofs without Key Attestations, but Credential Issuer requires Jwt Proofs with Key Attestations
+            test(
+                ProofsConfig.DeviceBound.Proof.JwtProofWithoutKeyAttestation,
+                CredentialOfferWithSdJwtVc_NO_GRANTS,
+                noKeyAttestationJwtProofsSpec(),
+            )
+
+            // Wallet supports Jwt Proofs with Key Attestations, but Credential Issuer requires Jwt Proofs without Key Attestations
+            test(ProofsConfig.DeviceBound.Proof.JwtProofWithKeyAttestation, CredentialOfferMsoMdoc_NO_GRANTS, keyAttestationJwtProofsSpec())
+
+            // Wallet supports Attestation Proofs, but Credential Issuer requires Jwt Proofs without Key Attestations
+            test(ProofsConfig.DeviceBound.Proof.AttestationProof, CredentialOfferMsoMdoc_NO_GRANTS, attestationProofSpec())
         }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
@@ -1260,7 +1260,7 @@ class IssuanceSingleRequestTest {
                         proofs = ProofsConfig(
                             supportsNonDeviceBound = false,
                             deviceBound = ProofsConfig.DeviceBound(
-                                algorithms = null,
+                                algorithms = setOf(JWSAlgorithm.ES256, JWSAlgorithm.ES384, JWSAlgorithm.ES512),
                                 proofs = setOf(supportedProofType),
                             ),
                         ),

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
@@ -1166,7 +1166,7 @@ class IssuanceSingleRequestTest {
                 tokenPostMocker(),
             )
             val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-                config = OpenId4VCIConfiguration.copy(proofs = ProofsConfig.None),
+                config = OpenId4VCIConfiguration.copy(proofs = ProofsConfig(false, null)),
                 credentialOfferStr = CredentialOfferWithMDLMdoc_NO_GRANTS,
                 httpClient = mockedHttpClient,
             )
@@ -1191,7 +1191,7 @@ class IssuanceSingleRequestTest {
                 tokenPostMocker(),
             )
             val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-                config = OpenId4VCIConfiguration.copy(proofs = ProofsConfig.None),
+                config = OpenId4VCIConfiguration.copy(proofs = ProofsConfig(false, null)),
                 credentialOfferStr = CredentialOfferWithSdJwtVc_NO_GRANTS,
                 httpClient = mockedHttpClient,
             )

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
@@ -1070,7 +1070,7 @@ class IssuanceSingleRequestTest {
                 tokenPostMocker(),
             )
             val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-                config = OpenId4VCIConfiguration.copy(proofs = ProofsConfig.None),
+                config = OpenId4VCIConfiguration.copy(proofs = ProofsConfig(false, null)),
                 credentialOfferStr = CredentialOfferWithMDLMdoc_NO_GRANTS,
                 httpClient = mockedHttpClient,
             )
@@ -1095,7 +1095,7 @@ class IssuanceSingleRequestTest {
                 tokenPostMocker(),
             )
             val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-                config = OpenId4VCIConfiguration.copy(proofs = ProofsConfig.None),
+                config = OpenId4VCIConfiguration.copy(proofs = ProofsConfig(false, null)),
                 credentialOfferStr = CredentialOfferWithSdJwtVc_NO_GRANTS,
                 httpClient = mockedHttpClient,
             )

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
@@ -1164,7 +1164,7 @@ class IssuanceSingleRequestTest {
                         proofs = ProofsConfig(
                             supportsNonDeviceBound = false,
                             deviceBound = ProofsConfig.DeviceBound(
-                                algorithms = null,
+                                algorithms = setOf(JWSAlgorithm.ES256, JWSAlgorithm.ES384, JWSAlgorithm.ES512),
                                 proofs = setOf(supportedProofType),
                             ),
                         ),

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
@@ -15,6 +15,7 @@
  */
 package eu.europa.ec.eudi.openid4vci
 
+import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.JWSObject
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator
@@ -1057,5 +1058,142 @@ class IssuanceSingleRequestTest {
                 }
                 authorizedRequest.request(requestPayload, proofSpec).getOrThrow()
             }
+        }
+
+    @Test
+    fun `when wallet does not support non device bound attestation, issuance fails`() =
+        runTest {
+            val mockedHttpClient = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                tokenPostMocker(),
+            )
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                config = OpenId4VCIConfiguration.copy(proofs = ProofsConfig.None),
+                credentialOfferStr = CredentialOfferWithMDLMdoc_NO_GRANTS,
+                httpClient = mockedHttpClient,
+            )
+
+            val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
+            with(issuer) {
+                val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
+                val exception = assertFailsWith<IllegalArgumentException> {
+                    authorizedRequest.request(requestPayload, ProofsSpecification.NoProofs).getOrThrow()
+                }
+                assertEquals("Wallet doesn't support non-device-bound attestations", exception.message)
+            }
+        }
+
+    @Test
+    fun `when wallet does not support device bound attestation, issuance fails`() =
+        runTest {
+            val mockedHttpClient = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                tokenPostMocker(),
+            )
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                config = OpenId4VCIConfiguration.copy(proofs = ProofsConfig.None),
+                credentialOfferStr = CredentialOfferWithSdJwtVc_NO_GRANTS,
+                httpClient = mockedHttpClient,
+            )
+
+            val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
+            with(issuer) {
+                val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
+                val exception = assertFailsWith<IllegalArgumentException> {
+                    authorizedRequest.request(requestPayload, noKeyAttestationJwtProofsSpec()).getOrThrow()
+                }
+                assertEquals("Wallet doesn't support device-bound attestations", exception.message)
+            }
+        }
+
+    @Test
+    fun `when wallet does supports device bound attestation, but none of the advertised algorithms, issuance fails`() =
+        runTest {
+            val mockedHttpClient = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                tokenPostMocker(),
+            )
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                config = OpenId4VCIConfiguration.copy(
+                    proofs = ProofsConfig(
+                        supportsNonDeviceBound = false,
+                        deviceBound = ProofsConfig.DeviceBound(
+                            algorithms = setOf(
+                                JWSAlgorithm.ES512,
+                            ),
+                            proofs = setOf(ProofsConfig.DeviceBound.Proof.JwtProofWithoutKeyAttestation),
+                        ),
+                    ),
+                ),
+                credentialOfferStr = CredentialOfferWithSdJwtVc_NO_GRANTS,
+                httpClient = mockedHttpClient,
+            )
+
+            val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
+            with(issuer) {
+                val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
+                val exception = assertFailsWith<IllegalArgumentException> {
+                    authorizedRequest.request(requestPayload, noKeyAttestationJwtProofsSpec()).getOrThrow()
+                }
+                assertEquals("Wallet doesn't support any of the advertised Proofs", exception.message)
+            }
+        }
+
+    @Test
+    fun `when wallet does not support the required device bound attestation proof, issuance fails`() =
+        runTest {
+            suspend fun test(
+                supportedProofType: ProofsConfig.DeviceBound.Proof,
+                credentialOffer: String,
+                proofsSpecification: ProofsSpecification,
+            ) {
+                val mockedHttpClient = mockedHttpClient(
+                    credentialIssuerMetadataWellKnownMocker(IssuerMetadataVersion.ATTESTATION_PROOF_SUPPORTED),
+                    authServerWellKnownMocker(),
+                    parPostMocker(),
+                    tokenPostMocker(),
+                )
+                val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                    config = OpenId4VCIConfiguration.copy(
+                        proofs = ProofsConfig(
+                            supportsNonDeviceBound = false,
+                            deviceBound = ProofsConfig.DeviceBound(
+                                algorithms = null,
+                                proofs = setOf(supportedProofType),
+                            ),
+                        ),
+                    ),
+                    credentialOfferStr = credentialOffer,
+                    httpClient = mockedHttpClient,
+                )
+
+                val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
+                with(issuer) {
+                    val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
+                    val exception = assertFailsWith<IllegalArgumentException> {
+                        authorizedRequest.request(requestPayload, proofsSpecification).getOrThrow()
+                    }
+                    assertEquals("Wallet doesn't support any of the advertised Proofs", exception.message)
+                }
+            }
+
+            // Wallet supports Jwt Proofs without Key Attestations, but Credential Issuer requires Jwt Proofs with Key Attestations
+            test(
+                ProofsConfig.DeviceBound.Proof.JwtProofWithoutKeyAttestation,
+                CredentialOfferWithSdJwtVc_NO_GRANTS,
+                noKeyAttestationJwtProofsSpec(),
+            )
+
+            // Wallet supports Jwt Proofs with Key Attestations, but Credential Issuer requires Jwt Proofs without Key Attestations
+            test(ProofsConfig.DeviceBound.Proof.JwtProofWithKeyAttestation, CredentialOfferMsoMdoc_NO_GRANTS, keyAttestationJwtProofsSpec())
+
+            // Wallet supports Attestation Proofs, but Credential Issuer requires Jwt Proofs without Key Attestations
+            test(ProofsConfig.DeviceBound.Proof.AttestationProof, CredentialOfferMsoMdoc_NO_GRANTS, attestationProofSpec())
         }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
@@ -89,6 +89,7 @@ val OpenId4VCIConfiguration = OpenId4VCIConfig(
     authFlowRedirectionURI = URI.create("eudi-wallet//auth"),
     encryptionSupportConfig = EncryptionSupportConfig(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
     dPoPUsage = DPoPUsage.Never,
+    proofs = ProofsConfig.All,
 )
 
 val OpenId4VCIConfigurationWithDpopSigner = OpenId4VCIConfig(
@@ -101,6 +102,7 @@ val OpenId4VCIConfigurationWithDpopSigner = OpenId4VCIConfig(
             alg = JWSAlgorithm.ES256,
         ),
     ),
+    proofs = ProofsConfig.All,
 )
 
 suspend fun authorizeRequestForCredentialOffer(

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
@@ -27,6 +27,7 @@ import com.nimbusds.jwt.SignedJWT
 import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier
 import com.nimbusds.jwt.proc.DefaultJWTProcessor
 import eu.europa.ec.eudi.openid4vci.CryptoGenerator.ecSigner
+import eu.europa.ec.eudi.openid4vci.ProofsConfig.DeviceBound
 import io.ktor.client.*
 import io.ktor.client.request.HttpRequestData
 import java.net.URI
@@ -100,7 +101,7 @@ val OpenId4VCIConfiguration = OpenId4VCIConfig(
     clientAuthentication = ClientAuthentication.None("MyWallet_ClientId", DPoPUsage.Never),
     authFlowRedirectionURI = URI.create("eudi-wallet//auth"),
     encryptionSupportConfig = EncryptionSupportConfig(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
-    proofs = ProofsConfig.All,
+    proofs = ProofsConfig.EC,
 )
 
 val OpenId4VCIConfigurationWithDpopSigner = OpenId4VCIConfig(
@@ -115,7 +116,7 @@ val OpenId4VCIConfigurationWithDpopSigner = OpenId4VCIConfig(
     ),
     authFlowRedirectionURI = URI.create("eudi-wallet//auth"),
     encryptionSupportConfig = EncryptionSupportConfig(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
-    proofs = ProofsConfig.All,
+    proofs = ProofsConfig.EC,
 )
 
 suspend fun authorizeRequestForCredentialOffer(
@@ -191,3 +192,20 @@ internal fun HttpRequestData.verifyDPoPProof(walletInstanceKey: ECKey, dpopNonce
     jwtProcessor.process(dpopProof, null)
     assertEquals(walletInstanceKey.toPublicJWK(), dpopProof.header.jwk)
 }
+
+internal val ProofsConfig.Companion.EC: ProofsConfig
+    get() = ProofsConfig(
+        supportsNonDeviceBound = true,
+        deviceBound = DeviceBound(
+            setOf(
+                JWSAlgorithm.ES256,
+                JWSAlgorithm.ES384,
+                JWSAlgorithm.ES512,
+            ),
+            setOf(
+                DeviceBound.Proof.JwtProofWithoutKeyAttestation,
+                DeviceBound.Proof.JwtProofWithKeyAttestation,
+                DeviceBound.Proof.AttestationProof,
+            ),
+        ),
+    )

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
@@ -100,6 +100,7 @@ val OpenId4VCIConfiguration = OpenId4VCIConfig(
     clientAuthentication = ClientAuthentication.None("MyWallet_ClientId", DPoPUsage.Never),
     authFlowRedirectionURI = URI.create("eudi-wallet//auth"),
     encryptionSupportConfig = EncryptionSupportConfig(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
+    proofs = ProofsConfig.All,
 )
 
 val OpenId4VCIConfigurationWithDpopSigner = OpenId4VCIConfig(
@@ -114,7 +115,7 @@ val OpenId4VCIConfigurationWithDpopSigner = OpenId4VCIConfig(
     ),
     authFlowRedirectionURI = URI.create("eudi-wallet//auth"),
     encryptionSupportConfig = EncryptionSupportConfig(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
-
+    proofs = ProofsConfig.All,
 )
 
 suspend fun authorizeRequestForCredentialOffer(

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
@@ -18,6 +18,7 @@ package eu.europa.ec.eudi.openid4vci
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.Curve
 import eu.europa.ec.eudi.openid4vci.CryptoGenerator.ecSigner
+import eu.europa.ec.eudi.openid4vci.ProofsConfig.DeviceBound
 import io.ktor.client.*
 import java.net.URI
 import java.util.*
@@ -89,7 +90,7 @@ val OpenId4VCIConfiguration = OpenId4VCIConfig(
     authFlowRedirectionURI = URI.create("eudi-wallet//auth"),
     encryptionSupportConfig = EncryptionSupportConfig(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
     dPoPUsage = DPoPUsage.Never,
-    proofs = ProofsConfig.All,
+    proofs = ProofsConfig.EC,
 )
 
 val OpenId4VCIConfigurationWithDpopSigner = OpenId4VCIConfig(
@@ -102,7 +103,7 @@ val OpenId4VCIConfigurationWithDpopSigner = OpenId4VCIConfig(
             alg = JWSAlgorithm.ES256,
         ),
     ),
-    proofs = ProofsConfig.All,
+    proofs = ProofsConfig.EC,
 )
 
 suspend fun authorizeRequestForCredentialOffer(
@@ -161,3 +162,20 @@ fun CredentialReusePolicy.effectiveBatchSize(supportedReusePolicies: CredentialR
 
         CredentialReusePolicy.None -> null
     }
+
+internal val ProofsConfig.Companion.EC: ProofsConfig
+    get() = ProofsConfig(
+        supportsNonDeviceBound = true,
+        deviceBound = DeviceBound(
+            setOf(
+                JWSAlgorithm.ES256,
+                JWSAlgorithm.ES384,
+                JWSAlgorithm.ES512,
+            ),
+            setOf(
+                DeviceBound.Proof.JwtProofWithoutKeyAttestation,
+                DeviceBound.Proof.JwtProofWithKeyAttestation,
+                DeviceBound.Proof.AttestationProof,
+            ),
+        ),
+    )

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingPreAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingPreAuthorizationFlow.kt
@@ -28,6 +28,7 @@ fun main(): Unit = runBlocking {
         authFlowRedirectionURI = URI.create("urn:ietf:wg:oauth:2.0:oob"),
         encryptionSupportConfig = EncryptionSupportConfig(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
         dPoPUsage = DPoPUsage.Never,
+        proofs = ProofsConfig.All,
     )
     val credentialOfferUrl =
         "openid-credential-offer://?credential_offer_uri=https%3A%2F%2Ftrial.authlete.net" +

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingPreAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingPreAuthorizationFlow.kt
@@ -27,7 +27,7 @@ fun main(): Unit = runBlocking {
         clientAuthentication = ClientAuthentication.None("218232426", DPoPUsage.Never),
         authFlowRedirectionURI = URI.create("urn:ietf:wg:oauth:2.0:oob"),
         encryptionSupportConfig = EncryptionSupportConfig(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
-        proofs = ProofsConfig.All,
+        proofs = ProofsConfig.EC,
     )
     val credentialOfferUrl =
         "openid-credential-offer://?credential_offer_uri=https%3A%2F%2Ftrial.authlete.net" +

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingPreAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingPreAuthorizationFlow.kt
@@ -27,6 +27,7 @@ fun main(): Unit = runBlocking {
         clientAuthentication = ClientAuthentication.None("218232426", DPoPUsage.Never),
         authFlowRedirectionURI = URI.create("urn:ietf:wg:oauth:2.0:oob"),
         encryptionSupportConfig = EncryptionSupportConfig(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
+        proofs = ProofsConfig.All,
     )
     val credentialOfferUrl =
         "openid-credential-offer://?credential_offer_uri=https%3A%2F%2Ftrial.authlete.net" +

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingPreAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingPreAuthorizationFlow.kt
@@ -28,7 +28,7 @@ fun main(): Unit = runBlocking {
         authFlowRedirectionURI = URI.create("urn:ietf:wg:oauth:2.0:oob"),
         encryptionSupportConfig = EncryptionSupportConfig(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
         dPoPUsage = DPoPUsage.Never,
-        proofs = ProofsConfig.All,
+        proofs = ProofsConfig.EC,
     )
     val credentialOfferUrl =
         "openid-credential-offer://?credential_offer_uri=https%3A%2F%2Ftrial.authlete.net" +

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuer.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuer.kt
@@ -46,6 +46,7 @@ internal object PidDevIssuer :
         authorizeIssuanceConfig = AuthorizeIssuanceConfig.FAVOR_SCOPES,
         parUsage = ParUsage.Required,
         supportedCredentialReusePolicies = CredentialReusePolicies.Supported(setOf(EudiReusePolicyType.OnceOnly)),
+        proofs = ProofsConfig.All,
     )
 
     val PID_SdJwtVC_config_id = CredentialConfigurationIdentifier("eu.europa.ec.eudi.pid_vc_sd_jwt")

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuer.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuer.kt
@@ -46,7 +46,7 @@ internal object PidDevIssuer :
         authorizeIssuanceConfig = AuthorizeIssuanceConfig.FAVOR_SCOPES,
         parUsage = ParUsage.Required,
         supportedCredentialReusePolicies = CredentialReusePolicies.Supported(setOf(EudiReusePolicyType.OnceOnly)),
-        proofs = ProofsConfig.All,
+        proofs = ProofsConfig.EC,
     )
 
     val PID_SdJwtVC_config_id = CredentialConfigurationIdentifier("eu.europa.ec.eudi.pid_vc_sd_jwt")

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuer.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuer.kt
@@ -40,7 +40,7 @@ internal object PidDevIssuer :
         dPoPUsage = DPoPUsage.Required(CryptoGenerator.ecSigner()),
         parUsage = ParUsage.Required,
         supportedCredentialReusePolicies = CredentialReusePolicies.Supported(setOf(EudiReusePolicyType.OnceOnly)),
-        proofs = ProofsConfig.All,
+        proofs = ProofsConfig.EC,
     )
 
     val PID_SdJwtVC_config_id = CredentialConfigurationIdentifier("eu.europa.ec.eudi.pid_vc_sd_jwt")

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuer.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuer.kt
@@ -40,6 +40,7 @@ internal object PidDevIssuer :
         dPoPUsage = DPoPUsage.Required(CryptoGenerator.ecSigner()),
         parUsage = ParUsage.Required,
         supportedCredentialReusePolicies = CredentialReusePolicies.Supported(setOf(EudiReusePolicyType.OnceOnly)),
+        proofs = ProofsConfig.All,
     )
 
     val PID_SdJwtVC_config_id = CredentialConfigurationIdentifier("eu.europa.ec.eudi.pid_vc_sd_jwt")


### PR DESCRIPTION
This PR add a new option called `proofs` in `OpenId4VCIConfig` as a means for a Wallet to configure the supported Attestation/Proofs.

Current a Wallet can configuration the following:
1. Whether non-device-bound attestations are supported;
2. Whether device-bound attestations are supported; For device-bound attestations a Wallet can also:
    1. Configure which JWS Algorithms are supported for the Proofs;
    2. Configure which Proof Types are supports; Currently the supports Proof Types are:
        1. JWT Proofs without Key Attestation;
        2. JWT Proofs with Key Attestation;
        3. Attestation Proofs;

The new configuration option is taken into account just before generating the Proofs for the Credential Request.
Before generating the Proofs for the Credential Request, we check for the selected Credential Configuration:
* If it's a non-device-bound attestation, whether Wallet supports non-device-bound attestations;
* If it's a device-bound attestation, whether the Credential Configuration contains any Wallet supported Proof Type. If no match is found, issuance fails;

Closes #508 