### PR TITLE
Make DPoP independent of ClientAuthentication

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
@@ -43,6 +43,11 @@ interface ProvisionClientAttestation {
 }
 
 /**
+ * Provisions a signer for DPoP.
+ */
+typealias ProvisionDPoPUsage = suspend (HttpsUrl) -> DPoPUsage<Signer<JWK>>
+
+/**
  * The Client Authentication Method used by the Wallet.
  */
 sealed interface ClientAuthentication : java.io.Serializable {
@@ -55,7 +60,7 @@ sealed interface ClientAuthentication : java.io.Serializable {
     /**
      * None, i.e. a Public Client.
      */
-    data class None(override val id: ClientId, val dPoPUsage: DPoPUsage<Signer<JWK>> = DPoPUsage.Never) : ClientAuthentication
+    data class None(override val id: ClientId) : ClientAuthentication
 
     /**
      * Attestation-Based Client Authentication.
@@ -79,6 +84,7 @@ sealed interface ClientAuthentication : java.io.Serializable {
  * Configuration object to pass configuration properties to the issuance components.
  *
  * @param clientAuthentication the OAuth 2.0 Client Authentication Method of the Wallet
+ * @param provisionDPoPUsage a way to provision [DPoPUsage] for an Authorization Server
  * @param authFlowRedirectionURI  Redirect url to be passed as the 'redirect_url' parameter to the authorization request.
  * @param encryptionSupportConfig   Configuration related to generation of encryption keys and encryption algorithms per algorithm family.
  * @param authorizeIssuanceConfig Instruction on how to assemble the authorization request. If scopes are supported
@@ -91,6 +97,7 @@ sealed interface ClientAuthentication : java.io.Serializable {
  */
 data class OpenId4VCIConfig(
     val clientAuthentication: ClientAuthentication,
+    val provisionDPoPUsage: ProvisionDPoPUsage,
     val authFlowRedirectionURI: URI,
     val encryptionSupportConfig: EncryptionSupportConfig,
     val authorizeIssuanceConfig: AuthorizeIssuanceConfig = AuthorizeIssuanceConfig.FAVOR_SCOPES,
@@ -105,16 +112,17 @@ data class OpenId4VCIConfig(
      */
     constructor(
         clientId: ClientId,
+        provisionDPoPUsage: ProvisionDPoPUsage,
         authFlowRedirectionURI: URI,
         encryptionSupportConfig: EncryptionSupportConfig,
         authorizeIssuanceConfig: AuthorizeIssuanceConfig = AuthorizeIssuanceConfig.FAVOR_SCOPES,
-        dPoPUsage: DPoPUsage<Signer<JWK>> = DPoPUsage.Never,
         parUsage: ParUsage = ParUsage.IfSupported,
         clock: Clock = Clock.systemDefaultZone(),
         issuerMetadataPolicy: IssuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
         supportedCredentialReusePolicies: CredentialReusePolicies? = null,
     ) : this(
-        ClientAuthentication.None(clientId, dPoPUsage),
+        ClientAuthentication.None(clientId),
+        provisionDPoPUsage,
         authFlowRedirectionURI,
         encryptionSupportConfig,
         authorizeIssuanceConfig,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
@@ -43,9 +43,15 @@ interface ProvisionClientAttestation {
 }
 
 /**
- * Provisions a signer for DPoP.
+ * Provisions a [Signer] for signing DPoP Proofs.
  */
-typealias ProvisionDPoPUsage = suspend (HttpsUrl) -> DPoPUsage<Signer<JWK>>
+interface ProvisionDPoPSigner {
+    val popAlgorithm: JwsAlgorithm
+
+    suspend operator fun invoke(authorizationServer: HttpsUrl): Signer<JWK>
+}
+
+typealias DPoPUsageOption = DPoPUsage<ProvisionDPoPSigner>
 
 /**
  * The Client Authentication Method used by the Wallet.
@@ -84,7 +90,7 @@ sealed interface ClientAuthentication : java.io.Serializable {
  * Configuration object to pass configuration properties to the issuance components.
  *
  * @param clientAuthentication the OAuth 2.0 Client Authentication Method of the Wallet
- * @param provisionDPoPUsage a way to provision [DPoPUsage] for an Authorization Server
+ * @param dPoPUsage an indication about whether DPoP is never to be used, supported, or required
  * @param authFlowRedirectionURI  Redirect url to be passed as the 'redirect_url' parameter to the authorization request.
  * @param encryptionSupportConfig   Configuration related to generation of encryption keys and encryption algorithms per algorithm family.
  * @param authorizeIssuanceConfig Instruction on how to assemble the authorization request. If scopes are supported
@@ -97,7 +103,7 @@ sealed interface ClientAuthentication : java.io.Serializable {
  */
 data class OpenId4VCIConfig(
     val clientAuthentication: ClientAuthentication,
-    val provisionDPoPUsage: ProvisionDPoPUsage,
+    val dPoPUsage: DPoPUsageOption = DPoPUsage.Never,
     val authFlowRedirectionURI: URI,
     val encryptionSupportConfig: EncryptionSupportConfig,
     val authorizeIssuanceConfig: AuthorizeIssuanceConfig = AuthorizeIssuanceConfig.FAVOR_SCOPES,
@@ -112,7 +118,7 @@ data class OpenId4VCIConfig(
      */
     constructor(
         clientId: ClientId,
-        provisionDPoPUsage: ProvisionDPoPUsage,
+        dPoPUsage: DPoPUsageOption = DPoPUsage.Never,
         authFlowRedirectionURI: URI,
         encryptionSupportConfig: EncryptionSupportConfig,
         authorizeIssuanceConfig: AuthorizeIssuanceConfig = AuthorizeIssuanceConfig.FAVOR_SCOPES,
@@ -122,7 +128,7 @@ data class OpenId4VCIConfig(
         supportedCredentialReusePolicies: CredentialReusePolicies? = null,
     ) : this(
         ClientAuthentication.None(clientId),
-        provisionDPoPUsage,
+        dPoPUsage,
         authFlowRedirectionURI,
         encryptionSupportConfig,
         authorizeIssuanceConfig,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
@@ -90,12 +90,12 @@ sealed interface ClientAuthentication : java.io.Serializable {
  * Configuration object to pass configuration properties to the issuance components.
  *
  * @param clientAuthentication the OAuth 2.0 Client Authentication Method of the Wallet
- * @param dPoPUsage an indication about whether DPoP is never to be used, supported, or required
  * @param authFlowRedirectionURI  Redirect url to be passed as the 'redirect_url' parameter to the authorization request.
  * @param encryptionSupportConfig   Configuration related to generation of encryption keys and encryption algorithms per algorithm family.
  * @param authorizeIssuanceConfig Instruction on how to assemble the authorization request. If scopes are supported
  * by the credential issuer and [AuthorizeIssuanceConfig.FAVOR_SCOPES] is selected then scopes will be used.
  * Otherwise, authorization details (RAR)
+ * @param dPoPUsage an indication about whether DPoP is never to be used, supported, or required
  * @param parUsage whether to use PAR in case of authorization code grant
  * @param clock Wallet's clock
  * @param issuerMetadataPolicy policy concerning signed metadata usage
@@ -103,10 +103,10 @@ sealed interface ClientAuthentication : java.io.Serializable {
  */
 data class OpenId4VCIConfig(
     val clientAuthentication: ClientAuthentication,
-    val dPoPUsage: DPoPUsageOption = DPoPUsage.Never,
     val authFlowRedirectionURI: URI,
     val encryptionSupportConfig: EncryptionSupportConfig,
     val authorizeIssuanceConfig: AuthorizeIssuanceConfig = AuthorizeIssuanceConfig.FAVOR_SCOPES,
+    val dPoPUsage: DPoPUsageOption = DPoPUsage.Never,
     val parUsage: ParUsage = ParUsage.IfSupported,
     val clock: Clock = Clock.systemDefaultZone(),
     val issuerMetadataPolicy: IssuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
@@ -118,20 +118,20 @@ data class OpenId4VCIConfig(
      */
     constructor(
         clientId: ClientId,
-        dPoPUsage: DPoPUsageOption = DPoPUsage.Never,
         authFlowRedirectionURI: URI,
         encryptionSupportConfig: EncryptionSupportConfig,
         authorizeIssuanceConfig: AuthorizeIssuanceConfig = AuthorizeIssuanceConfig.FAVOR_SCOPES,
+        dPoPUsage: DPoPUsageOption = DPoPUsage.Never,
         parUsage: ParUsage = ParUsage.IfSupported,
         clock: Clock = Clock.systemDefaultZone(),
         issuerMetadataPolicy: IssuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
         supportedCredentialReusePolicies: CredentialReusePolicies? = null,
     ) : this(
         ClientAuthentication.None(clientId),
-        dPoPUsage,
         authFlowRedirectionURI,
         encryptionSupportConfig,
         authorizeIssuanceConfig,
+        dPoPUsage,
         parUsage,
         clock,
         issuerMetadataPolicy,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
@@ -51,7 +51,15 @@ interface ProvisionDPoPSigner {
     suspend operator fun invoke(authorizationServer: HttpsUrl): Signer<JWK>
 }
 
-typealias DPoPUsageOption = DPoPUsage<ProvisionDPoPSigner>
+/**
+ * Configuration options for DPoP.
+ */
+data class DPoPConfig(val provisionDPoPSigner: ProvisionDPoPSigner)
+
+/**
+ * An indication about the Client's preference for DPoP.
+ */
+typealias DPoPUsageOption = DPoPUsage<DPoPConfig>
 
 /**
  * The Client Authentication Method used by the Wallet.

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
@@ -40,6 +40,7 @@ import java.time.Clock
  * @param requestEncryptionSpec the request encryption spec. Must be provided only if request encryption was used in the initial request.
  * @param responseEncryptionParams encryption method and compression algorithm as/if used in the initial request.
  * @param dPoPCtx the negotiated DPoP context. Must be provided only if DPoP was used.
+ * @param provisionDPoPUsage a way to provision [DPoPUsage] for an Authorization Server
  * @param clock Wallet's clock
  * @param preferredClientStatusPeriod PID or Attestation Provider's preference for the remaining status maintenance period
  */
@@ -53,6 +54,7 @@ data class DeferredIssuerConfig(
     val requestEncryptionSpec: EncryptionSpec?,
     val responseEncryptionParams: Pair<EncryptionMethod, CompressionAlgorithm?>?,
     val dPoPCtx: DPoPCtx? = null,
+    val provisionDPoPUsage: ProvisionDPoPUsage,
     val clock: Clock = Clock.systemDefaultZone(),
     val preferredClientStatusPeriod: PositiveDuration? = null,
 )
@@ -167,27 +169,30 @@ interface DeferredIssuer : RefreshAccessToken, QueryForDeferredCredential {
             responseEncryptionKey: JWK?,
             httpClient: HttpClient,
         ): Result<DeferredIssuer> = runCatching {
-            val (provisionedClientAttestation, dPoPSigner) =
+            val authorizationServer = HttpsUrl(config.authorizationServerId.toString()).getOrThrow()
+
+            val provisionedClientAttestation =
                 when (val clientAuthentication = config.clientAuthentication) {
                     is ClientAuthentication.AttestationBased -> {
-                        val authorizationServer = HttpsUrl(config.authorizationServerId.toString()).getOrThrow()
                         val provisionedClientAttestation = clientAuthentication.provisionClientAttestation(
                             authorizationServer,
                             config.preferredClientStatusPeriod,
                         )
                         clientAuthentication.provisionClientAttestation.ensureValid(config.clock.instant(), provisionedClientAttestation)
-                        provisionedClientAttestation to provisionedClientAttestation.popSigner
+                        provisionedClientAttestation
                     }
 
-                    is ClientAuthentication.None -> {
-                        val signer = when (val dPoPUsage = clientAuthentication.dPoPUsage) {
-                            DPoPUsage.Never -> null
-                            is DPoPUsage.IfSupported<Signer<JWK>> -> dPoPUsage.value
-                            is DPoPUsage.Required<Signer<JWK>> -> dPoPUsage.value
-                        }
-                        null to signer
-                    }
+                    is ClientAuthentication.None -> null
                 }
+
+            val dPoPSigner = when (val dPoPUsage = config.provisionDPoPUsage(authorizationServer)) {
+                DPoPUsage.Never -> null
+                is DPoPUsage.IfSupported -> dPoPUsage.value
+                is DPoPUsage.Required -> {
+                    checkNotNull(config.dPoPCtx) { "dPoPCtx is required when DPoPUsage is required" }
+                    dPoPUsage.value
+                }
+            }
 
             val dPoPJwtFactory = config.dPoPCtx?.let {
                 checkNotNull(dPoPSigner) { "dPoPSigner is required when using DPoP" }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
@@ -39,8 +39,7 @@ import java.time.Clock
  *   Must be provided only if client was of Client.Attested kind.
  * @param requestEncryptionSpec the request encryption spec. Must be provided only if request encryption was used in the initial request.
  * @param responseEncryptionParams encryption method and compression algorithm as/if used in the initial request.
- * @param dPoPCtx the negotiated DPoP context. Must be provided only if DPoP was used.
- * @param dPoPUsage an indication about whether DPoP is never to be used, supported, or required.
+ * @param dPoPConfig DPoP configuration. Must be provided only if DPoP was used.
  * @param clock Wallet's clock
  * @param preferredClientStatusPeriod PID or Attestation Provider's preference for the remaining status maintenance period
  */
@@ -53,8 +52,7 @@ data class DeferredIssuerConfig(
     val tokenEndpoint: URL,
     val requestEncryptionSpec: EncryptionSpec?,
     val responseEncryptionParams: Pair<EncryptionMethod, CompressionAlgorithm?>?,
-    val dPoPCtx: DPoPCtx? = null,
-    val dPoPUsage: DPoPUsageOption = DPoPUsage.Never,
+    val dPoPConfig: DPoPConfig?,
     val clock: Clock = Clock.systemDefaultZone(),
     val preferredClientStatusPeriod: PositiveDuration? = null,
 )
@@ -80,9 +78,9 @@ data class DeferredIssuanceContext(
     val authorizedTransaction: AuthorizedTransaction,
 ) {
     init {
-        if (authorizedTransaction.authorizedRequest.accessToken !is AccessToken.DPoP) {
-            requireNotNull(config.dPoPCtx) {
-                "config.dPoPCtx is required when DPoP access tokens are used"
+        if (authorizedTransaction.authorizedRequest.accessToken is AccessToken.DPoP) {
+            requireNotNull(config.dPoPConfig) {
+                "config.dPoPConfig is required when DPoP access tokens are used"
             }
         }
     }
@@ -185,25 +183,12 @@ interface DeferredIssuer : RefreshAccessToken, QueryForDeferredCredential {
                     is ClientAuthentication.None -> null
                 }
 
-            val dPoPSigner = when (val dPoPUsage = config.dPoPUsage) {
-                DPoPUsage.Never -> null
-                is DPoPUsage.IfSupported -> {
-                    val dPoPSigner = dPoPUsage.value(authorizationServer)
-                    dPoPUsage.ensureValid(dPoPSigner)
-                    dPoPSigner
-                }
-                is DPoPUsage.Required -> {
-                    checkNotNull(config.dPoPCtx) { "dPoPCtx is required when DPoPUsage is required" }
-                    val dPoPSigner = dPoPUsage.value(authorizationServer)
-                    dPoPUsage.ensureValid(dPoPSigner)
-                    dPoPSigner
-                }
+            val dPoPSigner = config.dPoPConfig?.let {
+                val dPoPSigner = it.provisionDPoPSigner(authorizationServer)
+                it.provisionDPoPSigner.ensureValid(dPoPSigner)
+                dPoPSigner
             }
-
-            val dPoPJwtFactory = config.dPoPCtx?.let {
-                checkNotNull(dPoPSigner) { "dPoPSigner is required when using DPoP" }
-                DPoPJwtFactory(clock = config.clock, dPoPCtx = it, signer = dPoPSigner)
-            }
+            val dPoPJwtFactory = dPoPSigner?.let { DPoPJwtFactory(clock = config.clock, signer = dPoPSigner) }
 
             val tokenEndpointClient = TokenEndpointClient(
                 config.credentialIssuerId,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
@@ -183,12 +183,12 @@ interface DeferredIssuer : RefreshAccessToken, QueryForDeferredCredential {
                     is ClientAuthentication.None -> null
                 }
 
-            val dPoPSigner = config.dPoPConfig?.let {
-                val dPoPSigner = it.provisionDPoPSigner(authorizationServer)
-                it.provisionDPoPSigner.ensureValid(dPoPSigner)
+            val dPoPSigner = config.dPoPConfig?.let { (provisionDPoPSigner) ->
+                val dPoPSigner = provisionDPoPSigner(authorizationServer)
+                provisionDPoPSigner.ensureValid(dPoPSigner)
                 dPoPSigner
             }
-            val dPoPJwtFactory = dPoPSigner?.let { DPoPJwtFactory(clock = config.clock, signer = dPoPSigner) }
+            val dPoPJwtFactory = dPoPSigner?.let { DPoPJwtFactory(clock = config.clock, signer = it) }
 
             val tokenEndpointClient = TokenEndpointClient(
                 config.credentialIssuerId,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
@@ -40,7 +40,7 @@ import java.time.Clock
  * @param requestEncryptionSpec the request encryption spec. Must be provided only if request encryption was used in the initial request.
  * @param responseEncryptionParams encryption method and compression algorithm as/if used in the initial request.
  * @param dPoPCtx the negotiated DPoP context. Must be provided only if DPoP was used.
- * @param provisionDPoPUsage a way to provision [DPoPUsage] for an Authorization Server
+ * @param dPoPUsage an indication about whether DPoP is never to be used, supported, or required.
  * @param clock Wallet's clock
  * @param preferredClientStatusPeriod PID or Attestation Provider's preference for the remaining status maintenance period
  */
@@ -54,7 +54,7 @@ data class DeferredIssuerConfig(
     val requestEncryptionSpec: EncryptionSpec?,
     val responseEncryptionParams: Pair<EncryptionMethod, CompressionAlgorithm?>?,
     val dPoPCtx: DPoPCtx? = null,
-    val provisionDPoPUsage: ProvisionDPoPUsage,
+    val dPoPUsage: DPoPUsageOption = DPoPUsage.Never,
     val clock: Clock = Clock.systemDefaultZone(),
     val preferredClientStatusPeriod: PositiveDuration? = null,
 )
@@ -185,12 +185,18 @@ interface DeferredIssuer : RefreshAccessToken, QueryForDeferredCredential {
                     is ClientAuthentication.None -> null
                 }
 
-            val dPoPSigner = when (val dPoPUsage = config.provisionDPoPUsage(authorizationServer)) {
+            val dPoPSigner = when (val dPoPUsage = config.dPoPUsage) {
                 DPoPUsage.Never -> null
-                is DPoPUsage.IfSupported -> dPoPUsage.value
+                is DPoPUsage.IfSupported -> {
+                    val dPoPSigner = dPoPUsage.value(authorizationServer)
+                    dPoPUsage.ensureValid(dPoPSigner)
+                    dPoPSigner
+                }
                 is DPoPUsage.Required -> {
                     checkNotNull(config.dPoPCtx) { "dPoPCtx is required when DPoPUsage is required" }
-                    dPoPUsage.value
+                    val dPoPSigner = dPoPUsage.value(authorizationServer)
+                    dPoPUsage.ensureValid(dPoPSigner)
+                    dPoPSigner
                 }
             }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
@@ -18,7 +18,9 @@ package eu.europa.ec.eudi.openid4vci
 import com.nimbusds.jose.CompressionAlgorithm
 import com.nimbusds.jose.EncryptionMethod
 import com.nimbusds.jose.jwk.JWK
+import eu.europa.ec.eudi.openid4vci.internal.ProvisionOnce
 import eu.europa.ec.eudi.openid4vci.internal.RefreshAccessTokenImpl
+import eu.europa.ec.eudi.openid4vci.internal.dPoPJwtFactory
 import eu.europa.ec.eudi.openid4vci.internal.http.DeferredEndPointClient
 import eu.europa.ec.eudi.openid4vci.internal.http.TokenEndpointClient
 import io.ktor.client.*
@@ -183,12 +185,10 @@ interface DeferredIssuer : RefreshAccessToken, QueryForDeferredCredential {
                     is ClientAuthentication.None -> null
                 }
 
-            val dPoPSigner = config.dPoPConfig?.let { (provisionDPoPSigner) ->
-                val dPoPSigner = provisionDPoPSigner(authorizationServer)
-                provisionDPoPSigner.ensureValid(dPoPSigner)
-                dPoPSigner
-            }
-            val dPoPJwtFactory = dPoPSigner?.let { DPoPJwtFactory(clock = config.clock, signer = it) }
+            val provisionDPoPJwtFactory =
+                config.dPoPConfig?.let {
+                    ProvisionOnce.dPoPJwtFactory(config.clock, authorizationServer, it)
+                } ?: { null }
 
             val tokenEndpointClient = TokenEndpointClient(
                 config.credentialIssuerId,
@@ -199,7 +199,7 @@ interface DeferredIssuer : RefreshAccessToken, QueryForDeferredCredential {
                 config.authorizationServerId,
                 challengeEndpoint = config.challengeEndpoint,
                 tokenEndpoint = config.tokenEndpoint,
-                dPoPJwtFactory,
+                provisionDPoPJwtFactory,
                 httpClient,
             )
 
@@ -207,7 +207,7 @@ interface DeferredIssuer : RefreshAccessToken, QueryForDeferredCredential {
 
             val deferredEndPointClient = DeferredEndPointClient(
                 CredentialIssuerEndpoint.invoke(config.deferredEndpoint.toString()).getOrThrow(),
-                dPoPJwtFactory,
+                provisionDPoPJwtFactory,
                 httpClient,
             )
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
@@ -18,7 +18,6 @@ package eu.europa.ec.eudi.openid4vci
 import com.nimbusds.jose.CompressionAlgorithm
 import com.nimbusds.jose.EncryptionMethod
 import com.nimbusds.jose.jwk.JWK
-import eu.europa.ec.eudi.openid4vci.internal.ProvisionOnce
 import eu.europa.ec.eudi.openid4vci.internal.RefreshAccessTokenImpl
 import eu.europa.ec.eudi.openid4vci.internal.dPoPJwtFactory
 import eu.europa.ec.eudi.openid4vci.internal.http.DeferredEndPointClient
@@ -185,10 +184,7 @@ interface DeferredIssuer : RefreshAccessToken, QueryForDeferredCredential {
                     is ClientAuthentication.None -> null
                 }
 
-            val provisionDPoPJwtFactory =
-                config.dPoPConfig?.let {
-                    ProvisionOnce.dPoPJwtFactory(config.clock, authorizationServer, it)
-                } ?: { null }
+            val provisionDPoPJwtFactory = config.dPoPConfig?.let { dPoPJwtFactory(config.clock, authorizationServer, it) } ?: { null }
 
             val tokenEndpointClient = TokenEndpointClient(
                 config.credentialIssuerId,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
@@ -285,7 +285,9 @@ interface Issuer :
                             responseEncryptionParams = credentialOffer.exchangeEncryptionSpecification.responseEncryptionSpec?.let {
                                 it.encryptionMethod to it.compressionAlgorithm
                             },
-                            dPoPConfig = dPoPConfig,
+                            dPoPConfig =
+                                if (null != credentialOffer.dPoPCtx) dPoPConfig
+                                else null,
                             clock = config.clock,
                         ),
                         AuthorizedTransaction(this@deferredContext, deferredCredential.transactionId),

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
@@ -152,7 +152,7 @@ interface Issuer :
             val provisionDPoPJwtFactory =
                 if (null != credentialOffer.dPoPCtx) {
                     checkNotNull(dPoPConfig) { "dPoPConfig is required when using DPoP" }
-                    ProvisionOnce.dPoPJwtFactory(config.clock, authorizationServer, dPoPConfig)
+                    dPoPJwtFactory(config.clock, authorizationServer, dPoPConfig)
                 } else {
                     { null }
                 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
@@ -18,6 +18,7 @@ package eu.europa.ec.eudi.openid4vci
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.ECKey
+import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod
 import eu.europa.ec.eudi.openid4vci.internal.*
 import eu.europa.ec.eudi.openid4vci.internal.http.*
@@ -138,12 +139,18 @@ interface Issuer :
                     is ClientAuthentication.None -> null
                 }
 
-            val dPoPSigner = when (val dPoPUsage = config.provisionDPoPUsage(authorizationServer)) {
+            val dPoPSigner = when (val dPoPUsage = config.dPoPUsage) {
                 DPoPUsage.Never -> null
-                is DPoPUsage.IfSupported -> dPoPUsage.value
+                is DPoPUsage.IfSupported -> {
+                    val dPoPSigner = dPoPUsage.value(authorizationServer)
+                    dPoPUsage.ensureValid(dPoPSigner)
+                    dPoPSigner
+                }
                 is DPoPUsage.Required -> {
                     checkNotNull(credentialOffer.dPoPCtx) { "dPoPCtx is required when DPoPUsage is required" }
-                    dPoPUsage.value
+                    val dPoPSigner = dPoPUsage.value(authorizationServer)
+                    dPoPUsage.ensureValid(dPoPSigner)
+                    dPoPSigner
                 }
             }
 
@@ -278,7 +285,7 @@ interface Issuer :
                                 it.encryptionMethod to it.compressionAlgorithm
                             },
                             dPoPCtx = credentialOffer.dPoPCtx,
-                            provisionDPoPUsage = config.provisionDPoPUsage,
+                            dPoPUsage = config.dPoPUsage,
                             clock = config.clock,
                         ),
                         AuthorizedTransaction(this@deferredContext, deferredCredential.transactionId),
@@ -421,5 +428,23 @@ internal fun ProvisionClientAttestation.ensureValid(now: Instant, provisioned: P
     val popSignerAlgorithm = provisioned.popSigner.javaAlgorithm.toJoseAlg()
     check(popAlgorithm.toNimbus() == popSignerAlgorithm) {
         "Client Attestation POP signer algorithm mismatch: expected ${popAlgorithm.name}, got ${popSignerAlgorithm.name}"
+    }
+}
+
+internal fun DPoPUsageOption.ensureValid(signer: Signer<JWK>) {
+    when (this) {
+        DPoPUsage.Never -> error("DPoP Signer was provisioned when DPoP is not to be used")
+        is DPoPUsage.IfSupported -> {
+            val signerAlgorithm = JwsAlgorithm(signer.javaAlgorithm.toJoseAlg().name)
+            check(this.value.popAlgorithm == signerAlgorithm) {
+                "DPoP Signer algorithm mismatch: expected ${this.value.popAlgorithm.name}, got ${signerAlgorithm.name}"
+            }
+        }
+        is DPoPUsage.Required -> {
+            val signerAlgorithm = JwsAlgorithm(signer.javaAlgorithm.toJoseAlg().name)
+            check(this.value.popAlgorithm == signerAlgorithm) {
+                "DPoP Signer algorithm mismatch: expected ${this.value.popAlgorithm.name}, got ${signerAlgorithm.name}"
+            }
+        }
     }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
@@ -150,9 +150,9 @@ interface Issuer :
                     dPoPUsage.value
                 }
             }
-            val dPoPSigner = dPoPConfig?.let {
-                val dPoPSigner = dPoPConfig.provisionDPoPSigner(authorizationServer)
-                dPoPConfig.provisionDPoPSigner.ensureValid(dPoPSigner)
+            val dPoPSigner = dPoPConfig?.let { (provisionDPoPSigner) ->
+                val dPoPSigner = provisionDPoPSigner(authorizationServer)
+                provisionDPoPSigner.ensureValid(dPoPSigner)
                 dPoPSigner
             }
             val dPoPJwtFactory = credentialOffer.dPoPCtx?.let {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
@@ -18,7 +18,6 @@ package eu.europa.ec.eudi.openid4vci
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.ECKey
-import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod
 import eu.europa.ec.eudi.openid4vci.internal.*
 import eu.europa.ec.eudi.openid4vci.internal.http.*
@@ -52,7 +51,6 @@ interface Issuer :
     NotifyIssuer {
 
     val credentialOffer: CredentialOffer
-    val dPoPJwtFactory: DPoPJwtFactory?
 
     /**
      * A convenient method for obtaining a [DeferredIssuanceContext], in case of a deferred issuance
@@ -150,15 +148,14 @@ interface Issuer :
                     dPoPUsage.value
                 }
             }
-            val dPoPSigner = dPoPConfig?.let { (provisionDPoPSigner) ->
-                val dPoPSigner = provisionDPoPSigner(authorizationServer)
-                provisionDPoPSigner.ensureValid(dPoPSigner)
-                dPoPSigner
-            }
-            val dPoPJwtFactory = credentialOffer.dPoPCtx?.let {
-                checkNotNull(dPoPSigner) { "dPoPSigner is required when using DPoP" }
-                DPoPJwtFactory(clock = config.clock, dPoPCtx = it, signer = dPoPSigner)
-            }
+
+            val provisionDPoPJwtFactory =
+                if (null != credentialOffer.dPoPCtx) {
+                    checkNotNull(dPoPConfig) { "dPoPConfig is required when using DPoP" }
+                    ProvisionOnce.dPoPJwtFactory(config.clock, authorizationServer, dPoPConfig)
+                } else {
+                    { null }
+                }
 
             val authorizationEndpointClient =
                 credentialOffer.authorizationServerMetadata
@@ -168,7 +165,7 @@ interface Issuer :
                             credentialOffer.credentialIssuerIdentifier,
                             credentialOffer.authorizationServerMetadata,
                             config,
-                            dPoPJwtFactory,
+                            provisionDPoPJwtFactory,
                             provisionedClientAttestation,
                             httpClient,
                         )
@@ -179,7 +176,7 @@ interface Issuer :
                     credentialOffer.credentialIssuerIdentifier,
                     credentialOffer.authorizationServerMetadata,
                     config,
-                    dPoPJwtFactory,
+                    provisionDPoPJwtFactory,
                     provisionedClientAttestation,
                     httpClient,
                 )
@@ -196,7 +193,7 @@ interface Issuer :
                 val credentialEndpointClient =
                     CredentialEndpointClient(
                         credentialOffer.credentialIssuerMetadata.credentialEndpoint,
-                        dPoPJwtFactory,
+                        provisionDPoPJwtFactory,
                         httpClient,
                     )
                 val nonceEndpointClient = credentialOffer.credentialIssuerMetadata.nonceEndpoint?.let {
@@ -222,7 +219,7 @@ interface Issuer :
                     null -> QueryForDeferredCredential.NotSupported
                     else -> {
                         val deferredEndPointClient =
-                            DeferredEndPointClient(deferredEndpoint, dPoPJwtFactory, httpClient)
+                            DeferredEndPointClient(deferredEndpoint, provisionDPoPJwtFactory, httpClient)
                         QueryForDeferredCredential(
                             config.clock,
                             refreshAccessToken,
@@ -237,7 +234,7 @@ interface Issuer :
                     null -> NotifyIssuer.NoOp
                     else -> {
                         val notificationEndPointClient =
-                            NotificationEndPointClient(notificationEndpoint, dPoPJwtFactory, httpClient)
+                            NotificationEndPointClient(notificationEndpoint, provisionDPoPJwtFactory, httpClient)
                         NotifyIssuer(notificationEndPointClient)
                     }
                 }
@@ -251,9 +248,6 @@ interface Issuer :
                 NotifyIssuer by notifyIssuer {
                 override val credentialOffer: CredentialOffer
                     get() = credentialOffer
-
-                override val dPoPJwtFactory: DPoPJwtFactory?
-                    get() = dPoPJwtFactory
 
                 override fun AuthorizedRequest.deferredContext(
                     deferredCredential: SubmissionOutcome.Deferred,
@@ -430,12 +424,5 @@ internal fun ProvisionClientAttestation.ensureValid(now: Instant, provisioned: P
     val popSignerAlgorithm = provisioned.popSigner.javaAlgorithm.toJoseAlg()
     check(popAlgorithm.toNimbus() == popSignerAlgorithm) {
         "Client Attestation POP signer algorithm mismatch: expected ${popAlgorithm.name}, got ${popSignerAlgorithm.name}"
-    }
-}
-
-internal fun ProvisionDPoPSigner.ensureValid(signer: Signer<JWK>) {
-    val signerAlgorithm = JwsAlgorithm(signer.javaAlgorithm.toJoseAlg().name)
-    check(popAlgorithm == signerAlgorithm) {
-        "DPoP Signer algorithm mismatch: expected ${popAlgorithm.name}, got ${signerAlgorithm.name}"
     }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
@@ -139,21 +139,22 @@ interface Issuer :
                     is ClientAuthentication.None -> null
                 }
 
-            val dPoPSigner = when (val dPoPUsage = config.dPoPUsage) {
+            val dPoPConfig = when (val dPoPUsage = config.dPoPUsage) {
                 DPoPUsage.Never -> null
-                is DPoPUsage.IfSupported -> {
-                    val dPoPSigner = dPoPUsage.value(authorizationServer)
-                    dPoPUsage.ensureValid(dPoPSigner)
-                    dPoPSigner
-                }
+                is DPoPUsage.IfSupported -> dPoPUsage.value
                 is DPoPUsage.Required -> {
-                    checkNotNull(credentialOffer.dPoPCtx) { "dPoPCtx is required when DPoPUsage is required" }
-                    val dPoPSigner = dPoPUsage.value(authorizationServer)
-                    dPoPUsage.ensureValid(dPoPSigner)
-                    dPoPSigner
+                    checkNotNull(credentialOffer.dPoPCtx) {
+                        "Client requires the usage of DPoP, but the Authorization Server does not support DPoP " +
+                            "or the signing algorithm supported by the Client"
+                    }
+                    dPoPUsage.value
                 }
             }
-
+            val dPoPSigner = dPoPConfig?.let {
+                val dPoPSigner = dPoPConfig.provisionDPoPSigner(authorizationServer)
+                dPoPConfig.provisionDPoPSigner.ensureValid(dPoPSigner)
+                dPoPSigner
+            }
             val dPoPJwtFactory = credentialOffer.dPoPCtx?.let {
                 checkNotNull(dPoPSigner) { "dPoPSigner is required when using DPoP" }
                 DPoPJwtFactory(clock = config.clock, dPoPCtx = it, signer = dPoPSigner)
@@ -284,8 +285,7 @@ interface Issuer :
                             responseEncryptionParams = credentialOffer.exchangeEncryptionSpecification.responseEncryptionSpec?.let {
                                 it.encryptionMethod to it.compressionAlgorithm
                             },
-                            dPoPCtx = credentialOffer.dPoPCtx,
-                            dPoPUsage = config.dPoPUsage,
+                            dPoPConfig = dPoPConfig,
                             clock = config.clock,
                         ),
                         AuthorizedTransaction(this@deferredContext, deferredCredential.transactionId),
@@ -431,20 +431,9 @@ internal fun ProvisionClientAttestation.ensureValid(now: Instant, provisioned: P
     }
 }
 
-internal fun DPoPUsageOption.ensureValid(signer: Signer<JWK>) {
-    when (this) {
-        DPoPUsage.Never -> error("DPoP Signer was provisioned when DPoP is not to be used")
-        is DPoPUsage.IfSupported -> {
-            val signerAlgorithm = JwsAlgorithm(signer.javaAlgorithm.toJoseAlg().name)
-            check(this.value.popAlgorithm == signerAlgorithm) {
-                "DPoP Signer algorithm mismatch: expected ${this.value.popAlgorithm.name}, got ${signerAlgorithm.name}"
-            }
-        }
-        is DPoPUsage.Required -> {
-            val signerAlgorithm = JwsAlgorithm(signer.javaAlgorithm.toJoseAlg().name)
-            check(this.value.popAlgorithm == signerAlgorithm) {
-                "DPoP Signer algorithm mismatch: expected ${this.value.popAlgorithm.name}, got ${signerAlgorithm.name}"
-            }
-        }
+internal fun ProvisionDPoPSigner.ensureValid(signer: Signer<JWK>) {
+    val signerAlgorithm = JwsAlgorithm(signer.javaAlgorithm.toJoseAlg().name)
+    check(popAlgorithm == signerAlgorithm) {
+        "DPoP Signer algorithm mismatch: expected ${popAlgorithm.name}, got ${signerAlgorithm.name}"
     }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
@@ -18,7 +18,6 @@ package eu.europa.ec.eudi.openid4vci
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.ECKey
-import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod
 import eu.europa.ec.eudi.openid4vci.internal.*
 import eu.europa.ec.eudi.openid4vci.internal.http.*
@@ -120,11 +119,11 @@ interface Issuer :
             requestEncryptionSpecFactory: RequestEncryptionSpecFactory = RequestEncryptionSpecFactory.DEFAULT,
             responseEncryptionSpecFactory: ResponseEncryptionSpecFactory = ResponseEncryptionSpecFactory.DEFAULT,
         ): Result<Issuer> = runCatching {
-            val (provisionedClientAttestation, dPoPSigner) =
+            val authorizationServer = HttpsUrl(credentialOffer.authorizationServerMetadata.issuer.value).getOrThrow()
+
+            val provisionedClientAttestation =
                 when (val clientAuthentication = config.clientAuthentication) {
                     is ClientAuthentication.AttestationBased -> {
-                        val authorizationServer =
-                            HttpsUrl(credentialOffer.authorizationServerMetadata.issuer.value).getOrThrow()
                         val provisionedClientAttestation =
                             clientAuthentication.provisionClientAttestation(
                                 authorizationServer,
@@ -133,19 +132,20 @@ interface Issuer :
 
                         clientAuthentication.provisionClientAttestation.ensureValid(config.clock.instant(), provisionedClientAttestation)
                         provisionedClientAttestation.ensureSupportedByAuthorizationServer(credentialOffer.authorizationServerMetadata)
-
-                        provisionedClientAttestation to provisionedClientAttestation.popSigner
+                        provisionedClientAttestation
                     }
 
-                    is ClientAuthentication.None -> {
-                        val signer = when (val dPoPUsage = clientAuthentication.dPoPUsage) {
-                            DPoPUsage.Never -> null
-                            is DPoPUsage.IfSupported<Signer<JWK>> -> dPoPUsage.value
-                            is DPoPUsage.Required<Signer<JWK>> -> dPoPUsage.value
-                        }
-                        null to signer
-                    }
+                    is ClientAuthentication.None -> null
                 }
+
+            val dPoPSigner = when (val dPoPUsage = config.provisionDPoPUsage(authorizationServer)) {
+                DPoPUsage.Never -> null
+                is DPoPUsage.IfSupported -> dPoPUsage.value
+                is DPoPUsage.Required -> {
+                    checkNotNull(credentialOffer.dPoPCtx) { "dPoPCtx is required when DPoPUsage is required" }
+                    dPoPUsage.value
+                }
+            }
 
             val dPoPJwtFactory = credentialOffer.dPoPCtx?.let {
                 checkNotNull(dPoPSigner) { "dPoPSigner is required when using DPoP" }
@@ -278,6 +278,7 @@ interface Issuer :
                                 it.encryptionMethod to it.compressionAlgorithm
                             },
                             dPoPCtx = credentialOffer.dPoPCtx,
+                            provisionDPoPUsage = config.provisionDPoPUsage,
                             clock = config.clock,
                         ),
                         AuthorizedTransaction(this@deferredContext, deferredCredential.transactionId),

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialOfferRequestResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialOfferRequestResolver.kt
@@ -125,7 +125,7 @@ internal class CredentialOfferRequestResolver(
             ).getOrThrow()
 
             val dPoPCtx = run {
-                val dPoPUsage = config.dPoPUsage.map { it.popAlgorithm }
+                val dPoPUsage = config.dPoPUsage.map { it.provisionDPoPSigner.popAlgorithm }
                 DPoPCtx.createForServer(dPoPUsage, authorizationServerMetadata).getOrThrow()
             }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialOfferRequestResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialOfferRequestResolver.kt
@@ -16,7 +16,6 @@
 package eu.europa.ec.eudi.openid4vci.internal
 
 import com.eygraber.uri.Uri
-import com.nimbusds.jose.jwk.JWK
 import eu.europa.ec.eudi.openid4vci.*
 import eu.europa.ec.eudi.openid4vci.CredentialOfferRequestError.UnableToResolveAuthorizationServerMetadata
 import eu.europa.ec.eudi.openid4vci.CredentialOfferRequestError.UnableToResolveCredentialIssuerMetadata
@@ -126,20 +125,7 @@ internal class CredentialOfferRequestResolver(
             ).getOrThrow()
 
             val dPoPCtx = run {
-                val dPoPUsage = when (val clientAuthentication = config.clientAuthentication) {
-                    is ClientAuthentication.AttestationBased -> DPoPUsage.Required(
-                        clientAuthentication.provisionClientAttestation.popAlgorithm,
-                    )
-                    is ClientAuthentication.None -> when (val u = clientAuthentication.dPoPUsage) {
-                        is DPoPUsage.IfSupported<Signer<JWK>> -> {
-                            DPoPUsage.IfSupported(JwsAlgorithm(u.value.javaAlgorithm.toJoseAlg().name))
-                        }
-                        is DPoPUsage.Required<Signer<JWK>> -> {
-                            DPoPUsage.Required(JwsAlgorithm(u.value.javaAlgorithm.toJoseAlg().name))
-                        }
-                        DPoPUsage.Never -> DPoPUsage.Never
-                    }
-                }
+                val dPoPUsage = config.provisionDPoPUsage(authorizationServer).map { JwsAlgorithm(it.javaAlgorithm.toJoseAlg().name) }
                 DPoPCtx.createForServer(dPoPUsage, authorizationServerMetadata).getOrThrow()
             }
 
@@ -284,3 +270,10 @@ internal fun createAuthorizationCodeGrantCredentialOfferUri(
         .build()
         .toString()
 }
+
+internal fun <A : Any, B : Any> DPoPUsage<A>.map(convert: (A) -> B): DPoPUsage<B> =
+    when (this) {
+        DPoPUsage.Never -> DPoPUsage.Never
+        is DPoPUsage.IfSupported -> DPoPUsage.IfSupported(convert(value))
+        is DPoPUsage.Required -> DPoPUsage.Required(convert(value))
+    }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialOfferRequestResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialOfferRequestResolver.kt
@@ -125,7 +125,7 @@ internal class CredentialOfferRequestResolver(
             ).getOrThrow()
 
             val dPoPCtx = run {
-                val dPoPUsage = config.provisionDPoPUsage(authorizationServer).map { JwsAlgorithm(it.javaAlgorithm.toJoseAlg().name) }
+                val dPoPUsage = config.dPoPUsage.map { it.popAlgorithm }
                 DPoPCtx.createForServer(dPoPUsage, authorizationServerMetadata).getOrThrow()
             }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProvisionOnce.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProvisionOnce.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.openid4vci.internal
+
+import com.nimbusds.jose.jwk.JWK
+import eu.europa.ec.eudi.openid4vci.DPoPConfig
+import eu.europa.ec.eudi.openid4vci.DPoPJwtFactory
+import eu.europa.ec.eudi.openid4vci.HttpsUrl
+import eu.europa.ec.eudi.openid4vci.JwsAlgorithm
+import eu.europa.ec.eudi.openid4vci.ProvisionDPoPSigner
+import eu.europa.ec.eudi.openid4vci.Signer
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.time.Clock
+
+internal class ProvisionOnce<V : Any>(private val provision: suspend () -> V?) : suspend () -> V? {
+
+    private var provisioned = false
+    private val mutex = Mutex()
+    private var value: V? = null
+
+    override suspend fun invoke(): V? =
+        if (!provisioned)
+            mutex.withLock {
+                if (!provisioned) {
+                    value = provision()
+                    provisioned = true
+                }
+                value
+            }
+        else value
+
+    companion object
+}
+
+internal fun ProvisionOnce.Companion.dPoPJwtFactory(
+    clock: Clock,
+    authorizationServer: HttpsUrl,
+    config: DPoPConfig,
+): ProvisionOnce<DPoPJwtFactory> =
+    ProvisionOnce {
+        fun ProvisionDPoPSigner.ensureValid(signer: Signer<JWK>) {
+            val signerAlgorithm = JwsAlgorithm(signer.javaAlgorithm.toJoseAlg().name)
+            check(popAlgorithm == signerAlgorithm) {
+                "DPoP Signer algorithm mismatch: expected ${popAlgorithm.name}, got ${signerAlgorithm.name}"
+            }
+        }
+
+        config?.let { (provisionDPoPSigner) ->
+            val dPoPSigner = provisionDPoPSigner(authorizationServer)
+            provisionDPoPSigner.ensureValid(dPoPSigner)
+            DPoPJwtFactory(clock = clock, signer = dPoPSigner)
+        }
+    }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProvisionOnce.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProvisionOnce.kt
@@ -46,7 +46,7 @@ internal class ProvisionOnce<V : Any>(private val provision: suspend () -> V?) :
     companion object
 }
 
-internal fun ProvisionOnce.Companion.dPoPJwtFactory(
+internal fun dPoPJwtFactory(
     clock: Clock,
     authorizationServer: HttpsUrl,
     config: DPoPConfig,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/AuthorizationEndpointClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/AuthorizationEndpointClient.kt
@@ -75,7 +75,7 @@ internal class AuthorizationEndpointClient(
     private val pushedAuthorizationRequestEndpoint: URL?,
     private val challengeEndpoint: URL?,
     private val config: OpenId4VCIConfig,
-    private val dPoPJwtFactory: DPoPJwtFactory?,
+    private val dPoPJwtFactory: suspend () -> DPoPJwtFactory?,
     private val provisionedClientAttestation: ProvisionClientAttestation.Provisioned?,
     private val httpClient: HttpClient,
 ) {
@@ -84,7 +84,7 @@ internal class AuthorizationEndpointClient(
         credentialIssuerId: CredentialIssuerId,
         authorizationServerMetadata: CIAuthorizationServerMetadata,
         config: OpenId4VCIConfig,
-        dPoPJwtFactory: DPoPJwtFactory?,
+        dPoPJwtFactory: suspend () -> DPoPJwtFactory?,
         provisionedClientAttestation: ProvisionClientAttestation.Provisioned?,
         httpClient: HttpClient,
     ) : this(
@@ -281,7 +281,7 @@ internal class AuthorizationEndpointClient(
                 existingDpopNonce = existingDpopNonce,
             )
             val dpopProof =
-                dPoPJwtFactory?.createDPoPJwt(Htm.POST, url, null, dpopNonce)
+                dPoPJwtFactory()?.createDPoPJwt(Htm.POST, url, null, dpopNonce)
                     ?.getOrThrow()
                     ?.serialize()
             val clientAttestation = provisionedClientAttestation?.generateClientAttestation(

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialEndpointClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialEndpointClient.kt
@@ -44,7 +44,7 @@ import io.ktor.http.*
 
 internal class CredentialEndpointClient(
     private val credentialEndpoint: CredentialIssuerEndpoint,
-    private val dPoPJwtFactory: DPoPJwtFactory?,
+    private val dPoPJwtFactory: suspend () -> DPoPJwtFactory?,
     private val httpClient: HttpClient,
 ) {
     /**
@@ -75,7 +75,7 @@ internal class CredentialEndpointClient(
                 .apply {
                     method = HttpMethod.Post
                     url.takeFrom(credentialEndpoint.value)
-                    bearerOrDPoPAuth(accessToken, dPoPJwtFactory, resourceServerDpopNonce)
+                    bearerOrDPoPAuth(accessToken, dPoPJwtFactory(), resourceServerDpopNonce)
                     encryptRequest(
                         requestTO = CredentialRequestTO.from(request),
                         requestEncryptionSpec = request.encryptionSpecs.requestEncryptionSpec,
@@ -110,7 +110,7 @@ internal class CredentialEndpointClient(
 
 internal class DeferredEndPointClient(
     private val deferredCredentialEndpoint: CredentialIssuerEndpoint,
-    private val dPoPJwtFactory: DPoPJwtFactory?,
+    private val dPoPJwtFactory: suspend () -> DPoPJwtFactory?,
     private val httpClient: HttpClient,
 ) {
     /**
@@ -157,7 +157,7 @@ internal class DeferredEndPointClient(
                 .apply {
                     method = HttpMethod.Post
                     url.takeFrom(deferredCredentialEndpoint.value)
-                    bearerOrDPoPAuth(accessToken, dPoPJwtFactory, resourceServerDpopNonce)
+                    bearerOrDPoPAuth(accessToken, dPoPJwtFactory(), resourceServerDpopNonce)
                     encryptRequest(
                         requestTO = deferredRequestTO,
                         requestEncryptionSpec = exchangeEncryptionSpecification.requestEncryptionSpec,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/NotificationEndPointClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/NotificationEndPointClient.kt
@@ -24,7 +24,7 @@ import io.ktor.http.*
 
 internal class NotificationEndPointClient(
     private val notificationEndpoint: CredentialIssuerEndpoint,
-    private val dPoPJwtFactory: DPoPJwtFactory?,
+    private val dPoPJwtFactory: suspend () -> DPoPJwtFactory?,
     private val httpClient: HttpClient,
 ) {
 
@@ -48,7 +48,7 @@ internal class NotificationEndPointClient(
                 .apply {
                     method = HttpMethod.Post
                     url.takeFrom(notificationEndpoint.value)
-                    bearerOrDPoPAuth(accessToken, dPoPJwtFactory, resourceServerDpopNonce)
+                    bearerOrDPoPAuth(accessToken, dPoPJwtFactory(), resourceServerDpopNonce)
                     contentType(ContentType.Application.Json)
                     setBody(NotificationTO.from(event))
                 },

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/TokenEndpointClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/TokenEndpointClient.kt
@@ -95,7 +95,7 @@ internal class TokenEndpointClient(
     private val authServerId: URL,
     private val challengeEndpoint: URL?,
     private val tokenEndpoint: URL,
-    private val dPoPJwtFactory: DPoPJwtFactory?,
+    private val dPoPJwtFactory: suspend () -> DPoPJwtFactory?,
     private val httpClient: HttpClient,
 ) {
 
@@ -114,7 +114,7 @@ internal class TokenEndpointClient(
         credentialIssuerId: CredentialIssuerId,
         authorizationServerMetadata: CIAuthorizationServerMetadata,
         config: OpenId4VCIConfig,
-        dPoPJwtFactory: DPoPJwtFactory?,
+        dPoPJwtFactory: suspend () -> DPoPJwtFactory?,
         provisionedClientAttestation: ProvisionClientAttestation.Provisioned?,
         httpClient: HttpClient,
     ) : this(
@@ -227,7 +227,7 @@ internal class TokenEndpointClient(
                 authServerId,
                 abcaChallenge,
             )
-            val dpopProof = dPoPJwtFactory?.createDPoPJwt(Htm.POST, tokenEndpoint, null, dpopNonce)
+            val dpopProof = dPoPJwtFactory()?.createDPoPJwt(Htm.POST, tokenEndpoint, null, dpopNonce)
                 ?.getOrThrow()
                 ?.serialize()
 

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CredentialReusePolicyTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CredentialReusePolicyTest.kt
@@ -314,7 +314,6 @@ internal class CredentialReusePolicyTest {
         assertFailsWith<IllegalArgumentException> {
             OpenId4VCIConfig(
                 clientAuthentication = ClientAuthentication.None("wallet"),
-                provisionDPoPUsage = { DPoPUsage.Never },
                 authFlowRedirectionURI = URI("eudi-openid4vci://cb"),
                 encryptionSupportConfig = EncryptionSupportConfig.invoke(
                     Curve.P_256,
@@ -331,7 +330,6 @@ internal class CredentialReusePolicyTest {
         assertDoesNotThrow {
             OpenId4VCIConfig(
                 clientAuthentication = ClientAuthentication.None("wallet"),
-                provisionDPoPUsage = { DPoPUsage.Never },
                 authFlowRedirectionURI = URI("eudi-openid4vci://cb"),
                 encryptionSupportConfig = EncryptionSupportConfig.invoke(
                     Curve.P_256,

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CredentialReusePolicyTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CredentialReusePolicyTest.kt
@@ -313,7 +313,8 @@ internal class CredentialReusePolicyTest {
     fun `fails when supportedCredentialReusePolicies is provided but doesn't contain a base method`() {
         assertFailsWith<IllegalArgumentException> {
             OpenId4VCIConfig(
-                clientAuthentication = ClientAuthentication.None("wallet", DPoPUsage.Never),
+                clientAuthentication = ClientAuthentication.None("wallet"),
+                provisionDPoPUsage = { DPoPUsage.Never },
                 authFlowRedirectionURI = URI("eudi-openid4vci://cb"),
                 encryptionSupportConfig = EncryptionSupportConfig.invoke(
                     Curve.P_256,
@@ -329,7 +330,8 @@ internal class CredentialReusePolicyTest {
     fun `succeeds when supportedCredentialReusePolicies is provided and contains a base method`() {
         assertDoesNotThrow {
             OpenId4VCIConfig(
-                clientAuthentication = ClientAuthentication.None("wallet", DPoPUsage.Never),
+                clientAuthentication = ClientAuthentication.None("wallet"),
+                provisionDPoPUsage = { DPoPUsage.Never },
                 authFlowRedirectionURI = URI("eudi-openid4vci://cb"),
                 encryptionSupportConfig = EncryptionSupportConfig.invoke(
                     Curve.P_256,

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
@@ -958,12 +958,14 @@ class IssuanceSingleRequestTest {
         val config = OpenId4VCIConfiguration.copy(
             clientAuthentication = client,
             dPoPUsage = DPoPUsage.Required(
-                object : ProvisionDPoPSigner {
-                    override val popAlgorithm: JwsAlgorithm = JwsAlgorithm(JWSAlgorithm.ES256.name)
-                    override suspend fun invoke(
-                        authorizationServer: HttpsUrl,
-                    ): Signer<JWK> = Signer.fromNimbusEcKey(dPoPSigningKey, dPoPSigningKey.toPublicJWK(), null, null)
-                },
+                DPoPConfig(
+                    object : ProvisionDPoPSigner {
+                        override val popAlgorithm: JwsAlgorithm = JwsAlgorithm(JWSAlgorithm.ES256.name)
+                        override suspend fun invoke(
+                            authorizationServer: HttpsUrl,
+                        ): Signer<JWK> = Signer.fromNimbusEcKey(dPoPSigningKey, dPoPSigningKey.toPublicJWK(), null, null)
+                    },
+                ),
             ),
         )
 
@@ -1016,12 +1018,14 @@ class IssuanceSingleRequestTest {
         val config = OpenId4VCIConfiguration.copy(
             clientAuthentication = client,
             dPoPUsage = DPoPUsage.Required(
-                object : ProvisionDPoPSigner {
-                    override val popAlgorithm: JwsAlgorithm = JwsAlgorithm(JWSAlgorithm.ES256.name)
-                    override suspend fun invoke(
-                        authorizationServer: HttpsUrl,
-                    ): Signer<JWK> = Signer.fromNimbusEcKey(dPoPSigningKey, dPoPSigningKey.toPublicJWK(), null, null)
-                },
+                DPoPConfig(
+                    object : ProvisionDPoPSigner {
+                        override val popAlgorithm: JwsAlgorithm = JwsAlgorithm(JWSAlgorithm.ES256.name)
+                        override suspend fun invoke(
+                            authorizationServer: HttpsUrl,
+                        ): Signer<JWK> = Signer.fromNimbusEcKey(dPoPSigningKey, dPoPSigningKey.toPublicJWK(), null, null)
+                    },
+                ),
             ),
         )
 

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
@@ -15,8 +15,10 @@
  */
 package eu.europa.ec.eudi.openid4vci
 
+import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.JWSObject
 import com.nimbusds.jose.jwk.Curve
+import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator
 import com.nimbusds.jwt.SignedJWT
 import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.ResponseUnparsable
@@ -955,7 +957,14 @@ class IssuanceSingleRequestTest {
 
         val config = OpenId4VCIConfiguration.copy(
             clientAuthentication = client,
-            provisionDPoPUsage = { DPoPUsage.Required(Signer.fromNimbusEcKey(dPoPSigningKey, dPoPSigningKey.toPublicJWK(), null, null)) },
+            dPoPUsage = DPoPUsage.Required(
+                object : ProvisionDPoPSigner {
+                    override val popAlgorithm: JwsAlgorithm = JwsAlgorithm(JWSAlgorithm.ES256.name)
+                    override suspend fun invoke(
+                        authorizationServer: HttpsUrl,
+                    ): Signer<JWK> = Signer.fromNimbusEcKey(dPoPSigningKey, dPoPSigningKey.toPublicJWK(), null, null)
+                },
+            ),
         )
 
         val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
@@ -1006,7 +1015,14 @@ class IssuanceSingleRequestTest {
 
         val config = OpenId4VCIConfiguration.copy(
             clientAuthentication = client,
-            provisionDPoPUsage = { DPoPUsage.Required(Signer.fromNimbusEcKey(dPoPSigningKey, dPoPSigningKey.toPublicJWK(), null, null)) },
+            dPoPUsage = DPoPUsage.Required(
+                object : ProvisionDPoPSigner {
+                    override val popAlgorithm: JwsAlgorithm = JwsAlgorithm(JWSAlgorithm.ES256.name)
+                    override suspend fun invoke(
+                        authorizationServer: HttpsUrl,
+                    ): Signer<JWK> = Signer.fromNimbusEcKey(dPoPSigningKey, dPoPSigningKey.toPublicJWK(), null, null)
+                },
+            ),
         )
 
         val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
@@ -26,6 +26,7 @@ import eu.europa.ec.eudi.openid4vci.CryptoGenerator.noKeyAttestationJwtProofsSpe
 import eu.europa.ec.eudi.openid4vci.IssuerMetadataVersion.NO_NONCE_ENDPOINT
 import eu.europa.ec.eudi.openid4vci.examples.selfSignedClient
 import eu.europa.ec.eudi.openid4vci.examples.verifySelfSignedClientAttestation
+import eu.europa.ec.eudi.openid4vci.internal.fromNimbusEcKey
 import eu.europa.ec.eudi.openid4vci.internal.http.CredentialRequestTO
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
@@ -925,6 +926,7 @@ class IssuanceSingleRequestTest {
 
     @Test
     fun `issuance success with attested client`() = runTest {
+        val dPoPSigningKey = CryptoGenerator.randomECSigningKey(Curve.P_256)
         val walletInstanceKey = ECKeyGenerator(Curve.P_521).keyID(UUID.randomUUID().toString()).generate()
         val client = selfSignedClient(
             walletInstanceKey = walletInstanceKey,
@@ -940,18 +942,21 @@ class IssuanceSingleRequestTest {
             challengePostMocker(challenge = abcaChallenge, dpopNonce = dpopNonce),
             parPostMocker {
                 it.verifySelfSignedClientAttestation(walletInstanceKey, abcaChallenge)
-                it.verifyDPoPProof(walletInstanceKey, dpopNonce)
+                it.verifyDPoPProof(dPoPSigningKey.toPublicJWK(), dpopNonce)
             },
             challengePostMocker(challenge = updatedAbcaChallenge),
             tokenPostMocker {
                 it.verifySelfSignedClientAttestation(walletInstanceKey, updatedAbcaChallenge)
-                it.verifyDPoPProof(walletInstanceKey, dpopNonce)
+                it.verifyDPoPProof(dPoPSigningKey.toPublicJWK(), dpopNonce)
             },
             nonceEndpointMocker(),
             singleIssuanceRequestMocker(),
         )
 
-        val config = OpenId4VCIConfiguration.copy(clientAuthentication = client)
+        val config = OpenId4VCIConfiguration.copy(
+            clientAuthentication = client,
+            provisionDPoPUsage = { DPoPUsage.Required(Signer.fromNimbusEcKey(dPoPSigningKey, dPoPSigningKey.toPublicJWK(), null, null)) },
+        )
 
         val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
             config = config,
@@ -971,6 +976,7 @@ class IssuanceSingleRequestTest {
 
     @Test
     fun `attested client considers dpop nonce returned by challenge endpoint`() = runTest {
+        val dPoPSigningKey = CryptoGenerator.randomECSigningKey(Curve.P_256)
         val walletInstanceKey = ECKeyGenerator(Curve.P_521).keyID(UUID.randomUUID().toString()).generate()
         val client = selfSignedClient(
             walletInstanceKey = walletInstanceKey,
@@ -987,18 +993,21 @@ class IssuanceSingleRequestTest {
             challengePostMocker(challenge = abcaChallenge, dpopNonce = dpopNonce),
             parPostMocker {
                 it.verifySelfSignedClientAttestation(walletInstanceKey, abcaChallenge)
-                it.verifyDPoPProof(walletInstanceKey, dpopNonce)
+                it.verifyDPoPProof(dPoPSigningKey.toPublicJWK(), dpopNonce)
             },
             challengePostMocker(challenge = updatedAbcaChallenge, dpopNonce = updatedDpopNonce),
             tokenPostMocker {
                 it.verifySelfSignedClientAttestation(walletInstanceKey, updatedAbcaChallenge)
-                it.verifyDPoPProof(walletInstanceKey, updatedDpopNonce)
+                it.verifyDPoPProof(dPoPSigningKey.toPublicJWK(), updatedDpopNonce)
             },
             nonceEndpointMocker(),
             singleIssuanceRequestMocker(),
         )
 
-        val config = OpenId4VCIConfiguration.copy(clientAuthentication = client)
+        val config = OpenId4VCIConfiguration.copy(
+            clientAuthentication = client,
+            provisionDPoPUsage = { DPoPUsage.Required(Signer.fromNimbusEcKey(dPoPSigningKey, dPoPSigningKey.toPublicJWK(), null, null)) },
+        )
 
         val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
             config = config,

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
@@ -15,10 +15,8 @@
  */
 package eu.europa.ec.eudi.openid4vci
 
-import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.JWSObject
 import com.nimbusds.jose.jwk.Curve
-import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator
 import com.nimbusds.jwt.SignedJWT
 import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.ResponseUnparsable
@@ -28,7 +26,6 @@ import eu.europa.ec.eudi.openid4vci.CryptoGenerator.noKeyAttestationJwtProofsSpe
 import eu.europa.ec.eudi.openid4vci.IssuerMetadataVersion.NO_NONCE_ENDPOINT
 import eu.europa.ec.eudi.openid4vci.examples.selfSignedClient
 import eu.europa.ec.eudi.openid4vci.examples.verifySelfSignedClientAttestation
-import eu.europa.ec.eudi.openid4vci.internal.fromNimbusEcKey
 import eu.europa.ec.eudi.openid4vci.internal.http.CredentialRequestTO
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
@@ -957,16 +954,7 @@ class IssuanceSingleRequestTest {
 
         val config = OpenId4VCIConfiguration.copy(
             clientAuthentication = client,
-            dPoPUsage = DPoPUsage.Required(
-                DPoPConfig(
-                    object : ProvisionDPoPSigner {
-                        override val popAlgorithm: JwsAlgorithm = JwsAlgorithm(JWSAlgorithm.ES256.name)
-                        override suspend fun invoke(
-                            authorizationServer: HttpsUrl,
-                        ): Signer<JWK> = Signer.fromNimbusEcKey(dPoPSigningKey, dPoPSigningKey.toPublicJWK(), null, null)
-                    },
-                ),
-            ),
+            dPoPUsage = DPoPUsage.Required(DPoPConfig(ProvisionDPoPSigner(dPoPSigningKey))),
         )
 
         val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
@@ -1017,16 +1005,7 @@ class IssuanceSingleRequestTest {
 
         val config = OpenId4VCIConfiguration.copy(
             clientAuthentication = client,
-            dPoPUsage = DPoPUsage.Required(
-                DPoPConfig(
-                    object : ProvisionDPoPSigner {
-                        override val popAlgorithm: JwsAlgorithm = JwsAlgorithm(JWSAlgorithm.ES256.name)
-                        override suspend fun invoke(
-                            authorizationServer: HttpsUrl,
-                        ): Signer<JWK> = Signer.fromNimbusEcKey(dPoPSigningKey, dPoPSigningKey.toPublicJWK(), null, null)
-                    },
-                ),
-            ),
+            dPoPUsage = DPoPUsage.Required(DPoPConfig(ProvisionDPoPSigner(dPoPSigningKey))),
         )
 
         val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
@@ -28,6 +28,8 @@ import com.nimbusds.jwt.SignedJWT
 import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier
 import com.nimbusds.jwt.proc.DefaultJWTProcessor
 import eu.europa.ec.eudi.openid4vci.CryptoGenerator.ecSigner
+import eu.europa.ec.eudi.openid4vci.internal.fromNimbusEcKey
+import eu.europa.ec.eudi.openid4vci.internal.toJoseAlg
 import io.ktor.client.*
 import io.ktor.client.request.HttpRequestData
 import java.net.URI
@@ -190,4 +192,15 @@ internal fun HttpRequestData.verifyDPoPProof(dPoPSigningKey: ECKey, dpopNonce: N
         }
     jwtProcessor.process(dpopProof, null)
     assertEquals(dPoPSigningKey.toPublicJWK().computeThumbprint(), dpopProof.header.jwk.computeThumbprint())
+}
+
+internal fun ProvisionDPoPSigner(signer: Signer<JWK>): ProvisionDPoPSigner =
+    object : ProvisionDPoPSigner {
+        override val popAlgorithm: JwsAlgorithm = JwsAlgorithm(signer.javaAlgorithm.toJoseAlg().name)
+        override suspend fun invoke(authorizationServer: HttpsUrl): Signer<JWK> = signer
+    }
+
+internal fun ProvisionDPoPSigner(signingKey: ECKey): ProvisionDPoPSigner {
+    require(signingKey.isPrivate)
+    return ProvisionDPoPSigner(Signer.fromNimbusEcKey(signingKey, signingKey.toPublicJWK(), secureRandom = null, provider = null))
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
@@ -19,6 +19,7 @@ import com.nimbusds.jose.JOSEObjectType
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.ECKey
+import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier
 import com.nimbusds.jose.proc.SecurityContext
 import com.nimbusds.jose.proc.SingleKeyJWSKeySelector
@@ -98,21 +99,18 @@ val CredentialOfferMixedDocTypes_AUTH_GRANT = """
 
 val OpenId4VCIConfiguration = OpenId4VCIConfig(
     clientAuthentication = ClientAuthentication.None("MyWallet_ClientId"),
-    provisionDPoPUsage = { DPoPUsage.Never },
     authFlowRedirectionURI = URI.create("eudi-wallet//auth"),
     encryptionSupportConfig = EncryptionSupportConfig(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
 )
 
 val OpenId4VCIConfigurationWithDpopSigner = OpenId4VCIConfig(
     clientAuthentication = ClientAuthentication.None("MyWallet_ClientId"),
-    provisionDPoPUsage = {
-        DPoPUsage.IfSupported(
-            ecSigner(
-                curve = Curve.P_256,
-                alg = JWSAlgorithm.ES256,
-            ),
-        )
-    },
+    dPoPUsage = DPoPUsage.IfSupported(
+        object : ProvisionDPoPSigner {
+            override val popAlgorithm: JwsAlgorithm = JwsAlgorithm(JWSAlgorithm.ES256.name)
+            override suspend fun invoke(authorizationServer: HttpsUrl): Signer<JWK> = ecSigner(Curve.P_256, JWSAlgorithm.ES256)
+        },
+    ),
     authFlowRedirectionURI = URI.create("eudi-wallet//auth"),
     encryptionSupportConfig = EncryptionSupportConfig(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
 

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
@@ -97,21 +97,22 @@ val CredentialOfferMixedDocTypes_AUTH_GRANT = """
 """.trimIndent()
 
 val OpenId4VCIConfiguration = OpenId4VCIConfig(
-    clientAuthentication = ClientAuthentication.None("MyWallet_ClientId", DPoPUsage.Never),
+    clientAuthentication = ClientAuthentication.None("MyWallet_ClientId"),
+    provisionDPoPUsage = { DPoPUsage.Never },
     authFlowRedirectionURI = URI.create("eudi-wallet//auth"),
     encryptionSupportConfig = EncryptionSupportConfig(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
 )
 
 val OpenId4VCIConfigurationWithDpopSigner = OpenId4VCIConfig(
-    clientAuthentication = ClientAuthentication.None(
-        "MyWallet_ClientId",
+    clientAuthentication = ClientAuthentication.None("MyWallet_ClientId"),
+    provisionDPoPUsage = {
         DPoPUsage.IfSupported(
             ecSigner(
                 curve = Curve.P_256,
                 alg = JWSAlgorithm.ES256,
             ),
-        ),
-    ),
+        )
+    },
     authFlowRedirectionURI = URI.create("eudi-wallet//auth"),
     encryptionSupportConfig = EncryptionSupportConfig(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
 
@@ -174,12 +175,12 @@ fun CredentialReusePolicy.effectiveBatchSize(supportedReusePolicies: CredentialR
         CredentialReusePolicy.None -> null
     }
 
-internal fun HttpRequestData.verifyDPoPProof(walletInstanceKey: ECKey, dpopNonce: Nonce) {
+internal fun HttpRequestData.verifyDPoPProof(dPoPSigningKey: ECKey, dpopNonce: Nonce) {
     val dpopProof = SignedJWT.parse(assertNotNull(headers["DPoP"]))
     val jwtProcessor = DefaultJWTProcessor<SecurityContext>()
         .apply {
             jwsTypeVerifier = DefaultJOSEObjectTypeVerifier(setOf(JOSEObjectType("dpop+jwt")))
-            jwsKeySelector = SingleKeyJWSKeySelector(dpopProof.header.algorithm, walletInstanceKey.toPublicKey())
+            jwsKeySelector = SingleKeyJWSKeySelector(dpopProof.header.algorithm, dPoPSigningKey.toPublicKey())
             jwtClaimsSetVerifier = DefaultJWTClaimsVerifier(
                 JWTClaimsSet.Builder()
                     .claim("nonce", dpopNonce.value)
@@ -188,5 +189,5 @@ internal fun HttpRequestData.verifyDPoPProof(walletInstanceKey: ECKey, dpopNonce
             )
         }
     jwtProcessor.process(dpopProof, null)
-    assertEquals(walletInstanceKey.toPublicJWK(), dpopProof.header.jwk)
+    assertEquals(dPoPSigningKey.toPublicJWK().computeThumbprint(), dpopProof.header.jwk.computeThumbprint())
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
@@ -107,14 +107,7 @@ val OpenId4VCIConfiguration = OpenId4VCIConfig(
 
 val OpenId4VCIConfigurationWithDpopSigner = OpenId4VCIConfig(
     clientAuthentication = ClientAuthentication.None("MyWallet_ClientId"),
-    dPoPUsage = DPoPUsage.IfSupported(
-        DPoPConfig(
-            object : ProvisionDPoPSigner {
-                override val popAlgorithm: JwsAlgorithm = JwsAlgorithm(JWSAlgorithm.ES256.name)
-                override suspend fun invoke(authorizationServer: HttpsUrl): Signer<JWK> = ecSigner(Curve.P_256, JWSAlgorithm.ES256)
-            },
-        ),
-    ),
+    dPoPUsage = DPoPUsage.IfSupported(DPoPConfig(ProvisionDPoPSigner(ecSigner(Curve.P_256, JWSAlgorithm.ES256)))),
     authFlowRedirectionURI = URI.create("eudi-wallet//auth"),
     encryptionSupportConfig = EncryptionSupportConfig(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
 

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
@@ -106,10 +106,12 @@ val OpenId4VCIConfiguration = OpenId4VCIConfig(
 val OpenId4VCIConfigurationWithDpopSigner = OpenId4VCIConfig(
     clientAuthentication = ClientAuthentication.None("MyWallet_ClientId"),
     dPoPUsage = DPoPUsage.IfSupported(
-        object : ProvisionDPoPSigner {
-            override val popAlgorithm: JwsAlgorithm = JwsAlgorithm(JWSAlgorithm.ES256.name)
-            override suspend fun invoke(authorizationServer: HttpsUrl): Signer<JWK> = ecSigner(Curve.P_256, JWSAlgorithm.ES256)
-        },
+        DPoPConfig(
+            object : ProvisionDPoPSigner {
+                override val popAlgorithm: JwsAlgorithm = JwsAlgorithm(JWSAlgorithm.ES256.name)
+                override suspend fun invoke(authorizationServer: HttpsUrl): Signer<JWK> = ecSigner(Curve.P_256, JWSAlgorithm.ES256)
+            },
+        ),
     ),
     authFlowRedirectionURI = URI.create("eudi-wallet//auth"),
     encryptionSupportConfig = EncryptionSupportConfig(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingPreAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingPreAuthorizationFlow.kt
@@ -25,7 +25,6 @@ import java.net.URI
 fun main(): Unit = runBlocking {
     val vciConfig = OpenId4VCIConfig(
         clientAuthentication = ClientAuthentication.None("218232426"),
-        provisionDPoPUsage = { DPoPUsage.Never },
         authFlowRedirectionURI = URI.create("urn:ietf:wg:oauth:2.0:oob"),
         encryptionSupportConfig = EncryptionSupportConfig(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
     )

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingPreAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingPreAuthorizationFlow.kt
@@ -24,7 +24,8 @@ import java.net.URI
 
 fun main(): Unit = runBlocking {
     val vciConfig = OpenId4VCIConfig(
-        clientAuthentication = ClientAuthentication.None("218232426", DPoPUsage.Never),
+        clientAuthentication = ClientAuthentication.None("218232426"),
+        provisionDPoPUsage = { DPoPUsage.Never },
         authFlowRedirectionURI = URI.create("urn:ietf:wg:oauth:2.0:oob"),
         encryptionSupportConfig = EncryptionSupportConfig(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
     )

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuer.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuer.kt
@@ -17,7 +17,6 @@ package eu.europa.ec.eudi.openid4vci.examples
 
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.Curve
-import com.nimbusds.jose.jwk.JWK
 import eu.europa.ec.eudi.openid4vci.*
 import io.ktor.http.Url
 
@@ -43,16 +42,7 @@ internal object PidDevIssuer :
                 Url("https://dev.wallet-provider.eudiw.dev/wallet-instance-attestation/jwk"),
             ),
         ),
-        dPoPUsage = DPoPUsage.Required(
-            DPoPConfig(
-                object : ProvisionDPoPSigner {
-                    override val popAlgorithm: JwsAlgorithm = JwsAlgorithm(JWSAlgorithm.ES256.name)
-                    override suspend fun invoke(
-                        authorizationServer: HttpsUrl,
-                    ): Signer<JWK> = CryptoGenerator.ecSigner(Curve.P_256, JWSAlgorithm.ES256)
-                },
-            ),
-        ),
+        dPoPUsage = DPoPUsage.Required(DPoPConfig(ProvisionDPoPSigner(CryptoGenerator.ecSigner(Curve.P_256, JWSAlgorithm.ES256)))),
         authFlowRedirectionURI = Keycloak.DebugRedirectUri,
         encryptionSupportConfig = EncryptionSupportConfig(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
         authorizeIssuanceConfig = AuthorizeIssuanceConfig.FAVOR_SCOPES,

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuer.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuer.kt
@@ -15,7 +15,9 @@
  */
 package eu.europa.ec.eudi.openid4vci.examples
 
+import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.Curve
+import com.nimbusds.jose.jwk.JWK
 import eu.europa.ec.eudi.openid4vci.*
 import io.ktor.http.Url
 
@@ -33,7 +35,6 @@ internal object PidDevIssuer :
 
     override val issuerId = IssuerId
     override val testUser = KeycloakUser("tneal", "password")
-    private val dPoPUsage by lazy { DPoPUsage.Required(CryptoGenerator.ecSigner()) }
     override val cfg = OpenId4VCIConfig(
         clientAuthentication = ClientAuthentication.AttestationBased(
             WALLET_CLIENT_ID,
@@ -42,7 +43,14 @@ internal object PidDevIssuer :
                 Url("https://dev.wallet-provider.eudiw.dev/wallet-instance-attestation/jwk"),
             ),
         ),
-        provisionDPoPUsage = { dPoPUsage },
+        dPoPUsage = DPoPUsage.Required(
+            object : ProvisionDPoPSigner {
+                override val popAlgorithm: JwsAlgorithm = JwsAlgorithm(JWSAlgorithm.ES256.name)
+                override suspend fun invoke(
+                    authorizationServer: HttpsUrl,
+                ): Signer<JWK> = CryptoGenerator.ecSigner(Curve.P_256, JWSAlgorithm.ES256)
+            },
+        ),
         authFlowRedirectionURI = Keycloak.DebugRedirectUri,
         encryptionSupportConfig = EncryptionSupportConfig(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
         authorizeIssuanceConfig = AuthorizeIssuanceConfig.FAVOR_SCOPES,

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuer.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuer.kt
@@ -44,12 +44,14 @@ internal object PidDevIssuer :
             ),
         ),
         dPoPUsage = DPoPUsage.Required(
-            object : ProvisionDPoPSigner {
-                override val popAlgorithm: JwsAlgorithm = JwsAlgorithm(JWSAlgorithm.ES256.name)
-                override suspend fun invoke(
-                    authorizationServer: HttpsUrl,
-                ): Signer<JWK> = CryptoGenerator.ecSigner(Curve.P_256, JWSAlgorithm.ES256)
-            },
+            DPoPConfig(
+                object : ProvisionDPoPSigner {
+                    override val popAlgorithm: JwsAlgorithm = JwsAlgorithm(JWSAlgorithm.ES256.name)
+                    override suspend fun invoke(
+                        authorizationServer: HttpsUrl,
+                    ): Signer<JWK> = CryptoGenerator.ecSigner(Curve.P_256, JWSAlgorithm.ES256)
+                },
+            ),
         ),
         authFlowRedirectionURI = Keycloak.DebugRedirectUri,
         encryptionSupportConfig = EncryptionSupportConfig(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuer.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuer.kt
@@ -33,6 +33,7 @@ internal object PidDevIssuer :
 
     override val issuerId = IssuerId
     override val testUser = KeycloakUser("tneal", "password")
+    private val dPoPUsage by lazy { DPoPUsage.Required(CryptoGenerator.ecSigner()) }
     override val cfg = OpenId4VCIConfig(
         clientAuthentication = ClientAuthentication.AttestationBased(
             WALLET_CLIENT_ID,
@@ -41,6 +42,7 @@ internal object PidDevIssuer :
                 Url("https://dev.wallet-provider.eudiw.dev/wallet-instance-attestation/jwk"),
             ),
         ),
+        provisionDPoPUsage = { dPoPUsage },
         authFlowRedirectionURI = Keycloak.DebugRedirectUri,
         encryptionSupportConfig = EncryptionSupportConfig(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
         authorizeIssuanceConfig = AuthorizeIssuanceConfig.FAVOR_SCOPES,

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/RefreshAccessTokenImplTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/RefreshAccessTokenImplTest.kt
@@ -109,7 +109,7 @@ private fun tokenEndpointClient(httpClient: HttpClient) = TokenEndpointClient(
     SampleIssuer.Id,
     oauthAuthorizationServerMetadata(),
     OpenId4VCIConfiguration,
-    null,
+    { null },
     null,
     httpClient,
 )


### PR DESCRIPTION
This PR aligns the library with TS3 v1.5.2 and reverts the requirement of TS3 v1.5.1 that DPoP Proofs be signed with the same key as Client Attestation PoP JWT.

DPoP related configuration properties have been moved from `ClientAuthentication` to `OpenId4VCIConfig`.

Similar to `ProvisionClientAttestation`,
```kotlin
interface ProvisionDPoPSigner {
    val popAlgorithm: JwsAlgorithm

    suspend operator fun invoke(authorizationServer: HttpsUrl): Signer<JWK>
}
``` 
has been introduced as a means to defer the provisioning of the DPoP Proof Signer.

`OpenId4VCIConfig` has been updated to include `val dPoPUsage: DPoPUsageOption = DPoPUsage.Never`, with `typealias DPoPUsageOption = DPoPUsage<ProvisionDPoPSigner>`.

