### PR TITLE
Implemented credential reuse policies per credential configuration (#…

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ data class OpenId4VCIConfig(
     val parUsage: ParUsage = ParUsage.IfSupported,
     val clock: Clock = Clock.systemDefaultZone(),
     val issuerMetadataPolicy: IssuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
+    val supportedReuseMethods: Set<ReuseMethod> = emptySet(),
 )
 ```
 
@@ -616,6 +617,7 @@ Options available:
   - `IssuerMetadataPolicy.RequireSigned`: require the presence of signed metadata and use only values from signed metadata
   - `IssuerMetadataPolicy.PreferSigned`: presence of signed metadata is optional, if present values from signed metadata take precedence
   - `IssuerMetadataPolicy.IgnoreSigned`: signed metadata are ignored
+- supportedReuseMethods: A set of `ReuseMethod`s supported by the wallet for credential reuse. Defaults to `emptySet()`.
 
 Trust between the Wallet and the Signer of the signed metadata advertised by the Credential Issuer is established using one of the following ways:
 - `IssuerTrust.ByPublicKey`: trusting the public key used to sign the metadata
@@ -631,10 +633,11 @@ val openId4VCIConfig = OpenId4VCIConfig(
     encryptionSupportConfig = EncryptionSupportConfig(
         compressionAlgorithms = listOf(CompressionAlgorithm.DEF), // which JWE compression algorithms are supported
         credentialResponseEncryptionPolicy = CredentialResponseEncryptionPolicy.SUPPORTED, // policy concerning the wallet's requirements for encryption of credential responses,
-        ecConfig =  EcConfig(curve = Curve.P_256, supportedJWEAlgorithms = EcConfig.SUPPORTED_ENCRYPTION_ALGORITHMS.toList()), // the EC Curve and JWE algorithms supported
-        rsaConfig =  RsaConfig(rcaKeySize = 4096, supportedJWEAlgorithms = RsaConfig.SUPPORTED_ENCRYPTION_ALGORITHMS.toList()), // the RSA key size and JWE algorithms supported
-        supportedEncryptionMethods = EncryptionSupportConfig.SUPPORTED_ENCRYPTION_METHODS.toList() // which JWE encryption methods are supported
-    )
+        ecConfig =  EcConfig(curve = Curve.P_256, supportedJWEAlgorithms = ECDHEncrypter.SUPPORTED_ALGORITHMS.toList()), // the EC Curve and JWE algorithms supported
+        rsaConfig =  RsaConfig(rcaKeySize = 4096, supportedJWEAlgorithms = RSAEncrypter.SUPPORTED_ALGORITHMS.toList()), // the RSA key size and JWE algorithms supported
+        supportedEncryptionMethods = ContentCryptoProvider.SUPPORTED_ENCRYPTION_METHODS.toList() // which JWE encryption methods are supported
+    ),
+    supportedReuseMethods = setOf(ReuseMethod.ONCE_ONLY, ReuseMethod.LIMITED_TIME) // which reuse methods are supported
 )
 val credentialOfferUri: String = "..." 
 val issuer = Issuer.make(openId4VCIConfig, credentialOfferUri).getOrThrow()

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 
 # Project properties
 group=eu.europa.ec.eudi
-version=0.10.2-SNAPSHOT
+version=0.11.0-SNAPSHOT
 
 # Sonar
 systemProp.sonar.host.url=https://sonarcloud.io

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/ClientAttestation.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/ClientAttestation.kt
@@ -56,6 +56,9 @@ value class ClientAttestationJWT(val jwt: SignedJWT) {
         val cnf = requireNotNull(jwt.jwtClaimsSet.cnf()) { "Invalid Attestation JWT. Misses `cnf` claim" }
         requireNotNull(cnf.cnfJwk()) { "Invalid Attestation JWT. Misses `jwk` claim from `cnf`" }
         jwt.ensureSignedOrVerified()
+        require(jwt.header.algorithm in TS3.WALLET_INSTANCE_ATTESTATION_ALLOWED_SIGNATURE_ALGORITHMS) {
+            "Invalid Attestation JWT. Signature algorithm must be one of ${TS3.WALLET_INSTANCE_ATTESTATION_ALLOWED_SIGNATURE_ALGORITHMS}"
+        }
     }
 
     val clientId: ClientId get() = checkNotNull(jwt.jwtClaimsSet.subject)

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
@@ -73,6 +73,7 @@ sealed interface ClientAuthentication : java.io.Serializable {
  * @param parUsage whether to use PAR in case of authorization code grant
  * @param clock Wallet's clock
  * @param issuerMetadataPolicy policy concerning signed metadata usage
+ * @param supportedCredentialReusePolicies the reuse policies supported by the wallet, used to validate against credential issuer metadata.
  */
 data class OpenId4VCIConfig(
     val clientAuthentication: ClientAuthentication,
@@ -84,6 +85,7 @@ data class OpenId4VCIConfig(
     val parUsage: ParUsage = ParUsage.IfSupported,
     val clock: Clock = Clock.systemDefaultZone(),
     val issuerMetadataPolicy: IssuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
+    val supportedCredentialReusePolicies: CredentialReusePolicies? = null,
 ) {
 
     /**
@@ -99,6 +101,7 @@ data class OpenId4VCIConfig(
         parUsage: ParUsage = ParUsage.IfSupported,
         clock: Clock = Clock.systemDefaultZone(),
         issuerMetadataPolicy: IssuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
+        supportedCredentialReusePolicies: CredentialReusePolicies? = null,
     ) : this(
         ClientAuthentication.None(clientId),
         authFlowRedirectionURI,
@@ -109,6 +112,7 @@ data class OpenId4VCIConfig(
         parUsage,
         clock,
         issuerMetadataPolicy,
+        supportedCredentialReusePolicies,
     )
 
     /**
@@ -125,6 +129,7 @@ data class OpenId4VCIConfig(
         parUsage: ParUsage = ParUsage.IfSupported,
         clock: Clock = Clock.systemDefaultZone(),
         issuerMetadataPolicy: IssuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
+        supportedCredentialReusePolicies: CredentialReusePolicies? = null,
     ) : this (
         clientAuthentication,
         authFlowRedirectionURI,
@@ -135,6 +140,7 @@ data class OpenId4VCIConfig(
         parUsage,
         clock,
         issuerMetadataPolicy,
+        supportedCredentialReusePolicies,
     )
 
     /**
@@ -151,6 +157,7 @@ data class OpenId4VCIConfig(
         parUsage: ParUsage = ParUsage.IfSupported,
         clock: Clock = Clock.systemDefaultZone(),
         issuerMetadataPolicy: IssuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
+        supportedCredentialReusePolicies: CredentialReusePolicies? = null,
     ) : this(
         ClientAuthentication.None(clientId),
         authFlowRedirectionURI,
@@ -161,6 +168,7 @@ data class OpenId4VCIConfig(
         parUsage,
         clock,
         issuerMetadataPolicy,
+        supportedCredentialReusePolicies,
     )
 
     @Deprecated(
@@ -169,6 +177,37 @@ data class OpenId4VCIConfig(
     )
     val clientId: ClientId
         get() = clientAuthentication.id
+}
+
+/**
+ * Wallet's policy regarding supported credential reuse policies.
+ */
+sealed interface CredentialReusePolicies {
+    val policyTypes: Set<EudiReusePolicyType>
+
+    /**
+     * The Wallet supports the provided reuse policies.
+     */
+    data class Supported(override val policyTypes: Set<EudiReusePolicyType>) : CredentialReusePolicies {
+        init {
+            require(policyTypes.isNotEmpty()) { "policyTypes must not be empty" }
+            require(policyTypes.contains(EudiReusePolicyType.OnceOnly) || policyTypes.contains(EudiReusePolicyType.LimitedTime)) {
+                "policyTypes must contain at least one of OnceOnly or LimitedTime"
+            }
+        }
+    }
+
+    /**
+     * The Wallet requires at least one of the provided reuse policies to be used.
+     */
+    data class Required(override val policyTypes: Set<EudiReusePolicyType>) : CredentialReusePolicies {
+        init {
+            require(policyTypes.isNotEmpty()) { "policyTypes must not be empty" }
+            require(policyTypes.contains(EudiReusePolicyType.OnceOnly) || policyTypes.contains(EudiReusePolicyType.LimitedTime)) {
+                "policyTypes must contain at least one of OnceOnly or LimitedTime"
+            }
+        }
+    }
 }
 
 /**

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
@@ -183,6 +183,7 @@ data class Display(
 data class CredentialMetadata(
     val display: List<Display>? = emptyList(),
     val claims: List<Claim>? = emptyList(),
+    val credentialReusePolicy: CredentialReusePolicy = CredentialReusePolicy.None,
 )
 
 /**

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialReusePolicy.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialReusePolicy.kt
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2023-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.openid4vci
+
+import java.io.Serializable
+import kotlin.time.Duration
+
+sealed class EudiReusePolicyType(val jsonValue: String) {
+    data object OnceOnly : EudiReusePolicyType("once_only")
+    data object LimitedTime : EudiReusePolicyType("limited_time")
+    data object RotatingBatch : EudiReusePolicyType("rotating-batch")
+    data object PerRelyingParty : EudiReusePolicyType("per-relying-party")
+
+    companion object {
+        fun fromJsonValue(value: String): EudiReusePolicyType =
+            entries.firstOrNull { it.jsonValue == value }
+                ?: throw IllegalArgumentException("Unsupported credential reuse method: $value")
+
+        val entries: List<EudiReusePolicyType> by lazy {
+            listOf(
+                OnceOnly,
+                LimitedTime,
+                RotatingBatch,
+                PerRelyingParty,
+            )
+        }
+    }
+}
+
+/**
+ * A single ARF Annex II option in the reuse policy.
+ */
+sealed interface EudiReusePolicy {
+
+    val batchSize: Int?
+    val reissueTriggerUnused: Int?
+    val reissueTriggerLifetimeLeft: Duration?
+
+    /**
+     * Checks if the client supports this reuse policy option.
+     */
+    fun isSupported(supportedReusePolicies: CredentialReusePolicies?): Boolean
+
+    data class OnceOnly(
+        override val batchSize: Int,
+        override val reissueTriggerUnused: Int,
+    ) : EudiReusePolicy {
+
+        init {
+            validateBatchSize(batchSize)
+            validateReissueTriggerUnused(reissueTriggerUnused, batchSize)
+        }
+
+        override fun isSupported(supportedReusePolicies: CredentialReusePolicies?): Boolean =
+            supportedReusePolicies?.policyTypes?.contains(EudiReusePolicyType.OnceOnly) ?: false
+
+        override val reissueTriggerLifetimeLeft: Duration? = null
+    }
+
+    data class LimitedTime(
+        override val reissueTriggerLifetimeLeft: Duration,
+    ) : EudiReusePolicy {
+
+        init {
+            validateReissueTriggerLifetimeLeft(reissueTriggerLifetimeLeft)
+        }
+
+        override fun isSupported(supportedReusePolicies: CredentialReusePolicies?): Boolean =
+            supportedReusePolicies?.policyTypes?.contains(EudiReusePolicyType.LimitedTime) ?: false
+
+        override val reissueTriggerUnused: Int? = null
+        override val batchSize: Int? = null
+    }
+
+    data class RotatingBatch(
+        override val batchSize: Int,
+        override val reissueTriggerLifetimeLeft: Duration,
+    ) : EudiReusePolicy {
+
+        init {
+            validateBatchSize(batchSize)
+            validateReissueTriggerLifetimeLeft(reissueTriggerLifetimeLeft)
+        }
+
+        override val reissueTriggerUnused: Int? = null
+
+        override fun isSupported(supportedReusePolicies: CredentialReusePolicies?): Boolean =
+            supportedReusePolicies?.policyTypes?.contains(EudiReusePolicyType.RotatingBatch) ?: false
+    }
+
+    data class PerRelyingParty(
+        override val batchSize: Int,
+        override val reissueTriggerLifetimeLeft: Duration,
+        override val reissueTriggerUnused: Int,
+    ) : EudiReusePolicy {
+
+        init {
+            validateBatchSize(batchSize)
+            validateReissueTriggerLifetimeLeft(reissueTriggerLifetimeLeft)
+            validateReissueTriggerUnused(reissueTriggerUnused, batchSize)
+        }
+
+        override fun isSupported(supportedReusePolicies: CredentialReusePolicies?): Boolean =
+            supportedReusePolicies?.policyTypes?.contains(EudiReusePolicyType.PerRelyingParty) ?: false
+    }
+
+    companion object {
+        fun fromDetails(
+            details: List<EudiReusePolicyType>,
+            batchSize: Int? = null,
+            reissueTriggerUnused: Int? = null,
+            reissueTriggerLifetimeLeft: Duration? = null,
+        ): List<EudiReusePolicy> {
+            val normalizedDetails = details.distinct()
+
+            require(normalizedDetails.isNotEmpty()) { "details must not be empty" }
+            require(normalizedDetails.size == details.size) {
+                "details must not contain duplicate values"
+            }
+            validateBaseMethodCombination(normalizedDetails)
+
+            return normalizedDetails.map { detail ->
+                when (detail) {
+                    EudiReusePolicyType.OnceOnly -> OnceOnly(
+                        batchSize = requireNotNull(batchSize) {
+                            "batch_size is required when details contains once_only, rotating-batch, or per-relying-party"
+                        },
+                        reissueTriggerUnused = requireNotNull(reissueTriggerUnused) {
+                            "reissue_trigger_unused is required when details contains once_only"
+                        },
+                    )
+
+                    EudiReusePolicyType.LimitedTime -> LimitedTime(
+                        reissueTriggerLifetimeLeft = requireNotNull(reissueTriggerLifetimeLeft) {
+                            "reissue_trigger_lifetime_left is required when details contains limited_time, " +
+                                "rotating-batch, or per-relying-party"
+                        },
+                    )
+
+                    EudiReusePolicyType.RotatingBatch -> RotatingBatch(
+                        batchSize = requireNotNull(batchSize) {
+                            "batch_size is required when details contains once_only, rotating-batch, or per-relying-party"
+                        },
+                        reissueTriggerLifetimeLeft = requireNotNull(reissueTriggerLifetimeLeft) {
+                            "reissue_trigger_lifetime_left is required when details contains limited_time, " +
+                                "rotating-batch, or per-relying-party"
+                        },
+                    )
+
+                    EudiReusePolicyType.PerRelyingParty -> PerRelyingParty(
+                        batchSize = requireNotNull(batchSize) {
+                            "batch_size is required when details contains once_only, " +
+                                "rotating-batch, or per-relying-party"
+                        },
+                        reissueTriggerLifetimeLeft = requireNotNull(reissueTriggerLifetimeLeft) {
+                            "reissue_trigger_lifetime_left is required when details contains limited_time, " +
+                                "rotating-batch, or per-relying-party"
+                        },
+                        reissueTriggerUnused = requireNotNull(reissueTriggerUnused) {
+                            "reissue_trigger_unused is required when details contains once_only or per-relying-party"
+                        },
+                    )
+                }
+            }
+        }
+
+        private fun validateBaseMethodCombination(details: List<EudiReusePolicyType>) {
+            val hasOnceOnly = EudiReusePolicyType.OnceOnly in details
+            val hasLimitedTime = EudiReusePolicyType.LimitedTime in details
+
+            require(hasOnceOnly.xor(hasLimitedTime)) {
+                "details must contain exactly one base method: once_only or limited_time"
+            }
+        }
+
+        private fun validateBatchSize(batchSize: Int) {
+            require(batchSize > 1) { "batch_size must be greater than 1" }
+        }
+
+        private fun validateReissueTriggerUnused(reissueTriggerUnused: Int, batchSize: Int) {
+            require(reissueTriggerUnused >= 0) { "reissue_trigger_unused must be non-negative" }
+            require(reissueTriggerUnused < batchSize) { "reissue_trigger_unused must be lower than batch_size" }
+        }
+
+        private fun validateReissueTriggerLifetimeLeft(reissueTriggerLifetimeLeft: Duration) {
+            require(reissueTriggerLifetimeLeft.isPositive()) { "reissue_trigger_lifetime_left must be greater than 0" }
+        }
+    }
+}
+
+/**
+ * Credential reuse policy as it may appear in the credential metadata of a credential configuration.
+ *
+ */
+sealed interface CredentialReusePolicy : Serializable {
+
+    /**
+     * No reuse policy is defined.
+     */
+    data object None : CredentialReusePolicy {
+        private fun readResolve(): Any = None
+    }
+
+    /**
+     * ARF Annex II reuse policy.
+     *
+     * @param options extra details about the specific reuse policy
+     */
+    data class EUDI(
+        val options: List<EudiReusePolicy>,
+    ) : CredentialReusePolicy {
+
+        init {
+            require(options.isNotEmpty()) { "options must not be empty for arf_annex_ii policy" }
+            validateNoOverlappingDetails(options)
+        }
+
+        companion object {
+
+            private fun validateNoOverlappingDetails(options: List<EudiReusePolicy>) {
+                if (options.size <= 1) return
+                val optionTypes = options.map { it::class }
+                require(optionTypes.size == optionTypes.toSet().size) {
+                    "When multiple policy options are defined, each option type must be unique"
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
@@ -69,10 +69,13 @@ sealed interface SubmissionOutcome : java.io.Serializable {
      *
      * @param credentials The credentials issued
      * @param notificationId The identifier to be used in issuer's notification endpoint.
+     * @param selectedCredentialReusePolicy The supported credential reuse policy option selected by the wallet
+     * for this issuance, if any.
      */
     data class Success(
         val credentials: List<IssuedCredential>,
         val notificationId: NotificationId?,
+        val selectedCredentialReusePolicy: EudiReusePolicy? = null,
     ) : SubmissionOutcome {
         init {
             require(credentials.isNotEmpty()) { "credentials must not be empty" }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Specs.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Specs.kt
@@ -15,6 +15,8 @@
  */
 package eu.europa.ec.eudi.openid4vci
 
+import com.nimbusds.jose.JWSAlgorithm
+
 /**
  * [OpenID for Verifiable Credential Issuance](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html)
  */
@@ -105,4 +107,23 @@ object RFC7519 {
     const val NOT_BEFORE: String = "nbf"
     const val ISSUED_AT: String = "iat"
     const val JWT_ID: String = "jti"
+}
+
+/**
+ * [Specification of Wallet Unit Attestations (WUA) used in issuance of PID and Attestations](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts3-wallet-unit-attestation.md)
+ */
+object TS3 {
+    val WALLET_INSTANCE_ATTESTATION_ALLOWED_SIGNATURE_ALGORITHMS: Set<JWSAlgorithm> =
+        setOf(JWSAlgorithm.ES256, JWSAlgorithm.ES384, JWSAlgorithm.ES512)
+}
+
+object ETSI4723 {
+    const val REUSE_POLICY_ARF_ANNEX_II = "arf_annex_ii"
+    const val CREDENTIAL_REUSE_POLICY = "credential_reuse_policy"
+    const val CREDENTIAL_REUSE_POLICY_ID = "id"
+    const val CREDENTIAL_REUSE_POLICY_OPTIONS = "options"
+    const val REUSE_POLICY_OPTION_DETAILS = "details"
+    const val REUSE_POLICY_OPTION_BATCH_SIZE = "batch_size"
+    const val REUSE_POLICY_OPTION_TRIGGER_UNUSED = "reissue_trigger_unused"
+    const val REUSE_POLICY_OPTION_TRIGGER_LIFETIME = "reissue_trigger_lifetime_left"
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -58,8 +58,15 @@ internal class RequestIssuanceImpl(
         proofsSpecification: ProofsSpecification,
     ): Result<AuthorizedRequestAnd<SubmissionOutcome>> = runCatchingCancellable {
         validateRequestPayload(requestPayload, credentialIdentifiers.orEmpty())
+        val credentialConfiguration = credentialSupportedById(requestPayload.credentialConfigurationIdentifier)
+        val selectedCredentialReusePolicy = selectCredentialReusePolicy(credentialConfiguration)
 
-        val (proofs, proofsDpopNonce) = buildProofs(proofsSpecification, requestPayload.credentialConfigurationIdentifier, grant)
+        val (proofs, proofsDpopNonce) = buildProofs(
+            proofsSpecification,
+            selectedCredentialReusePolicy,
+            requestPayload.credentialConfigurationIdentifier,
+            grant,
+        )
         val credentialRequest = buildRequest(requestPayload, proofs, credentialIdentifiers.orEmpty())
 
         // Place the request
@@ -74,7 +81,7 @@ internal class RequestIssuanceImpl(
         // Update state (maybe) with new Dpop Nonce from resource server
         val updatedAuthorizedRequest =
             this.withResourceServerDpopNonce(newResourceServerDpopNonce ?: proofsOrAuthRequestDpopNonce)
-        updatedAuthorizedRequest to outcome.toPub()
+        updatedAuthorizedRequest to outcome.withSelectedCredentialReusePolicy(selectedCredentialReusePolicy).toPub()
     }
 
     private fun validateRequestPayload(
@@ -101,6 +108,7 @@ internal class RequestIssuanceImpl(
 
     private suspend fun buildProofs(
         proofsSpecification: ProofsSpecification,
+        selectedReusePolicy: EudiReusePolicy?,
         credentialConfigId: CredentialConfigurationIdentifier,
         grant: Grant,
     ): Pair<List<Proof>, Nonce?> {
@@ -114,6 +122,7 @@ internal class RequestIssuanceImpl(
                 val proofs = listOf(
                     jwtProofWithKeyAttestation(
                         proofsSpecification,
+                        selectedReusePolicy,
                         credentialConfigId,
                         grant,
                         cNonceAndDPoPNonce?.cnonce,
@@ -126,6 +135,7 @@ internal class RequestIssuanceImpl(
                 val cNonceAndDPoPNonce = cNonce()
                 val proofs = jwtProofsWithoutKeyAttestation(
                     proofsSpecification,
+                    selectedReusePolicy,
                     credentialConfigId,
                     grant,
                     cNonceAndDPoPNonce?.cnonce,
@@ -138,6 +148,7 @@ internal class RequestIssuanceImpl(
                 val proofs = listOf(
                     attestationProof(
                         proofsSpecification,
+                        selectedReusePolicy,
                         credentialConfigId,
                         cNonceAndDPoPNonce?.cnonce,
                     ),
@@ -147,7 +158,9 @@ internal class RequestIssuanceImpl(
         }
     }
 
-    private fun ProofsSpecification.ensureCompatibleWith(credentialConfigId: CredentialConfigurationIdentifier) {
+    private fun ProofsSpecification.ensureCompatibleWith(
+        credentialConfigId: CredentialConfigurationIdentifier,
+    ) {
         val credentialConfiguration = credentialSupportedById(credentialConfigId)
         val proofTypesSupported = credentialConfiguration.proofTypesSupported
 
@@ -188,6 +201,47 @@ internal class RequestIssuanceImpl(
         }
     }
 
+    private fun selectCredentialReusePolicy(
+        credentialConfiguration: CredentialConfiguration,
+    ): EudiReusePolicy? {
+        val reusePolicy = credentialConfiguration.credentialMetadata?.credentialReusePolicy
+        val issuerEudiReuseTypes = when (reusePolicy) {
+            is CredentialReusePolicy.EUDI -> {
+                reusePolicy.options.map {
+                    when (it) {
+                        is EudiReusePolicy.OnceOnly -> EudiReusePolicyType.OnceOnly
+                        is EudiReusePolicy.LimitedTime -> EudiReusePolicyType.LimitedTime
+                        is EudiReusePolicy.RotatingBatch -> EudiReusePolicyType.RotatingBatch
+                        is EudiReusePolicy.PerRelyingParty -> EudiReusePolicyType.PerRelyingParty
+                    }
+                }.toSet()
+            }
+            else -> null
+        }
+
+        if (config.supportedCredentialReusePolicies is CredentialReusePolicies.Required) {
+            requireNotNull(issuerEudiReuseTypes) {
+                "Credential reuse policies are required but not supported by issuer"
+            }
+            require(config.supportedCredentialReusePolicies.policyTypes.intersect(issuerEudiReuseTypes).isNotEmpty()) {
+                "None of the required credential reuse policies are supported by issuer"
+            }
+        }
+
+        return when (reusePolicy) {
+            is CredentialReusePolicy.EUDI -> {
+                val selectedPolicy = reusePolicy.options.firstOrNull {
+                    it.isSupported(config.supportedCredentialReusePolicies)
+                }
+                requireNotNull(selectedPolicy) {
+                    "The configured credential reuse policies cannot support the credential's reuse policy."
+                }
+            }
+
+            else -> null
+        }
+    }
+
     private fun credentialSupportedById(credentialId: CredentialConfigurationIdentifier): CredentialConfiguration {
         val credentialSupported =
             credentialOffer.credentialIssuerMetadata.credentialConfigurationsSupported[credentialId]
@@ -198,6 +252,7 @@ internal class RequestIssuanceImpl(
 
     private suspend fun jwtProofWithKeyAttestation(
         proofsSpecification: ProofsSpecification.JwtProofs.WithKeyAttestation,
+        selectedReusePolicy: EudiReusePolicy?,
         credentialConfigId: CredentialConfigurationIdentifier,
         grant: Grant,
         cNonce: Nonce?,
@@ -211,6 +266,7 @@ internal class RequestIssuanceImpl(
         val claims = jwtProofClaims(cNonce = cNonce, grant = grant)
         val jwtProof = proofSigner.use { operation ->
             operation.publicMaterial.ensureKeyAttestationJwtAlgIsSupported(credentialConfigId, ProofType.JWT)
+            operation.publicMaterial.attestedKeys.assertMatchesBatchIssuanceBatchSize(selectedReusePolicy)
             val signer = KeyAttestationJwtProofSigner(joseAlg, operation, keyIndex)
             val signedJwt = signer.sign(claims)
             SignedJWT.parse(signedJwt)
@@ -233,6 +289,7 @@ internal class RequestIssuanceImpl(
 
     private suspend fun jwtProofsWithoutKeyAttestation(
         proofsSpecification: ProofsSpecification.JwtProofs.NoKeyAttestation,
+        selectedReusePolicy: EudiReusePolicy?,
         credentialConfigId: CredentialConfigurationIdentifier,
         grant: Grant,
         cNonce: Nonce?,
@@ -242,7 +299,7 @@ internal class RequestIssuanceImpl(
             javaSigningAlgorithm.toSupportedJoseAlgorithm(credentialConfigId)
         }
         return proofsSpecification.proofsSigner.use { operation ->
-            operation.assertMatchesBatchIssuanceBatchSize()
+            operation.assertMatchesBatchIssuanceBatchSize(selectedReusePolicy)
             val proofsSigner = JwtProofsSigner(joseAlg, operation)
             val claims = jwtProofClaims(cNonce = cNonce, grant = grant)
             proofsSigner.sign(claims).map {
@@ -253,30 +310,57 @@ internal class RequestIssuanceImpl(
 
     private suspend fun attestationProof(
         proofsSpecification: ProofsSpecification.AttestationProof,
+        selectedReusePolicy: EudiReusePolicy?,
         credentialConfigId: CredentialConfigurationIdentifier,
         cNonce: Nonce?,
     ): Proof.Attestation {
         val keyAttestationJwt = proofsSpecification.attestationProvider(cNonce)
         keyAttestationJwt.ensureKeyAttestationJwtAlgIsSupported(credentialConfigId, ProofType.ATTESTATION)
+        keyAttestationJwt.attestedKeys.assertMatchesBatchIssuanceBatchSize(selectedReusePolicy)
         return Proof.Attestation(keyAttestationJwt)
     }
 
-    private fun BatchSignOperation<JwtBindingKey>.assertMatchesBatchIssuanceBatchSize() =
-        when (val popSignersNo = operations.size) {
-            0 -> error("At least one PopSigner is required in Authorized.ProofRequired")
-            1 -> Unit
-            else -> {
+    private fun BatchSignOperation<JwtBindingKey>.assertMatchesBatchIssuanceBatchSize(
+        selectedReusePolicy: EudiReusePolicy?,
+    ) = operations.size.assertMatchesBatchIssuanceBatchSize(selectedReusePolicy)
+
+    private fun List<JWK>.assertMatchesBatchIssuanceBatchSize(
+        selectedReusePolicy: EudiReusePolicy?,
+    ) = size.assertMatchesBatchIssuanceBatchSize(selectedReusePolicy)
+
+    private fun Int.assertMatchesBatchIssuanceBatchSize(
+        selectedReusePolicy: EudiReusePolicy?,
+    ) = when (this) {
+        0 -> error("At least one PopSigner is required in Authorized.ProofRequired")
+        1 -> Unit
+        else -> {
+            if (selectedReusePolicy != null) {
+                when (selectedReusePolicy) {
+                    is EudiReusePolicy.LimitedTime ->
+                        throw CredentialIssuanceError.IssuerDoesNotSupportBatchIssuance()
+
+                    else -> {
+                        val policyBatchSize = checkNotNull(selectedReusePolicy.batchSize) {
+                            "Batch reuse policy ${selectedReusePolicy::class} with null batch size"
+                        }
+                        ensure(this <= policyBatchSize) {
+                            CredentialIssuanceError.IssuerBatchSizeLimitExceeded(policyBatchSize)
+                        }
+                    }
+                }
+            } else {
                 when (batchCredentialIssuance) {
-                    BatchCredentialIssuance.NotSupported -> CredentialIssuanceError.IssuerDoesNotSupportBatchIssuance()
+                    BatchCredentialIssuance.NotSupported -> throw CredentialIssuanceError.IssuerDoesNotSupportBatchIssuance()
                     is BatchCredentialIssuance.Supported -> {
                         val maxBatchSize = batchCredentialIssuance.batchSize
-                        ensure(popSignersNo <= maxBatchSize) {
+                        ensure(this <= maxBatchSize) {
                             CredentialIssuanceError.IssuerBatchSizeLimitExceeded(maxBatchSize)
                         }
                     }
                 }
             }
         }
+    }
 
     private fun String.toSupportedJoseAlgorithm(credentialConfigId: CredentialConfigurationIdentifier): JWSAlgorithm {
         val proofTypesSupported = credentialSupportedById(credentialConfigId).proofTypesSupported
@@ -382,6 +466,7 @@ internal sealed interface SubmissionOutcomeInternal {
     data class Success(
         val credentials: List<IssuedCredential>,
         val notificationId: NotificationId?,
+        val selectedCredentialReusePolicy: EudiReusePolicy? = null,
     ) : SubmissionOutcomeInternal
 
     data class Deferred(
@@ -399,8 +484,16 @@ internal sealed interface SubmissionOutcomeInternal {
 
     fun toPub(): SubmissionOutcome =
         when (this) {
-            is Success -> SubmissionOutcome.Success(credentials, notificationId)
+            is Success -> SubmissionOutcome.Success(credentials, notificationId, selectedCredentialReusePolicy)
             is Deferred -> SubmissionOutcome.Deferred(transactionId, interval)
             is Failed -> SubmissionOutcome.Failed(error)
+        }
+
+    fun withSelectedCredentialReusePolicy(
+        selectedCredentialReusePolicy: EudiReusePolicy?,
+    ): SubmissionOutcomeInternal =
+        when (this) {
+            is Success -> copy(selectedCredentialReusePolicy = selectedCredentialReusePolicy)
+            is Deferred, is Failed -> this
         }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialIssuerMetadataJsonParser.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialIssuerMetadataJsonParser.kt
@@ -30,6 +30,7 @@ import kotlinx.serialization.*
 import kotlinx.serialization.json.*
 import java.net.URI
 import java.util.*
+import kotlin.time.Duration.Companion.seconds
 
 internal object CredentialIssuerMetadataJsonParser {
 
@@ -61,15 +62,73 @@ private sealed interface CredentialSupportedTO {
 }
 
 @Serializable
+private data class ArfAnnex2CredentialReusePolicyOptionTO(
+    @SerialName(ETSI4723.REUSE_POLICY_OPTION_DETAILS) @Required val details: List<String>,
+    @SerialName(ETSI4723.REUSE_POLICY_OPTION_BATCH_SIZE) val batchSize: Int? = null,
+    @SerialName(ETSI4723.REUSE_POLICY_OPTION_TRIGGER_UNUSED) val reissueTriggerUnused: Int? = null,
+    @SerialName(ETSI4723.REUSE_POLICY_OPTION_TRIGGER_LIFETIME) val reissueTriggerLifetimeLeft: Long? = null,
+) {
+    fun toDomain(): List<EudiReusePolicy> =
+        EudiReusePolicy.fromDetails(
+            details = details.map { EudiReusePolicyType.fromJsonValue(it) },
+            batchSize = batchSize,
+            reissueTriggerUnused = reissueTriggerUnused,
+            reissueTriggerLifetimeLeft = reissueTriggerLifetimeLeft?.seconds,
+        )
+}
+
+@Serializable
+private data class CredentialReusePolicyTO(
+    @SerialName(ETSI4723.CREDENTIAL_REUSE_POLICY_ID) @Required val id: String,
+    @SerialName(ETSI4723.CREDENTIAL_REUSE_POLICY_OPTIONS) val options: List<JsonElement>? = null,
+) {
+    fun toDomain(): CredentialReusePolicy =
+        when (id) {
+            ETSI4723.REUSE_POLICY_ARF_ANNEX_II -> {
+                val parsed = options?.flatMap {
+                    JsonSupport.decodeFromJsonElement<ArfAnnex2CredentialReusePolicyOptionTO>(it).toDomain()
+                }.orEmpty()
+                CredentialReusePolicy.EUDI(parsed)
+            }
+            else -> CredentialReusePolicy.None
+        }
+}
+
+@Serializable
 private data class CredentialMetadataTO(
     @SerialName("display") val display: List<CredentialSupportedDisplayTO>? = null,
     @SerialName("claims") val claims: List<ClaimTO>? = null,
+    @Serializable(with = KeepKnownReusePolicies::class)
+    @SerialName(ETSI4723.CREDENTIAL_REUSE_POLICY) val credentialReusePolicy: CredentialReusePolicyTO? = null,
 ) {
     fun toDomain(): CredentialMetadata {
         val display = display?.map { it.toDomain() }.orEmpty()
         val claims = claims?.map { it.toDomain() }.orEmpty()
-        return CredentialMetadata(display, claims)
+        val reusePolicy = credentialReusePolicy?.toDomain() ?: CredentialReusePolicy.None
+        return CredentialMetadata(display, claims, reusePolicy)
     }
+}
+
+private object KeepKnownReusePolicies : JsonTransformingSerializer<CredentialReusePolicyTO>(CredentialReusePolicyTO.serializer()) {
+
+    override fun transformDeserialize(element: JsonElement): JsonElement {
+        // For unknown policies, replace with a JSON object whose id won't match
+        // any known policy, so toDomain() will map it to CredentialReusePolicy.None
+        return if (element.isKnown()) element
+        else buildJsonObject { put("id", "unknown") }
+    }
+
+    private val knownPolicies = setOf(ETSI4723.REUSE_POLICY_ARF_ANNEX_II)
+
+    private fun JsonElement.isKnown(): Boolean =
+        when (this) {
+            is JsonObject -> {
+                val policyId = get("id")?.takeIf { it is JsonPrimitive }?.jsonPrimitive?.contentOrNull
+                policyId != null && policyId in knownPolicies
+            }
+
+            else -> false
+        }
 }
 
 @Serializable

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CredentialReusePolicyTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CredentialReusePolicyTest.kt
@@ -1,0 +1,349 @@
+/*
+ * Copyright (c) 2023-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.openid4vci
+
+import com.nimbusds.jose.jwk.Curve
+import org.junit.jupiter.api.assertDoesNotThrow
+import java.net.URI
+import kotlin.test.*
+import kotlin.time.Duration.Companion.seconds
+
+internal class CredentialReusePolicyTest {
+
+    @Test
+    fun `once_only option is valid with batch_size and reissue_trigger_unused`() {
+        val option = EudiReusePolicy.OnceOnly(
+            batchSize = 10,
+            reissueTriggerUnused = 4,
+        )
+        assertEquals(10, option.batchSize)
+        assertEquals(4, option.reissueTriggerUnused)
+        assertNull(option.reissueTriggerLifetimeLeft)
+    }
+
+    @Test
+    fun `limited_time option is valid with reissue_trigger_lifetime_left`() {
+        val option = EudiReusePolicy.LimitedTime(
+            reissueTriggerLifetimeLeft = 885433.seconds,
+        )
+        assertNull(option.batchSize)
+        assertNull(option.reissueTriggerUnused)
+        assertEquals(885433.seconds, option.reissueTriggerLifetimeLeft)
+    }
+
+    @Test
+    fun `limited_time with rotating-batch and per-relying-party is valid`() {
+        val option = EudiReusePolicy.PerRelyingParty(
+            batchSize = 5,
+            reissueTriggerLifetimeLeft = 655433.seconds,
+            reissueTriggerUnused = 3,
+        )
+        assertIs<EudiReusePolicy.PerRelyingParty>(option)
+        assertEquals(5, option.batchSize)
+        assertEquals(655433.seconds, option.reissueTriggerLifetimeLeft)
+        assertEquals(3, option.reissueTriggerUnused)
+    }
+
+    @Test
+    fun `once_only with rotating-batch is valid`() {
+        val option = EudiReusePolicy.RotatingBatch(
+            batchSize = 20,
+            reissueTriggerLifetimeLeft = 100000.seconds,
+        )
+        assertIs<EudiReusePolicy.RotatingBatch>(option)
+        assertEquals(20, option.batchSize)
+        assertEquals(100000.seconds, option.reissueTriggerLifetimeLeft)
+    }
+
+    @Test
+    fun `fails when details is empty`() {
+        assertFailsWith<IllegalArgumentException> {
+            EudiReusePolicy.fromDetails(details = emptyList())
+        }
+    }
+
+    @Test
+    fun `fails when rotating-batch is used without a base detail`() {
+        assertFailsWith<IllegalArgumentException> {
+            EudiReusePolicy.fromDetails(
+                details = listOf(EudiReusePolicyType.RotatingBatch),
+                batchSize = 10,
+                reissueTriggerLifetimeLeft = 100.seconds,
+            )
+        }
+    }
+
+    @Test
+    fun `fails when per-relying-party is used without a base detail`() {
+        assertFailsWith<IllegalArgumentException> {
+            EudiReusePolicy.fromDetails(
+                details = listOf(EudiReusePolicyType.PerRelyingParty),
+                batchSize = 10,
+                reissueTriggerUnused = 2,
+                reissueTriggerLifetimeLeft = 100.seconds,
+            )
+        }
+    }
+
+    @Test
+    fun `fails when details contains both once_only and limited_time`() {
+        assertFailsWith<IllegalArgumentException> {
+            EudiReusePolicy.fromDetails(
+                details = listOf(EudiReusePolicyType.OnceOnly, EudiReusePolicyType.LimitedTime),
+                batchSize = 10,
+                reissueTriggerUnused = 2,
+                reissueTriggerLifetimeLeft = 100.seconds,
+            )
+        }
+    }
+
+    @Test
+    fun `fails when once_only is missing batch_size`() {
+        assertFailsWith<IllegalArgumentException> {
+            EudiReusePolicy.fromDetails(
+                details = listOf(EudiReusePolicyType.OnceOnly),
+                reissueTriggerUnused = 2,
+            )
+        }
+    }
+
+    @Test
+    fun `fails when once_only is missing reissue_trigger_unused`() {
+        assertFailsWith<IllegalArgumentException> {
+            EudiReusePolicy.fromDetails(
+                details = listOf(EudiReusePolicyType.OnceOnly),
+                batchSize = 10,
+            )
+        }
+    }
+
+    @Test
+    fun `fails when reissue_trigger_unused is not lower than batch_size`() {
+        assertFailsWith<IllegalArgumentException> {
+            EudiReusePolicy.OnceOnly(
+                batchSize = 10,
+                reissueTriggerUnused = 10,
+            )
+        }
+    }
+
+    @Test
+    fun `fails when limited_time is missing reissue_trigger_lifetime_left`() {
+        assertFailsWith<IllegalArgumentException> {
+            EudiReusePolicy.fromDetails(
+                details = listOf(EudiReusePolicyType.LimitedTime),
+            )
+        }
+    }
+
+    @Test
+    fun `fails when rotating-batch is missing batch_size`() {
+        assertFailsWith<IllegalArgumentException> {
+            EudiReusePolicy.fromDetails(
+                details = listOf(EudiReusePolicyType.LimitedTime, EudiReusePolicyType.RotatingBatch),
+                reissueTriggerLifetimeLeft = 100.seconds,
+            )
+        }
+    }
+
+    @Test
+    fun `fromDetails returns one option per detail entry`() {
+        val options = EudiReusePolicy.fromDetails(
+            details = listOf(
+                EudiReusePolicyType.LimitedTime,
+                EudiReusePolicyType.RotatingBatch,
+                EudiReusePolicyType.PerRelyingParty,
+            ),
+            batchSize = 5,
+            reissueTriggerLifetimeLeft = 655433.seconds,
+            reissueTriggerUnused = 3,
+        )
+
+        assertEquals(3, options.size)
+        assertIs<EudiReusePolicy.LimitedTime>(options[0])
+        val rotatingBatch = assertIs<EudiReusePolicy.RotatingBatch>(options[1])
+        assertEquals(5, rotatingBatch.batchSize)
+        assertEquals(655433.seconds, rotatingBatch.reissueTriggerLifetimeLeft)
+        assertIs<EudiReusePolicy.PerRelyingParty>(options[2])
+    }
+
+    @Test
+    fun `fromDetails returns once_only and per_relying_party options for combined details`() {
+        val options = EudiReusePolicy.fromDetails(
+            details = listOf(
+                EudiReusePolicyType.OnceOnly,
+                EudiReusePolicyType.PerRelyingParty,
+            ),
+            batchSize = 10,
+            reissueTriggerUnused = 3,
+            reissueTriggerLifetimeLeft = 200.seconds,
+        )
+
+        assertEquals(2, options.size)
+        assertIs<EudiReusePolicy.OnceOnly>(options[0])
+        val perRelyingParty = assertIs<EudiReusePolicy.PerRelyingParty>(options[1])
+        assertEquals(10, perRelyingParty.batchSize)
+        assertEquals(3, perRelyingParty.reissueTriggerUnused)
+        assertEquals(200.seconds, perRelyingParty.reissueTriggerLifetimeLeft)
+    }
+
+    @Test
+    fun `ArfAnnex2ReusePolicy requires non-empty options`() {
+        assertFailsWith<IllegalArgumentException> {
+            CredentialReusePolicy.EUDI(options = emptyList())
+        }
+    }
+
+    @Test
+    fun `CredentialReusePolicy None has no effective batch size`() {
+        val policy = CredentialReusePolicy.None
+        // There is no effectiveBatchSize in None
+    }
+
+    @Test
+    fun `ArfAnnex2ReusePolicy fails with overlapping details across options`() {
+        assertFailsWith<IllegalArgumentException> {
+            CredentialReusePolicy.EUDI(
+                options = listOf(
+                    EudiReusePolicy.RotatingBatch(
+                        batchSize = 10,
+                        reissueTriggerLifetimeLeft = 100.seconds,
+                    ),
+                    EudiReusePolicy.RotatingBatch(
+                        batchSize = 20,
+                        reissueTriggerLifetimeLeft = 200.seconds,
+                    ),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `ArfAnnex2ReusePolicy with multiple non-overlapping options is valid`() {
+        val policy = CredentialReusePolicy.EUDI(
+            options = listOf(
+                EudiReusePolicy.OnceOnly(
+                    batchSize = 10,
+                    reissueTriggerUnused = 4,
+                ),
+                EudiReusePolicy.RotatingBatch(
+                    batchSize = 20,
+                    reissueTriggerLifetimeLeft = 100.seconds,
+                ),
+            ),
+        )
+        assertEquals(2, policy.options.size)
+    }
+
+    @Test
+    fun `effectiveBatchSize returns first batch_size from supported options`() {
+        val policy = CredentialReusePolicy.EUDI(
+            options = listOf(
+                EudiReusePolicy.RotatingBatch(
+                    batchSize = 5,
+                    reissueTriggerLifetimeLeft = 885433.seconds,
+                ),
+                EudiReusePolicy.OnceOnly(
+                    batchSize = 10,
+                    reissueTriggerUnused = 4,
+                ),
+            ),
+        )
+        // If ROTATING_BATCH is not supported, it should pick the second one
+        assertEquals(10, policy.effectiveBatchSize(CredentialReusePolicies.Supported(setOf(EudiReusePolicyType.OnceOnly))))
+
+        // If ROTATING_BATCH is supported, it should pick the first one
+        assertEquals(
+            5,
+            policy.effectiveBatchSize(
+                CredentialReusePolicies.Supported(setOf(EudiReusePolicyType.LimitedTime, EudiReusePolicyType.RotatingBatch)),
+            ),
+        )
+    }
+
+    @Test
+    fun `effectiveBatchSize returns null when no batch_size present in supported options`() {
+        val policy = CredentialReusePolicy.EUDI(
+            options = listOf(
+                EudiReusePolicy.LimitedTime(
+                    reissueTriggerLifetimeLeft = 885433.seconds,
+                ),
+                EudiReusePolicy.OnceOnly(
+                    batchSize = 10,
+                    reissueTriggerUnused = 4,
+                ),
+            ),
+        )
+        // Only LIMITED_TIME is supported, which doesn't have batch_size
+        assertNull(policy.effectiveBatchSize(CredentialReusePolicies.Supported(setOf(EudiReusePolicyType.LimitedTime))))
+    }
+
+    @Test
+    fun `ArfReuseMethod jsonValue round-trip`() {
+        for (method in EudiReusePolicyType.entries) {
+            assertEquals(method, EudiReusePolicyType.fromJsonValue(method.jsonValue))
+        }
+    }
+
+    @Test
+    fun `ArfReuseMethod fromJsonValue fails for unknown`() {
+        val exception = assertFailsWith<IllegalArgumentException> {
+            EudiReusePolicyType.fromJsonValue("unknown_method")
+        }
+
+        assertTrue(exception.message?.contains("unknown_method") == true)
+    }
+
+    @Test
+    fun `fails when supportedCredentialReusePolicies is provided but doesn't contain a base method`() {
+        assertFailsWith<IllegalArgumentException> {
+            OpenId4VCIConfig(
+                clientAuthentication = ClientAuthentication.None("wallet"),
+                authFlowRedirectionURI = URI("eudi-openid4vci://cb"),
+                encryptionSupportConfig = EncryptionSupportConfig.invoke(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
+                dPoPUsage = DPoPUsage.Never,
+                supportedCredentialReusePolicies = CredentialReusePolicies.Supported(setOf(EudiReusePolicyType.RotatingBatch)),
+            )
+        }
+    }
+
+    @Test
+    fun `succeeds when supportedCredentialReusePolicies is provided and contains a base method`() {
+        assertDoesNotThrow {
+            OpenId4VCIConfig(
+                clientAuthentication = ClientAuthentication.None("wallet"),
+                authFlowRedirectionURI = URI("eudi-openid4vci://cb"),
+                encryptionSupportConfig = EncryptionSupportConfig.invoke(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
+                dPoPUsage = DPoPUsage.Never,
+                supportedCredentialReusePolicies = CredentialReusePolicies.Supported(setOf(EudiReusePolicyType.OnceOnly)),
+            )
+        }
+    }
+
+    @Test
+    fun `isSupported returns true if the policy type is in the supported policies`() {
+        val policy = CredentialReusePolicies.Supported(setOf(EudiReusePolicyType.OnceOnly))
+        assertTrue(EudiReusePolicy.OnceOnly(10, 2).isSupported(policy))
+        assertFalse(EudiReusePolicy.LimitedTime(100.seconds).isSupported(policy))
+    }
+
+    @Test
+    fun `isSupported returns true if the policy type is in the required policies`() {
+        val policy = CredentialReusePolicies.Required(setOf(EudiReusePolicyType.OnceOnly))
+        assertTrue(EudiReusePolicy.OnceOnly(10, 2).isSupported(policy))
+        assertFalse(EudiReusePolicy.LimitedTime(100.seconds).isSupported(policy))
+    }
+}

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/DefaultCredentialIssuerMetadataResolverTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/DefaultCredentialIssuerMetadataResolverTest.kt
@@ -26,10 +26,8 @@ import io.ktor.client.engine.mock.*
 import io.ktor.http.*
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.assertDoesNotThrow
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
+import kotlin.test.*
+import kotlin.time.Duration.Companion.seconds
 
 internal class DefaultCredentialIssuerMetadataResolverTest {
 
@@ -346,6 +344,66 @@ internal class DefaultCredentialIssuerMetadataResolverTest {
 
         id = CredentialIssuerId("https://issuer.example.com/tenant").getOrThrow()
         assertEquals("https://issuer.example.com/.well-known/openid-credential-issuer/tenant", id.wellKnown().toString())
+    }
+
+    @Test
+    internal fun `resolution succeeds with credential reuse policy`() = runTest {
+        val credentialIssuerId = SampleIssuer.Id
+
+        val resolver = resolver(
+            credentialIssuerMetaDataHandler(
+                credentialIssuerId,
+                "eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy.json",
+            ),
+        )
+        val metaData =
+            assertDoesNotThrow { resolver.resolve(credentialIssuerId, IssuerMetadataPolicy.IgnoreSigned).getOrThrow() }
+
+        val pidMsoMdoc = metaData.credentialConfigurationsSupported[CredentialConfigurationIdentifier("PID_msoMdoc")]
+        val msoMdocPolicy = pidMsoMdoc?.credentialMetadata?.credentialReusePolicy
+        assertTrue(msoMdocPolicy is CredentialReusePolicy.EUDI)
+        assertEquals(3, msoMdocPolicy.options.size)
+        assertIs<EudiReusePolicy.LimitedTime>(msoMdocPolicy.options[0])
+        val msoMdocRotatingBatch = assertIs<EudiReusePolicy.RotatingBatch>(msoMdocPolicy.options[1])
+        assertEquals(5, msoMdocRotatingBatch.batchSize)
+        assertEquals(655433.seconds, msoMdocRotatingBatch.reissueTriggerLifetimeLeft)
+        val msoMdocOption = assertIs<EudiReusePolicy.PerRelyingParty>(msoMdocPolicy.options[2])
+        assertEquals(5, msoMdocOption.batchSize)
+        assertEquals(655433.seconds, msoMdocOption.reissueTriggerLifetimeLeft)
+
+        val pidSdJwt = metaData.credentialConfigurationsSupported[CredentialConfigurationIdentifier("PID_SdJwtVc")]
+        val sdJwtPolicy = pidSdJwt?.credentialMetadata?.credentialReusePolicy
+        assertTrue(sdJwtPolicy is CredentialReusePolicy.EUDI)
+        assertEquals(4, sdJwtPolicy.options.size)
+        assertIs<EudiReusePolicy.LimitedTime>(sdJwtPolicy.options[0])
+        val sdJwtRotatingBatch = assertIs<EudiReusePolicy.RotatingBatch>(sdJwtPolicy.options[1])
+        assertEquals(40, sdJwtRotatingBatch.batchSize)
+        assertEquals(655433.seconds, sdJwtRotatingBatch.reissueTriggerLifetimeLeft)
+        val sdJwtOnceOnly = assertIs<EudiReusePolicy.OnceOnly>(sdJwtPolicy.options[2])
+        assertEquals(60, sdJwtOnceOnly.batchSize)
+        assertEquals(10, sdJwtOnceOnly.reissueTriggerUnused)
+        val sdJwtPerRelyingParty = assertIs<EudiReusePolicy.PerRelyingParty>(sdJwtPolicy.options[3])
+        assertEquals(60, sdJwtPerRelyingParty.batchSize)
+        assertEquals(10, sdJwtPerRelyingParty.reissueTriggerUnused)
+        assertEquals(777543.seconds, sdJwtPerRelyingParty.reissueTriggerLifetimeLeft)
+    }
+
+    @Test
+    internal fun `resolution succeeds with unknown credential reuse policy`() = runTest {
+        val credentialIssuerId = SampleIssuer.Id
+
+        val resolver = resolver(
+            credentialIssuerMetaDataHandler(
+                credentialIssuerId,
+                "eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_unknown_reuse_policy.json",
+            ),
+        )
+        val metaData =
+            assertDoesNotThrow { resolver.resolve(credentialIssuerId, IssuerMetadataPolicy.IgnoreSigned).getOrThrow() }
+
+        val pidMsoMdoc = metaData.credentialConfigurationsSupported[CredentialConfigurationIdentifier("PID_msoMdoc")]
+        val msoMdocPolicy = pidMsoMdoc?.credentialMetadata?.credentialReusePolicy
+        assertEquals(CredentialReusePolicy.None, msoMdocPolicy)
     }
 
     @Test

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
@@ -39,7 +39,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import tokenPostApplyPreAuthFlowAssertionsAndGetFormData
-import java.util.UUID
+import java.util.*
 import kotlin.test.*
 
 class IssuanceSingleRequestTest {
@@ -144,6 +144,53 @@ class IssuanceSingleRequestTest {
             with(issuer) {
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
                 authorizedRequest.request(requestPayload, noKeyAttestationJwtProofsSpec(Curve.P_256, 4)).getOrThrow()
+            }
+        }
+    }
+
+    @Test
+    fun `when key attestation JWT proof contains more attested keys than the batch limit IssuerBatchSizeLimitExceeded is thrown`() =
+        runTest {
+            val mockedKtorHttpClientFactory = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(IssuerMetadataVersion.KEY_ATTESTATION_REQUIRED),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                tokenPostMocker(),
+                nonceEndpointMocker(),
+            )
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
+                httpClient = mockedKtorHttpClientFactory,
+            )
+
+            val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
+            assertFailsWith<CredentialIssuanceError.IssuerBatchSizeLimitExceeded> {
+                with(issuer) {
+                    val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
+                    authorizedRequest.request(requestPayload, keyAttestationJwtProofsSpec(Curve.P_256, 4)).getOrThrow()
+                }
+            }
+        }
+
+    @Test
+    fun `when attestation proof contains more attested keys than the batch limit IssuerBatchSizeLimitExceeded is thrown`() = runTest {
+        val mockedKtorHttpClientFactory = mockedHttpClient(
+            credentialIssuerMetadataWellKnownMocker(IssuerMetadataVersion.ATTESTATION_PROOF_SUPPORTED),
+            authServerWellKnownMocker(),
+            parPostMocker(),
+            tokenPostMocker(),
+            nonceEndpointMocker(),
+        )
+        val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+            credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
+            httpClient = mockedKtorHttpClientFactory,
+        )
+
+        val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
+        assertFailsWith<CredentialIssuanceError.IssuerBatchSizeLimitExceeded> {
+            with(issuer) {
+                val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
+                authorizedRequest.request(requestPayload, attestationProofSpec(keysNo = 4)).getOrThrow()
             }
         }
     }
