### PR TITLE
Defer Client Attestation provisioning

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/DeferredIssuer.kt
@@ -19,6 +19,7 @@ import com.nimbusds.jose.CompressionAlgorithm
 import com.nimbusds.jose.EncryptionMethod
 import com.nimbusds.jose.jwk.JWK
 import eu.europa.ec.eudi.openid4vci.internal.RefreshAccessTokenImpl
+import eu.europa.ec.eudi.openid4vci.internal.clientAttestation
 import eu.europa.ec.eudi.openid4vci.internal.dPoPJwtFactory
 import eu.europa.ec.eudi.openid4vci.internal.http.DeferredEndPointClient
 import eu.europa.ec.eudi.openid4vci.internal.http.TokenEndpointClient
@@ -163,25 +164,26 @@ interface DeferredIssuer : RefreshAccessToken, QueryForDeferredCredential {
          *
          * @return the deferred issuer instance
          */
-        suspend fun make(
+        fun make(
             config: DeferredIssuerConfig,
             responseEncryptionKey: JWK?,
             httpClient: HttpClient,
         ): Result<DeferredIssuer> = runCatching {
             val authorizationServer = HttpsUrl(config.authorizationServerId.toString()).getOrThrow()
 
-            val provisionedClientAttestation =
+            val provisionClientAttestation =
                 when (val clientAuthentication = config.clientAuthentication) {
-                    is ClientAuthentication.AttestationBased -> {
-                        val provisionedClientAttestation = clientAuthentication.provisionClientAttestation(
+                    is ClientAuthentication.AttestationBased ->
+                        clientAttestation(
+                            config.clock,
                             authorizationServer,
                             config.preferredClientStatusPeriod,
+                            clientAuthentication,
                         )
-                        clientAuthentication.provisionClientAttestation.ensureValid(config.clock.instant(), provisionedClientAttestation)
-                        provisionedClientAttestation
-                    }
 
-                    is ClientAuthentication.None -> null
+                    is ClientAuthentication.None -> {
+                        { null }
+                    }
                 }
 
             val provisionDPoPJwtFactory = config.dPoPConfig?.let { dPoPJwtFactory(config.clock, authorizationServer, it) } ?: { null }
@@ -190,7 +192,7 @@ interface DeferredIssuer : RefreshAccessToken, QueryForDeferredCredential {
                 config.credentialIssuerId,
                 config.clock,
                 config.clientAuthentication.id,
-                provisionedClientAttestation,
+                provisionClientAttestation,
                 URI.create("https://willNotBeUsed"), // this will not be used
                 config.authorizationServerId,
                 challengeEndpoint = config.challengeEndpoint,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuer.kt
@@ -111,7 +111,7 @@ interface Issuer :
          * @return if wallet's [config] can satisfy the requirements of [credentialOffer] an [Issuer] will be
          * created. Otherwise, there would be a failed result
          */
-        suspend fun make(
+        fun make(
             config: OpenId4VCIConfig,
             credentialOffer: CredentialOffer,
             httpClient: HttpClient,
@@ -120,21 +120,21 @@ interface Issuer :
         ): Result<Issuer> = runCatching {
             val authorizationServer = HttpsUrl(credentialOffer.authorizationServerMetadata.issuer.value).getOrThrow()
 
-            val provisionedClientAttestation =
+            val provisionClientAttestation =
                 when (val clientAuthentication = config.clientAuthentication) {
-                    is ClientAuthentication.AttestationBased -> {
-                        val provisionedClientAttestation =
-                            clientAuthentication.provisionClientAttestation(
-                                authorizationServer,
-                                credentialOffer.credentialIssuerMetadata.preferredClientStatusPeriod,
-                            )
+                    is ClientAuthentication.AttestationBased ->
+                        clientAttestation(
+                            config.clock,
+                            authorizationServer,
+                            credentialOffer.credentialIssuerMetadata.preferredClientStatusPeriod,
+                            clientAuthentication,
+                        ).verifying {
+                            it.ensureSupportedByAuthorizationServer(credentialOffer.authorizationServerMetadata)
+                        }
 
-                        clientAuthentication.provisionClientAttestation.ensureValid(config.clock.instant(), provisionedClientAttestation)
-                        provisionedClientAttestation.ensureSupportedByAuthorizationServer(credentialOffer.authorizationServerMetadata)
-                        provisionedClientAttestation
+                    is ClientAuthentication.None -> {
+                        { null }
                     }
-
-                    is ClientAuthentication.None -> null
                 }
 
             val dPoPConfig = when (val dPoPUsage = config.dPoPUsage) {
@@ -166,7 +166,7 @@ interface Issuer :
                             credentialOffer.authorizationServerMetadata,
                             config,
                             provisionDPoPJwtFactory,
-                            provisionedClientAttestation,
+                            provisionClientAttestation,
                             httpClient,
                         )
                     }
@@ -177,7 +177,7 @@ interface Issuer :
                     credentialOffer.authorizationServerMetadata,
                     config,
                     provisionDPoPJwtFactory,
-                    provisionedClientAttestation,
+                    provisionClientAttestation,
                     httpClient,
                 )
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProvisionOnce.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProvisionOnce.kt
@@ -26,24 +26,28 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.time.Clock
 
-internal class ProvisionOnce<V : Any>(private val provision: suspend () -> V?) : suspend () -> V? {
+internal class ProvisionOnce<V : Any>(private val provision: suspend () -> V) : suspend () -> V {
 
+    @Volatile
     private var provisioned = false
+
     private val mutex = Mutex()
     private var value: V? = null
 
-    override suspend fun invoke(): V? =
-        if (!provisioned)
-            mutex.withLock {
-                if (!provisioned) {
-                    value = provision()
-                    provisioned = true
+    override suspend fun invoke(): V {
+        val value =
+            if (!provisioned)
+                mutex.withLock {
+                    if (!provisioned) {
+                        val provisioned = provision()
+                        value = provisioned
+                        this.provisioned = true
+                    }
+                    value
                 }
-                value
-            }
-        else value
-
-    companion object
+            else value
+        return checkNotNull(value)
+    }
 }
 
 internal fun dPoPJwtFactory(
@@ -59,9 +63,8 @@ internal fun dPoPJwtFactory(
             }
         }
 
-        config?.let { (provisionDPoPSigner) ->
-            val dPoPSigner = provisionDPoPSigner(authorizationServer)
-            provisionDPoPSigner.ensureValid(dPoPSigner)
-            DPoPJwtFactory(clock = clock, signer = dPoPSigner)
-        }
+        val provisionDPoPSigner = config.provisionDPoPSigner
+        val dPoPSigner = provisionDPoPSigner(authorizationServer)
+        provisionDPoPSigner.ensureValid(dPoPSigner)
+        DPoPJwtFactory(clock = clock, signer = dPoPSigner)
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProvisionOnce.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/ProvisionOnce.kt
@@ -16,12 +16,16 @@
 package eu.europa.ec.eudi.openid4vci.internal
 
 import com.nimbusds.jose.jwk.JWK
+import eu.europa.ec.eudi.openid4vci.ClientAuthentication
 import eu.europa.ec.eudi.openid4vci.DPoPConfig
 import eu.europa.ec.eudi.openid4vci.DPoPJwtFactory
 import eu.europa.ec.eudi.openid4vci.HttpsUrl
 import eu.europa.ec.eudi.openid4vci.JwsAlgorithm
+import eu.europa.ec.eudi.openid4vci.PositiveDuration
+import eu.europa.ec.eudi.openid4vci.ProvisionClientAttestation
 import eu.europa.ec.eudi.openid4vci.ProvisionDPoPSigner
 import eu.europa.ec.eudi.openid4vci.Signer
+import eu.europa.ec.eudi.openid4vci.ensureValid
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.time.Clock
@@ -48,6 +52,13 @@ internal class ProvisionOnce<V : Any>(private val provision: suspend () -> V) : 
             else value
         return checkNotNull(value)
     }
+
+    fun verifying(verify: suspend(V) -> Unit): ProvisionOnce<V> =
+        ProvisionOnce {
+            val provisioned = provision()
+            verify(provisioned)
+            provisioned
+        }
 }
 
 internal fun dPoPJwtFactory(
@@ -67,4 +78,16 @@ internal fun dPoPJwtFactory(
         val dPoPSigner = provisionDPoPSigner(authorizationServer)
         provisionDPoPSigner.ensureValid(dPoPSigner)
         DPoPJwtFactory(clock = clock, signer = dPoPSigner)
+    }
+
+internal fun clientAttestation(
+    clock: Clock,
+    authorizationServer: HttpsUrl,
+    preferredClientStatusPeriod: PositiveDuration?,
+    clientAuthentication: ClientAuthentication.AttestationBased,
+): ProvisionOnce<ProvisionClientAttestation.Provisioned> =
+    ProvisionOnce {
+        val provisionedClientAttestation = clientAuthentication.provisionClientAttestation(authorizationServer, preferredClientStatusPeriod)
+        clientAuthentication.provisionClientAttestation.ensureValid(clock.instant(), provisionedClientAttestation)
+        provisionedClientAttestation
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/AuthorizationEndpointClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/AuthorizationEndpointClient.kt
@@ -76,7 +76,7 @@ internal class AuthorizationEndpointClient(
     private val challengeEndpoint: URL?,
     private val config: OpenId4VCIConfig,
     private val dPoPJwtFactory: suspend () -> DPoPJwtFactory?,
-    private val provisionedClientAttestation: ProvisionClientAttestation.Provisioned?,
+    private val provisionedClientAttestation: suspend () -> ProvisionClientAttestation.Provisioned?,
     private val httpClient: HttpClient,
 ) {
 
@@ -85,7 +85,7 @@ internal class AuthorizationEndpointClient(
         authorizationServerMetadata: CIAuthorizationServerMetadata,
         config: OpenId4VCIConfig,
         dPoPJwtFactory: suspend () -> DPoPJwtFactory?,
-        provisionedClientAttestation: ProvisionClientAttestation.Provisioned?,
+        provisionedClientAttestation: suspend () -> ProvisionClientAttestation.Provisioned?,
         httpClient: HttpClient,
     ) : this(
         credentialIssuerId,
@@ -284,7 +284,7 @@ internal class AuthorizationEndpointClient(
                 dPoPJwtFactory()?.createDPoPJwt(Htm.POST, url, null, dpopNonce)
                     ?.getOrThrow()
                     ?.serialize()
-            val clientAttestation = provisionedClientAttestation?.generateClientAttestation(
+            val clientAttestation = provisionedClientAttestation()?.generateClientAttestation(
                 config.clock,
                 config.clientAuthentication.id,
                 URI(authorizationIssuer).toURL(),

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/GetAbcaChallengeAndDPoPNonce.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/GetAbcaChallengeAndDPoPNonce.kt
@@ -19,10 +19,11 @@ import eu.europa.ec.eudi.openid4vci.Nonce
 import eu.europa.ec.eudi.openid4vci.ProvisionClientAttestation
 
 internal class GetAbcaChallengeAndDPoPNonce(
-    private val provisionedClientAttestation: ProvisionClientAttestation.Provisioned?,
+    private val provisionClientAttestation: suspend () -> ProvisionClientAttestation.Provisioned?,
     private val challengeEndpointClient: ChallengeEndpointClient?,
 ) {
     suspend operator fun invoke(existingAbcaChallenge: Nonce?, existingDpopNonce: Nonce?): Pair<Nonce?, Nonce?> {
+        val provisionedClientAttestation = provisionClientAttestation()
         if (null == provisionedClientAttestation) {
             return null to existingDpopNonce
         }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/TokenEndpointClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/TokenEndpointClient.kt
@@ -90,7 +90,7 @@ internal class TokenEndpointClient(
     private val credentialIssuerId: CredentialIssuerId,
     private val clock: Clock,
     private val clientId: ClientId,
-    private val provisionedClientAttestation: ProvisionClientAttestation.Provisioned?,
+    private val provisionedClientAttestation: suspend () -> ProvisionClientAttestation.Provisioned?,
     private val authFlowRedirectionURI: URI,
     private val authServerId: URL,
     private val challengeEndpoint: URL?,
@@ -115,7 +115,7 @@ internal class TokenEndpointClient(
         authorizationServerMetadata: CIAuthorizationServerMetadata,
         config: OpenId4VCIConfig,
         dPoPJwtFactory: suspend () -> DPoPJwtFactory?,
-        provisionedClientAttestation: ProvisionClientAttestation.Provisioned?,
+        provisionedClientAttestation: suspend () -> ProvisionClientAttestation.Provisioned?,
         httpClient: HttpClient,
     ) : this(
         credentialIssuerId,
@@ -221,7 +221,7 @@ internal class TokenEndpointClient(
                 existingAbcaChallenge = existingAbcaChallenge,
                 existingDpopNonce = existingDpopNonce,
             )
-            val clientAttestation = provisionedClientAttestation?.generateClientAttestation(
+            val clientAttestation = provisionedClientAttestation()?.generateClientAttestation(
                 clock,
                 clientId,
                 authServerId,

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/RefreshAccessTokenImplTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/RefreshAccessTokenImplTest.kt
@@ -110,6 +110,6 @@ private fun tokenEndpointClient(httpClient: HttpClient) = TokenEndpointClient(
     oauthAuthorizationServerMetadata(),
     OpenId4VCIConfiguration,
     { null },
-    null,
+    { null },
     httpClient,
 )


### PR DESCRIPTION
This PR:

1. Updates `ProvisionOnce` to work with non-null types.
2. Marks `ProvisionOnce.provisioned` as `@Volatile` to ensure the double-check pattern always works as expected.
3. Defers Client Attestation provisioning till the point of first use.
4. Removes `suspend` modifier from `Issuer.make`, `DeferredIssuer.make` since it's no longer needed.