### PR TITLE
Expose a way for clients to manually refresh access tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,8 +326,6 @@ Prerequisites:
 1. Authorization Server supports `refresh_token` grant
 2. `AuthorizedRequest` contains a `RefreshAccessToken`
 
-#### Refresh Access Token if expired
-
 Library will perform a `refresh_token` grant, and return the updated `AuthorizedRequest`:
 
 ```kotlin
@@ -336,19 +334,6 @@ val authorizedRequest = // has been retrieved in a previous step
 val (updatedAuthorizedRequest) =  
     with(issuer) {
         authorizedRequest.refresh().getOrThrow()
-    }
-```
-
-#### Refresh Access Token if needed
-
-Library will perform a `refresh_token` grant in case `AuthorizedRequest` contains an expired `AccessToken`, and will return the updated `AuthorizedRequest`: 
-
-```kotlin
-val authorizedRequest = // has been retrieved in a previous step
-
-val (updatedAuthorizedRequest) =  
-    with(issuer) {
-        authorizedRequest.refreshIfNeeded().getOrThrow()
     }
 ```
 

--- a/README.md
+++ b/README.md
@@ -318,6 +318,39 @@ val authorizedRequest =
 > reduce the scope of the `access_token` by passing `authorization_details` to the token endpoint.
 > Function `authorizeWithPreAuthorizationCode` supports this via parameter `authDetailsOption: AccessTokenOption`
 
+### Refresh Access Token
+
+A Wallet/Caller can refresh the `AccessToken` of an `AuthorizedRequest` using a `refresh_token` grant.
+
+Prerequisites:
+1. Authorization Server supports `refresh_token` grant
+2. `AuthorizedRequest` contains a `RefreshAccessToken`
+
+#### Refresh Access Token if expired
+
+Library will perform a `refresh_token` grant, and return the updated `AuthorizedRequest`:
+
+```kotlin
+val authorizedRequest = // has been retrieved in a previous step
+
+val (updatedAuthorizedRequest) =  
+    with(issuer) {
+        authorizedRequest.refresh().getOrThrow()
+    }
+```
+
+#### Refresh Access Token if needed
+
+Library will perform a `refresh_token` grant in case `AuthorizedRequest` contains an expired `AccessToken`, and will return the updated `AuthorizedRequest`: 
+
+```kotlin
+val authorizedRequest = // has been retrieved in a previous step
+
+val (updatedAuthorizedRequest) =  
+    with(issuer) {
+        authorizedRequest.refreshIfNeeded().getOrThrow()
+    }
+```
 
 ### Place credential request
 