@@ -274,7 +321,8 @@ class IssuanceSingleRequestTest {
         val (_, outcome) = with(issuer) {
             authorizedRequest.request(requestPayload, noKeyAttestationJwtProofsSpec(Curve.P_256)).getOrThrow()
         }
-        assertIs<SubmissionOutcome.Success>(outcome)
+        val success = assertIs<SubmissionOutcome.Success>(outcome)
+        assertNull(success.selectedCredentialReusePolicy)
     }
 
     @Test

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
@@ -148,3 +148,14 @@ suspend fun preAuthorizeRequestForCredentialOffer(
 
     return authorizedRequest to issuer
 }
+
+fun CredentialReusePolicy.effectiveBatchSize(supportedReusePolicies: CredentialReusePolicies): Int? =
+    when (this) {
+        is CredentialReusePolicy.EUDI -> {
+            options
+                .filter { it.isSupported(supportedReusePolicies) }
+                .firstNotNullOfOrNull { it.batchSize }
+        }
+
+        CredentialReusePolicy.None -> null
+    }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuer.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuer.kt
@@ -39,6 +39,7 @@ internal object PidDevIssuer :
         authorizeIssuanceConfig = AuthorizeIssuanceConfig.FAVOR_SCOPES,
         dPoPUsage = DPoPUsage.Required(CryptoGenerator.ecSigner()),
         parUsage = ParUsage.Required,