@@ -447,6 +480,7 @@ val (updatedAuthorizedRequest, outcome) =
     }    
 
 ```
+
 #### Query for deferred credentials next steps
 
 - Validate credential and store it. That's out of library scope, or

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
@@ -18,7 +18,7 @@ package eu.europa.ec.eudi.openid4vci
 import com.nimbusds.jose.CompressionAlgorithm
 import com.nimbusds.jose.EncryptionMethod
 import com.nimbusds.jose.jwk.JWK
-import eu.europa.ec.eudi.openid4vci.internal.RefreshAccessToken
+import eu.europa.ec.eudi.openid4vci.internal.RefreshAccessTokenImpl
 import eu.europa.ec.eudi.openid4vci.internal.http.DeferredEndPointClient
 import eu.europa.ec.eudi.openid4vci.internal.http.TokenEndpointClient
 import io.ktor.client.*
@@ -105,9 +105,9 @@ data class DeferredIssuanceContext(
  *
  * The [DeferredIssuanceContext] can be obtained by [Issuer.deferredContext]
  *
- * Finally, [DeferredIssuer] supports transparent refresh of access token
+ * Finally, [DeferredIssuer] provides the [RefreshAccessToken] capability and, supports transparent refresh of access token
  */
-interface DeferredIssuer : QueryForDeferredCredential {
+interface DeferredIssuer : RefreshAccessToken, QueryForDeferredCredential {
 
     companion object {
 
@@ -183,7 +183,7 @@ interface DeferredIssuer : QueryForDeferredCredential {
                 httpClient,
             )
 
-            val refreshAccessToken = RefreshAccessToken(config.clock, tokenEndpointClient)
+            val refreshAccessToken = RefreshAccessTokenImpl(config.clock, tokenEndpointClient)
 
             val deferredEndPointClient = DeferredEndPointClient(
                 CredentialIssuerEndpoint.invoke(config.deferredEndpoint.toString()).getOrThrow(),
@@ -213,6 +213,7 @@ interface DeferredIssuer : QueryForDeferredCredential {
                 )
             object :
                 DeferredIssuer,
+                RefreshAccessToken by refreshAccessToken,
                 QueryForDeferredCredential by queryForDeferredCredential {}
         }
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
@@ -107,6 +107,7 @@ data class DeferredIssuanceContext(
  *
  * Finally, [DeferredIssuer] provides the [RefreshAccessToken] capability and, supports transparent refresh of access token
  */
+@Deprecated("Use Issuer instead")
 interface DeferredIssuer : RefreshAccessToken, QueryForDeferredCredential {
 
     companion object {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
@@ -183,7 +183,7 @@ interface DeferredIssuer : RefreshAccessToken, QueryForDeferredCredential {
                 httpClient,
             )
 
-            val refreshAccessToken = RefreshAccessTokenImpl(config.clock, tokenEndpointClient)
+            val refreshAccessToken = RefreshAccessTokenImpl(tokenEndpointClient)
 
             val deferredEndPointClient = DeferredEndPointClient(
                 CredentialIssuerEndpoint.invoke(config.deferredEndpoint.toString()).getOrThrow(),
@@ -207,6 +207,7 @@ interface DeferredIssuer : RefreshAccessToken, QueryForDeferredCredential {
 
             val queryForDeferredCredential =
                 QueryForDeferredCredential(
+                    config.clock,
                     refreshAccessToken,
                     deferredEndPointClient,
                     issuanceEncryptionSpecs,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
@@ -185,7 +185,7 @@ interface Issuer :
                 )
             }
 
-            val refreshAccessToken = RefreshAccessTokenImpl(config.clock, tokenEndpointClient)
+            val refreshAccessToken = RefreshAccessTokenImpl(tokenEndpointClient)
 
             val queryForDeferredCredential =
                 when (val deferredEndpoint = credentialOffer.credentialIssuerMetadata.deferredCredentialEndpoint) {
@@ -193,7 +193,7 @@ interface Issuer :
                     else -> {
                         val deferredEndPointClient =
                             DeferredEndPointClient(deferredEndpoint, dPoPJwtFactory, httpClient)
-                        QueryForDeferredCredential(refreshAccessToken, deferredEndPointClient, issuanceEncryptionSpecs)
+                        QueryForDeferredCredential(config.clock, refreshAccessToken, deferredEndPointClient, issuanceEncryptionSpecs)
                     }
                 }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
@@ -29,6 +29,7 @@ import java.net.URI
  *
  * Provides the following capabilities
  * - [AuthorizeIssuance]
+ * - [RefreshAccessToken]
  * - [RequestIssuance]
  * - [QueryForDeferredCredential]
  * - [NotifyIssuer]
@@ -40,6 +41,7 @@ import java.net.URI
  */
 interface Issuer :
     AuthorizeIssuance,
+    RefreshAccessToken,
     RequestIssuance,
     QueryForDeferredCredential,
     NotifyIssuer {
@@ -183,11 +185,12 @@ interface Issuer :
                 )
             }
 
+            val refreshAccessToken = RefreshAccessTokenImpl(config.clock, tokenEndpointClient)
+
             val queryForDeferredCredential =
                 when (val deferredEndpoint = credentialOffer.credentialIssuerMetadata.deferredCredentialEndpoint) {
                     null -> QueryForDeferredCredential.NotSupported
                     else -> {
-                        val refreshAccessToken = RefreshAccessToken(config.clock, tokenEndpointClient)
                         val deferredEndPointClient =
                             DeferredEndPointClient(deferredEndpoint, dPoPJwtFactory, httpClient)
                         QueryForDeferredCredential(refreshAccessToken, deferredEndPointClient, issuanceEncryptionSpecs)
@@ -207,6 +210,7 @@ interface Issuer :
             object :
                 Issuer,
                 AuthorizeIssuance by authorizeIssuance,
+                RefreshAccessToken by refreshAccessToken,
                 RequestIssuance by requestIssuance,
                 QueryForDeferredCredential by queryForDeferredCredential,
                 NotifyIssuer by notifyIssuer {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/QueryForDeferredCredential.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/QueryForDeferredCredential.kt
@@ -17,6 +17,7 @@ package eu.europa.ec.eudi.openid4vci
 
 import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.IssuerDoesNotSupportDeferredIssuance
 import eu.europa.ec.eudi.openid4vci.internal.http.DeferredEndPointClient
+import java.time.Clock
 import kotlin.time.Duration
 
 sealed interface DeferredCredentialQueryOutcome : java.io.Serializable {
@@ -68,12 +69,14 @@ fun interface QueryForDeferredCredential {
          * Factory method that produces a [QueryForDeferredCredential]
          * that is capable of refreshing the access_token if needed, and if possible.
          *
+         * @param clock Wallet's clock
          * @param refreshAccessToken the ability to refresh the [AuthorizedRequest]
          * @param deferredEndPointClient client of the deferred endpoint
          * @param exchangeEncryptionSpecification encryption specifications for encrypted request and response
          * that has been sent to the credential issuer
          */
         internal operator fun invoke(
+            clock: Clock,
             refreshAccessToken: RefreshAccessToken,
             deferredEndPointClient: DeferredEndPointClient,
             exchangeEncryptionSpecification: ExchangeEncryptionSpecification,
@@ -87,10 +90,13 @@ fun interface QueryForDeferredCredential {
                 refreshed.withResourceServerDpopNonce(newResourceServerDpopNonce) to outcome
             }
 
-            private suspend fun refreshIfNeeded(authorizedRequest: AuthorizedRequest): AuthorizedRequest =
-                with(refreshAccessToken) {
-                    authorizedRequest.refreshIfNeeded().getOrThrow()
+            private suspend fun refreshIfNeeded(authorizedRequest: AuthorizedRequest): AuthorizedRequest {
+                val now = clock.instant()
+                return if (!authorizedRequest.isAccessTokenExpired(now)) authorizedRequest
+                else with(refreshAccessToken) {
+                    authorizedRequest.refresh().getOrThrow()
                 }
+            }
 
             private suspend fun placeDeferredCredentialRequest(
                 authorizedRequest: AuthorizedRequest,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/QueryForDeferredCredential.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/QueryForDeferredCredential.kt
@@ -16,7 +16,6 @@
 package eu.europa.ec.eudi.openid4vci
 
 import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.IssuerDoesNotSupportDeferredIssuance
-import eu.europa.ec.eudi.openid4vci.internal.RefreshAccessToken
 import eu.europa.ec.eudi.openid4vci.internal.http.DeferredEndPointClient
 import kotlin.time.Duration
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/RefreshAccessToken.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/RefreshAccessToken.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.openid4vci
+
+/**
+ * Service for refreshing the [AccessToken] and [RefreshAccessToken] of an [AuthorizedRequest].
+ */
+interface RefreshAccessToken {
+
+    /**
+     * Performs a `refresh_token` grant against the Token Endpoint of the Authorization Server to fetch a new Access Token, and Refresh Token.
+     */
+    suspend fun AuthorizedRequest.refresh(): Result<AuthorizedRequest>
+
+    /**
+     * Performs a `refresh_token` grant against the Token Endpoint of the Authorization Server to fetch a new Access Token, and Refresh Token,
+     * in case the current Access Token is expired.
+     */
+    suspend fun AuthorizedRequest.refreshIfNeeded(): Result<AuthorizedRequest>
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/RefreshAccessToken.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/RefreshAccessToken.kt
@@ -24,10 +24,4 @@ interface RefreshAccessToken {
      * Performs a `refresh_token` grant against the Token Endpoint of the Authorization Server to fetch a new Access Token, and Refresh Token.
      */
     suspend fun AuthorizedRequest.refresh(): Result<AuthorizedRequest>
-
-    /**
-     * Performs a `refresh_token` grant against the Token Endpoint of the Authorization Server to fetch a new Access Token, and Refresh Token,
-     * in case the current Access Token is expired.
-     */
-    suspend fun AuthorizedRequest.refreshIfNeeded(): Result<AuthorizedRequest>
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RefreshAccessTokenImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RefreshAccessTokenImpl.kt
@@ -36,13 +36,12 @@ internal class RefreshAccessTokenImpl(
             val at = clock.instant()
             when {
                 !isAccessTokenExpired(at) -> this
-                refreshToken == null -> error("Refresh token was not provided")
                 else -> refresh(this)
             }
         }
 
     private suspend fun refresh(authorizedRequest: AuthorizedRequest): AuthorizedRequest {
-        val refreshToken = requireNotNull(authorizedRequest.refreshToken)
+        val refreshToken = checkNotNull(authorizedRequest.refreshToken) { "Refresh token was not provided" }
         val (tokenResponse, newDpopNonce) =
             tokenEndpointClient.refreshAccessToken(refreshToken, authorizedRequest.authorizationServerDpopNonce).getOrThrow()
         return authorizedRequest.withRefreshedAccessToken(

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RefreshAccessTokenImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RefreshAccessTokenImpl.kt
@@ -17,38 +17,22 @@ package eu.europa.ec.eudi.openid4vci.internal
 
 import eu.europa.ec.eudi.openid4vci.AuthorizedRequest
 import eu.europa.ec.eudi.openid4vci.RefreshAccessToken
+import eu.europa.ec.eudi.openid4vci.RefreshToken
 import eu.europa.ec.eudi.openid4vci.internal.http.TokenEndpointClient
 import eu.europa.ec.eudi.openid4vci.runCatchingCancellable
-import java.time.Clock
 
-internal class RefreshAccessTokenImpl(
-    private val clock: Clock,
-    private val tokenEndpointClient: TokenEndpointClient,
-) : RefreshAccessToken {
+internal class RefreshAccessTokenImpl(private val tokenEndpointClient: TokenEndpointClient) : RefreshAccessToken {
 
     override suspend fun AuthorizedRequest.refresh(): Result<AuthorizedRequest> =
         runCatchingCancellable {
-            refresh(this)
+            val refreshToken = checkNotNull<RefreshToken>(refreshToken) { "Refresh token was not provided" }
+            val (tokenResponse, newDpopNonce) =
+                tokenEndpointClient.refreshAccessToken(refreshToken, authorizationServerDpopNonce).getOrThrow()
+            withRefreshedAccessToken(
+                refreshedAccessToken = tokenResponse.accessToken,
+                newRefreshToken = tokenResponse.refreshToken,
+                at = tokenResponse.timestamp,
+                newAuthorizationServerDpopNonce = newDpopNonce,
+            )
         }
-
-    override suspend fun AuthorizedRequest.refreshIfNeeded(): Result<AuthorizedRequest> =
-        runCatchingCancellable {
-            val at = clock.instant()
-            when {
-                !isAccessTokenExpired(at) -> this
-                else -> refresh(this)
-            }
-        }
-
-    private suspend fun refresh(authorizedRequest: AuthorizedRequest): AuthorizedRequest {
-        val refreshToken = checkNotNull(authorizedRequest.refreshToken) { "Refresh token was not provided" }
-        val (tokenResponse, newDpopNonce) =
-            tokenEndpointClient.refreshAccessToken(refreshToken, authorizedRequest.authorizationServerDpopNonce).getOrThrow()
-        return authorizedRequest.withRefreshedAccessToken(
-            refreshedAccessToken = tokenResponse.accessToken,
-            newRefreshToken = tokenResponse.refreshToken,
-            at = tokenResponse.timestamp,
-            newAuthorizationServerDpopNonce = newDpopNonce,
-        )
-    }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RefreshAccessTokenImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RefreshAccessTokenImpl.kt
@@ -16,23 +16,30 @@
 package eu.europa.ec.eudi.openid4vci.internal
 
 import eu.europa.ec.eudi.openid4vci.AuthorizedRequest
+import eu.europa.ec.eudi.openid4vci.RefreshAccessToken
 import eu.europa.ec.eudi.openid4vci.internal.http.TokenEndpointClient
 import eu.europa.ec.eudi.openid4vci.runCatchingCancellable
 import java.time.Clock
 
-internal class RefreshAccessToken(
+internal class RefreshAccessTokenImpl(
     private val clock: Clock,
     private val tokenEndpointClient: TokenEndpointClient,
-) {
+) : RefreshAccessToken {
 
-    suspend fun AuthorizedRequest.refreshIfNeeded(): Result<AuthorizedRequest> = runCatchingCancellable {
-        val at = clock.instant()
-        when {
-            !isAccessTokenExpired(at) -> this
-            refreshToken == null -> error("Refresh token was not provided")
-            else -> refresh(this)
+    override suspend fun AuthorizedRequest.refresh(): Result<AuthorizedRequest> =
+        runCatchingCancellable {
+            refresh(this)
         }
-    }
+
+    override suspend fun AuthorizedRequest.refreshIfNeeded(): Result<AuthorizedRequest> =
+        runCatchingCancellable {
+            val at = clock.instant()
+            when {
+                !isAccessTokenExpired(at) -> this
+                refreshToken == null -> error("Refresh token was not provided")
+                else -> refresh(this)
+            }
+        }
 
     private suspend fun refresh(authorizedRequest: AuthorizedRequest): AuthorizedRequest {
         val refreshToken = requireNotNull(authorizedRequest.refreshToken)

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/RefreshAccessTokenImplTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/RefreshAccessTokenImplTest.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2023-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.openid4vci.internal
+
+import eu.europa.ec.eudi.openid4vci.AccessToken
+import eu.europa.ec.eudi.openid4vci.AuthorizedRequest
+import eu.europa.ec.eudi.openid4vci.Grant
+import eu.europa.ec.eudi.openid4vci.OpenId4VCIConfiguration
+import eu.europa.ec.eudi.openid4vci.RefreshToken
+import eu.europa.ec.eudi.openid4vci.SampleIssuer
+import eu.europa.ec.eudi.openid4vci.internal.http.TokenEndpointClient
+import eu.europa.ec.eudi.openid4vci.mockedHttpClient
+import eu.europa.ec.eudi.openid4vci.oauthAuthorizationServerMetadata
+import eu.europa.ec.eudi.openid4vci.tokenPostMocker
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.request.forms.FormDataContent
+import io.ktor.http.HttpMethod
+import kotlinx.coroutines.test.runTest
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
+import kotlin.test.fail
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.toJavaDuration
+
+class RefreshAccessTokenImplTest {
+    private val clock = Clock.systemDefaultZone()
+
+    @Test
+    fun `fails when no refresh token is present`() = runTest {
+        val engine = MockEngine { fail("no http calls were expected") }
+        val tokenEndpointClient = tokenEndpointClient(HttpClient(engine))
+        val refreshAccessToken = RefreshAccessTokenImpl(clock, tokenEndpointClient)
+
+        val authorizedRequest = authorizedRequest(
+            accessTokenIssuedAt = clock.instant(),
+            accessTokenExpiresIn = 0.minutes.toJavaDuration(),
+            refreshToken = null,
+        )
+
+        with(refreshAccessToken) {
+            val exception = assertFailsWith<IllegalStateException> { authorizedRequest.refresh().getOrThrow() }
+            assertEquals("Refresh token was not provided", exception.message)
+        }
+
+        with(refreshAccessToken) {
+            val exception = assertFailsWith<IllegalStateException> { authorizedRequest.refreshIfNeeded().getOrThrow() }
+            assertEquals("Refresh token was not provided", exception.message)
+        }
+    }
+
+    @Test
+    fun `does not refresh when not needed`() = runTest {
+        val engine = MockEngine { fail("no http calls were expected") }
+        val tokenEndpointClient = tokenEndpointClient(HttpClient(engine))
+        val refreshAccessToken = RefreshAccessTokenImpl(clock, tokenEndpointClient)
+
+        val authorizedRequest = authorizedRequest(
+            accessTokenIssuedAt = clock.instant(),
+            accessTokenExpiresIn = 10.minutes.toJavaDuration(),
+            refreshToken = RefreshToken("Refresh"),
+        )
+
+        val refreshedAuthorizedRequest = with(refreshAccessToken) {
+            authorizedRequest.refreshIfNeeded().getOrThrow()
+        }
+        assertEquals(authorizedRequest, refreshedAuthorizedRequest)
+    }
+
+    @Test
+    fun `refreshes when manually forced`() = runTest {
+        val httpClient = mockedHttpClient(
+            tokenPostMocker {
+                assertEquals(HttpMethod.Post, it.method)
+                val formData = assertIs<FormDataContent>(it.body).formData
+                assertEquals("refresh_token", formData["grant_type"])
+                assertEquals("Refresh", formData["refresh_token"])
+            },
+        )
+        val tokenEndpointClient = tokenEndpointClient(httpClient)
+        val refreshAccessToken = RefreshAccessTokenImpl(clock, tokenEndpointClient)
+
+        val authorizedRequest = authorizedRequest(
+            accessTokenIssuedAt = clock.instant(),
+            accessTokenExpiresIn = 10.minutes.toJavaDuration(),
+            refreshToken = RefreshToken("Refresh"),
+        )
+
+        val refreshedAuthorizedRequest = with(refreshAccessToken) {
+            authorizedRequest.refresh().getOrThrow()
+        }
+        assertNotEquals(authorizedRequest, refreshedAuthorizedRequest)
+        assertNotEquals(authorizedRequest.accessToken, refreshedAuthorizedRequest.accessToken)
+        assertEquals(authorizedRequest.refreshToken, refreshedAuthorizedRequest.refreshToken)
+    }
+
+    @Test
+    fun `refreshes if needed`() = runTest {
+        val httpClient = mockedHttpClient(
+            tokenPostMocker {
+                assertEquals(HttpMethod.Post, it.method)
+                val formData = assertIs<FormDataContent>(it.body).formData
+                assertEquals("refresh_token", formData["grant_type"])
+                assertEquals("Refresh", formData["refresh_token"])
+            },
+        )
+        val tokenEndpointClient = tokenEndpointClient(httpClient)
+        val refreshAccessToken = RefreshAccessTokenImpl(clock, tokenEndpointClient)
+
+        val authorizedRequest = authorizedRequest(
+            accessTokenIssuedAt = clock.instant(),
+            accessTokenExpiresIn = 0.minutes.toJavaDuration(),
+            refreshToken = RefreshToken("Refresh"),
+        )
+
+        val refreshedAuthorizedRequest = with(refreshAccessToken) {
+            authorizedRequest.refreshIfNeeded().getOrThrow()
+        }
+        assertNotEquals(authorizedRequest, refreshedAuthorizedRequest)
+        assertNotEquals(authorizedRequest.accessToken, refreshedAuthorizedRequest.accessToken)
+        assertEquals(authorizedRequest.refreshToken, refreshedAuthorizedRequest.refreshToken)
+    }
+}
+
+private fun authorizedRequest(
+    accessTokenIssuedAt: Instant,
+    accessTokenExpiresIn: Duration,
+    refreshToken: RefreshToken?,
+) = AuthorizedRequest(
+    accessToken = AccessToken.Bearer("Token", accessTokenExpiresIn),
+    refreshToken = refreshToken,
+    credentialIdentifiers = emptyMap(),
+    timestamp = accessTokenIssuedAt,
+    authorizationServerDpopNonce = null,
+    resourceServerDpopNonce = null,
+    grant = Grant.AuthorizationCode,
+)
+
+private fun tokenEndpointClient(httpClient: HttpClient) = TokenEndpointClient(
+    SampleIssuer.Id,
+    oauthAuthorizationServerMetadata(),
+    OpenId4VCIConfiguration,
+    null,
+    httpClient,
+)

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/RefreshAccessTokenImplTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/RefreshAccessTokenImplTest.kt
@@ -49,7 +49,7 @@ class RefreshAccessTokenImplTest {
     fun `fails when no refresh token is present`() = runTest {
         val engine = MockEngine { fail("no http calls were expected") }
         val tokenEndpointClient = tokenEndpointClient(HttpClient(engine))
-        val refreshAccessToken = RefreshAccessTokenImpl(clock, tokenEndpointClient)
+        val refreshAccessToken = RefreshAccessTokenImpl(tokenEndpointClient)
 
         val authorizedRequest = authorizedRequest(
             accessTokenIssuedAt = clock.instant(),
@@ -61,33 +61,10 @@ class RefreshAccessTokenImplTest {
             val exception = assertFailsWith<IllegalStateException> { authorizedRequest.refresh().getOrThrow() }
             assertEquals("Refresh token was not provided", exception.message)
         }
-
-        with(refreshAccessToken) {
-            val exception = assertFailsWith<IllegalStateException> { authorizedRequest.refreshIfNeeded().getOrThrow() }
-            assertEquals("Refresh token was not provided", exception.message)
-        }
     }
 
     @Test
-    fun `does not refresh when not needed`() = runTest {
-        val engine = MockEngine { fail("no http calls were expected") }
-        val tokenEndpointClient = tokenEndpointClient(HttpClient(engine))
-        val refreshAccessToken = RefreshAccessTokenImpl(clock, tokenEndpointClient)
-
-        val authorizedRequest = authorizedRequest(
-            accessTokenIssuedAt = clock.instant(),
-            accessTokenExpiresIn = 10.minutes.toJavaDuration(),
-            refreshToken = RefreshToken("Refresh"),
-        )
-
-        val refreshedAuthorizedRequest = with(refreshAccessToken) {
-            authorizedRequest.refreshIfNeeded().getOrThrow()
-        }
-        assertEquals(authorizedRequest, refreshedAuthorizedRequest)
-    }
-
-    @Test
-    fun `refreshes when manually forced`() = runTest {
+    fun `refreshes when manually invoked`() = runTest {
         val httpClient = mockedHttpClient(
             tokenPostMocker {
                 assertEquals(HttpMethod.Post, it.method)
@@ -97,7 +74,7 @@ class RefreshAccessTokenImplTest {
             },
         )
         val tokenEndpointClient = tokenEndpointClient(httpClient)
-        val refreshAccessToken = RefreshAccessTokenImpl(clock, tokenEndpointClient)
+        val refreshAccessToken = RefreshAccessTokenImpl(tokenEndpointClient)
 
         val authorizedRequest = authorizedRequest(
             accessTokenIssuedAt = clock.instant(),
@@ -107,33 +84,6 @@ class RefreshAccessTokenImplTest {
 
         val refreshedAuthorizedRequest = with(refreshAccessToken) {
             authorizedRequest.refresh().getOrThrow()
-        }
-        assertNotEquals(authorizedRequest, refreshedAuthorizedRequest)
-        assertNotEquals(authorizedRequest.accessToken, refreshedAuthorizedRequest.accessToken)
-        assertEquals(authorizedRequest.refreshToken, refreshedAuthorizedRequest.refreshToken)
-    }
-
-    @Test
-    fun `refreshes if needed`() = runTest {
-        val httpClient = mockedHttpClient(
-            tokenPostMocker {
-                assertEquals(HttpMethod.Post, it.method)
-                val formData = assertIs<FormDataContent>(it.body).formData
-                assertEquals("refresh_token", formData["grant_type"])
-                assertEquals("Refresh", formData["refresh_token"])
-            },
-        )
-        val tokenEndpointClient = tokenEndpointClient(httpClient)
-        val refreshAccessToken = RefreshAccessTokenImpl(clock, tokenEndpointClient)
-
-        val authorizedRequest = authorizedRequest(
-            accessTokenIssuedAt = clock.instant(),
-            accessTokenExpiresIn = 0.minutes.toJavaDuration(),
-            refreshToken = RefreshToken("Refresh"),
-        )
-
-        val refreshedAuthorizedRequest = with(refreshAccessToken) {
-            authorizedRequest.refreshIfNeeded().getOrThrow()
         }
         assertNotEquals(authorizedRequest, refreshedAuthorizedRequest)
         assertNotEquals(authorizedRequest.accessToken, refreshedAuthorizedRequest.accessToken)


### PR DESCRIPTION
This PR introduces `RefreshAccessToken` as a new capability to `Issuer` and `DeferredIssuer`. 

It allows clients to manually run a `refresh_token` grant if needed.

This functionality already existed in the library and was transparently handled by the library when querying for deferred credentials. 
This PR effectively makes it public.

Closes #522 