+        supportedCredentialReusePolicies = CredentialReusePolicies.Supported(setOf(EudiReusePolicyType.OnceOnly)),
     )
 
     val PID_SdJwtVC_config_id = CredentialConfigurationIdentifier("eu.europa.ec.eudi.pid_vc_sd_jwt")

--- a/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy.json
+++ b/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy.json
@@ -1,0 +1,149 @@
+{
+  "credential_issuer": "https://credential-issuer.example.com",
+  "authorization_servers": [
+    "https://keycloak-eudi.netcompany-intrasoft.com/realms/pid-issuer-realm"
+  ],
+  "credential_endpoint": "https://credential-issuer.example.com/credentials",
+  "nonce_endpoint": "https://credential-issuer.example.com/nonce",
+  "deferred_credential_endpoint": "https://credential-issuer.example.com/credentials/deferred",
+  "notification_endpoint": "https://credential-issuer.example.com/notification",
+  "credential_request_encryption": {
+    "jwks": {
+      "keys": [
+        {
+          "kty": "EC",
+          "use": "enc",
+          "crv": "P-256",
+          "alg": "ECDH-ES",
+          "kid": "encKey-0",
+          "x": "TmcsNF6JpWjP85wKfBXKybHaJNowtp6jCuToppDosdw",
+          "y": "egzDuJuSxyypCE0qUoo1oKOnslpaw1Om-flQ4knafas",
+          "iat": 1755352588
+        }
+      ]
+    },
+    "enc_values_supported": [
+      "XC20P"
+    ],
+    "zip_values_supported": [
+      "DEF"
+    ],
+    "encryption_required": true
+  },
+  "credential_response_encryption": {
+    "alg_values_supported": [
+      "ECDH-ES",
+      "ECDH-ES+A128KW",
+      "ECDH-ES+A192KW",
+      "ECDH-ES+A256KW",
+      "RSA-OAEP-256",
+      "RSA-OAEP-384",
+      "RSA-OAEP-512"
+    ],
+    "enc_values_supported": [
+      "XC20P"
+    ],
+    "zip_values_supported": [
+      "DEF"
+    ],
+    "encryption_required": true
+  },
+  "batch_credential_issuance": {
+    "batch_size": 2
+  },
+  "credential_identifiers_supported": true,
+  "credential_configurations_supported": {
+    "PID_msoMdoc": {
+      "format": "mso_mdoc",
+      "scope": "PID_msoMdoc",
+      "doctype": "eu.europa.ec.eudi.pid.1",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        -7,
+        -35,
+        -36
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ]
+        }
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "EU PID",
+            "locale": "en-US"
+          }
+        ],
+        "credential_reuse_policy": {
+          "id": "arf_annex_ii",
+          "options": [
+            {
+              "details": ["limited_time", "rotating-batch", "per-relying-party"],
+              "batch_size": 5,
+              "reissue_trigger_lifetime_left": 655433,
+              "reissue_trigger_unused": 3
+            }
+          ]
+        }
+      }
+    },
+    "PID_SdJwtVc": {
+      "format": "dc+sd-jwt",
+      "scope": "PID_SdJwtVc",
+      "vct": "eu.europa.ec.eudi.pid.1",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ]
+        }
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "EU PID SD-JWT",
+            "locale": "en-US"
+          }
+        ],
+        "credential_reuse_policy": {
+          "id": "arf_annex_ii",
+          "options": [
+            {
+              "details": ["limited_time", "rotating-batch"],
+              "batch_size": 40,
+              "reissue_trigger_lifetime_left": 655433
+            },
+            {
+              "details": ["once_only", "per-relying-party"],
+              "batch_size": 60,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 777543
+            }
+          ]
+        }
+      }
+    }
+  },
+  "display": [
+    {
+      "name": "credential-issuer.example.com",
+      "locale": "en-US",
+      "logo": {
+        "uri": "https://credential-issuer.example.com/logo.png",
+        "alt_text": "Credential Issuer Logo"
+      }
+    }
+  ]
+}

--- a/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_unknown_reuse_policy.json
+++ b/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_unknown_reuse_policy.json
@@ -1,0 +1,99 @@
+{
+  "credential_issuer": "https://credential-issuer.example.com",
+  "authorization_servers": [
+    "https://keycloak-eudi.netcompany-intrasoft.com/realms/pid-issuer-realm"
+  ],
+  "credential_endpoint": "https://credential-issuer.example.com/credentials",
+  "nonce_endpoint": "https://credential-issuer.example.com/nonce",
+  "deferred_credential_endpoint": "https://credential-issuer.example.com/credentials/deferred",
+  "notification_endpoint": "https://credential-issuer.example.com/notification",
+  "credential_request_encryption": {
+    "jwks": {
+      "keys": [
+        {
+          "kty": "EC",
+          "use": "enc",
+          "crv": "P-256",
+          "alg": "ECDH-ES",
+          "kid": "encKey-0",
+          "x": "TmcsNF6JpWjP85wKfBXKybHaJNowtp6jCuToppDosdw",
+          "y": "egzDuJuSxyypCE0qUoo1oKOnslpaw1Om-flQ4knafas",
+          "iat": 1755352588
+        }
+      ]
+    },
+    "enc_values_supported": [
+      "XC20P"
+    ],
+    "zip_values_supported": [
+      "DEF"
+    ],
+    "encryption_required": true
+  },
+  "credential_response_encryption": {
+    "alg_values_supported": [
+      "ECDH-ES",
+      "ECDH-ES+A128KW",
+      "ECDH-ES+A192KW",
+      "ECDH-ES+A256KW",
+      "RSA-OAEP-256",
+      "RSA-OAEP-384",
+      "RSA-OAEP-512"
+    ],
+    "enc_values_supported": [
+      "XC20P"
+    ],
+    "zip_values_supported": [
+      "DEF"
+    ],
+    "encryption_required": true
+  },
+  "batch_credential_issuance": {
+    "batch_size": 2
+  },
+  "credential_identifiers_supported": true,
+  "credential_configurations_supported": {
+    "PID_msoMdoc": {
+      "format": "mso_mdoc",
+      "scope": "PID_msoMdoc",
+      "doctype": "eu.europa.ec.eudi.pid.1",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        -7,
+        -35,
+        -36
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ]
+        }
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "EU PID",
+            "locale": "en-US"
+          }
+        ],
+        "credential_reuse_policy": {
+          "id": "some_id"
+        }
+      }
+    }
+  },
+  "display": [
+    {
+      "name": "credential-issuer.example.com",
+      "locale": "en-US",
+      "logo": {
+        "uri": "https://credential-issuer.example.com/logo.png",
+        "alt_text": "Credential Issuer Logo"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
…502)

* Bump version to 0.11.0-SNAPSHOT

* Limit signing algorithms for WIA to ECDSA (#499)

* Implemented credential reuse policies per credential configuration

* Refactored credential reuse policies to align with ARF Annex II specifications and introduced `None` as the default reuse policy.

* Refactored `ArfAnnex2ReusePolicyOption` into distinct sealed subtypes and updated tests and parsers accordingly to improve reuse policy handling.

* Refactored `ArfAnnex2ReusePolicyOption` into distinct sealed subtypes and updated tests and parsers accordingly to improve reuse policy handling.

* Enforced batch size limit validation for key attestation and attestation proofs during credential issuance, with related test coverage.

* Refactor credential reuse policies (#9)

* Refactored `EudiReusePolicyType` into sealed subclasses, improved validation for `supportedCredentialReusePolicies`, and added related test coverage.

* Refactored `reissueTriggerLifetimeLeft` from `Long` to `Duration` in `EudiReusePolicy`, adjusted validations, and updated tests and parsers accordingly.

* Refactored `supportedCredentialReusePolicies` into `CredentialReusePolicies`, introduced `Supported` and `Required` subtypes, and updated related logic and tests.

---------