### PR TITLE
Add a configuration option to allow disabling Authorization Code DPoP binding

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
@@ -82,7 +82,7 @@ data class OpenId4VCIConfig(
     val authorizeIssuanceConfig: AuthorizeIssuanceConfig = AuthorizeIssuanceConfig.FAVOR_SCOPES,
     val dPoPUsage: DPoPUsage = DPoPUsage.Never,
     val clientAttestationPoPBuilder: ClientAttestationPoPBuilder = ClientAttestationPoPBuilder.Default,
-    val parUsage: ParUsage = ParUsage.IfSupported,
+    val parUsage: ParUsage = ParUsage.IfSupported(),
     val clock: Clock = Clock.systemDefaultZone(),
     val issuerMetadataPolicy: IssuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
     val supportedCredentialReusePolicies: CredentialReusePolicies? = null,
@@ -98,7 +98,7 @@ data class OpenId4VCIConfig(
         authorizeIssuanceConfig: AuthorizeIssuanceConfig = AuthorizeIssuanceConfig.FAVOR_SCOPES,
         dPoPUsage: DPoPUsage = DPoPUsage.Never,
         clientAttestationPoPBuilder: ClientAttestationPoPBuilder = ClientAttestationPoPBuilder.Default,
-        parUsage: ParUsage = ParUsage.IfSupported,
+        parUsage: ParUsage = ParUsage.IfSupported(),
         clock: Clock = Clock.systemDefaultZone(),
         issuerMetadataPolicy: IssuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
         supportedCredentialReusePolicies: CredentialReusePolicies? = null,
@@ -126,7 +126,7 @@ data class OpenId4VCIConfig(
         authorizeIssuanceConfig: AuthorizeIssuanceConfig = AuthorizeIssuanceConfig.FAVOR_SCOPES,
         dPoPSigner: Signer<JWK>? = null,
         clientAttestationPoPBuilder: ClientAttestationPoPBuilder = ClientAttestationPoPBuilder.Default,
-        parUsage: ParUsage = ParUsage.IfSupported,
+        parUsage: ParUsage = ParUsage.IfSupported(),
         clock: Clock = Clock.systemDefaultZone(),
         issuerMetadataPolicy: IssuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
         supportedCredentialReusePolicies: CredentialReusePolicies? = null,
@@ -154,7 +154,7 @@ data class OpenId4VCIConfig(
         authorizeIssuanceConfig: AuthorizeIssuanceConfig = AuthorizeIssuanceConfig.FAVOR_SCOPES,
         dPoPSigner: Signer<JWK>? = null,
         clientAttestationPoPBuilder: ClientAttestationPoPBuilder = ClientAttestationPoPBuilder.Default,
-        parUsage: ParUsage = ParUsage.IfSupported,
+        parUsage: ParUsage = ParUsage.IfSupported(),
         clock: Clock = Clock.systemDefaultZone(),
         issuerMetadataPolicy: IssuerMetadataPolicy = IssuerMetadataPolicy.IgnoreSigned,
         supportedCredentialReusePolicies: CredentialReusePolicies? = null,
@@ -236,16 +236,20 @@ sealed interface DPoPUsage {
 
 /**
  * Wallet's policy in regard to using PAR, during a authorization code grant.
+ * - [Never]: Disables PAR. Wallet will use the usual authorization code flow
  * - [IfSupported]: If authorization server advertises PAR endpoint it will be used. Otherwise, falls back
  *   to usual authorization code flow
- * - [Never]: Disables PAR. Wallet will use the usual authorization code flow
  * - [Required]: Wallet always will place PAR request, regardless what if authorization server advertises the PAR
  *   endpoint. If PAR endpoint is not being advertised, the issuance will fail.
  */
-enum class ParUsage {
-    IfSupported,
-    Never,
-    Required,
+sealed interface ParUsage : java.io.Serializable {
+    data object Never : ParUsage {
+        private fun readResolve(): Any = Never
+    }
+
+    data class IfSupported(val authorizationCodeDPoPBinding: Boolean = true) : ParUsage
+
+    data class Required(val authorizationCodeDPoPBinding: Boolean = true) : ParUsage
 }
 
 /**

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/AuthorizationEndpointClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/AuthorizationEndpointClient.kt
@@ -114,9 +114,9 @@ internal class AuthorizationEndpointClient(
         issuerState: String?,
     ): Result<Triple<PKCEVerifier, HttpsUrl, Nonce?>> {
         val usePar = when (config.parUsage) {
-            ParUsage.IfSupported -> supportsPar
             ParUsage.Never -> false
-            ParUsage.Required -> {
+            is ParUsage.IfSupported -> supportsPar
+            is ParUsage.Required -> {
                 require(supportsPar) {
                     "PAR uses is required, yet authorization server doesn't advertise PAR endpoint"
                 }
@@ -124,7 +124,12 @@ internal class AuthorizationEndpointClient(
             }
         }
         return if (usePar) {
-            submitPushedAuthorizationRequest(scopes, credentialsConfigurationIds, state, issuerState)
+            val authorizationCodeDPoPBinding = when (config.parUsage) {
+                ParUsage.Never -> error("cannot happen")
+                is ParUsage.IfSupported -> config.parUsage.authorizationCodeDPoPBinding
+                is ParUsage.Required -> config.parUsage.authorizationCodeDPoPBinding
+            }
+            submitPushedAuthorizationRequest(scopes, credentialsConfigurationIds, state, issuerState, authorizationCodeDPoPBinding)
         } else {
             authorizationRequestUrl(scopes, credentialsConfigurationIds, state, issuerState).map { (a, b) ->
                 Triple(a, b, null)
@@ -138,6 +143,7 @@ internal class AuthorizationEndpointClient(
      * @param scopes    The scopes of the authorization request.
      * @param state     The oauth2 specific 'state' request parameter.
      * @param issuerState   The state passed from credential issuer during the negotiation phase of the issuance.
+     * @param authorizationCodeDPoPBinding Whether the Authorization Code will be bound using a DPoP Proof.
      * @return The result of the request as a pair of the PKCE verifier used during the request and the authorization code
      *      url that caller will need to follow to retrieve the authorization code.
      *
@@ -149,6 +155,7 @@ internal class AuthorizationEndpointClient(
         credentialsConfigurationIds: List<CredentialConfigurationIdentifier>,
         state: String,
         issuerState: String?,
+        authorizationCodeDPoPBinding: Boolean,
     ): Result<Triple<PKCEVerifier, HttpsUrl, Nonce?>> = runCatchingCancellable {
         require(scopes.isNotEmpty() || credentialsConfigurationIds.isNotEmpty()) {
             "No scopes or authorization details provided. Cannot submit par."
@@ -183,7 +190,7 @@ internal class AuthorizationEndpointClient(
             }.build()
             PushedAuthorizationRequest(parEndpoint, request)
         }
-        val (response, dpopNonce) = pushAuthorizationRequest(parEndpoint, pushedAuthorizationRequest)
+        val (response, dpopNonce) = pushAuthorizationRequest(parEndpoint, pushedAuthorizationRequest, authorizationCodeDPoPBinding)
         val (pkceVerifier, url) = response.authorizationCodeUrlOrFail(clientID, codeVerifier, state)
         Triple(pkceVerifier, url, dpopNonce)
     }
@@ -255,6 +262,7 @@ internal class AuthorizationEndpointClient(
     private suspend fun pushAuthorizationRequest(
         parEndpoint: URI,
         pushedAuthorizationRequest: PushedAuthorizationRequest,
+        authorizationCodeDPoPBinding: Boolean,
     ): Pair<PushedAuthorizationRequestResponseTO, Nonce?> {
         val url = parEndpoint.toURL()
         val formParameters = run {
@@ -271,8 +279,12 @@ internal class AuthorizationEndpointClient(
             dpopNonceRetried: Boolean,
         ): Pair<PushedAuthorizationRequestResponseTO, Nonce?> {
             val dpopProof =
-                dPoPJwtFactory?.createDPoPJwt(Htm.POST, url, null, existingDpopNonce)
-                    ?.getOrThrow()?.serialize()
+                if (authorizationCodeDPoPBinding)
+                    dPoPJwtFactory
+                        ?.createDPoPJwt(Htm.POST, url, null, existingDpopNonce)
+                        ?.getOrThrow()
+                        ?.serialize()
+                else null
 
             val abcaChallenge = when (config.clientAuthentication) {
                 is ClientAuthentication.AttestationBased ->

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceAuthorizationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceAuthorizationTest.kt
@@ -28,6 +28,8 @@ import tokenPostApplyAuthFlowAssertionsAndGetFormData
 import tokenPostApplyPreAuthFlowAssertionsAndGetFormData
 import java.util.*
 import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
@@ -328,6 +330,68 @@ class IssuanceAuthorizationTest {
                     )
             }
         }
+
+    @Test
+    fun `ensure not dpop proof is sent to par endpoint when authorization code binding is disabled`() = runTest {
+        val mockedHttpClient = mockedHttpClient(
+            credentialIssuerMetadataWellKnownMocker(),
+            authServerWellKnownMocker(),
+            parPostMocker { request ->
+                val headers = request.headers
+                val dpopProof = headers[DPoP]
+                assertNull(dpopProof, "got dpop proof when authorization code binding was disabled")
+            },
+            tokenPostMocker { request ->
+                with(request) { tokenPostApplyAuthFlowAssertionsAndGetFormData() }
+            },
+        )
+
+        val offer = credentialOffer(mockedHttpClient, CredentialOfferMixedDocTypes_NO_GRANTS)
+        val issuer = Issuer.make(
+            config = OpenId4VCIConfigurationWithDpopSigner.copy(parUsage = ParUsage.Required(authorizationCodeDPoPBinding = false)),
+            credentialOffer = offer,
+            httpClient = mockedHttpClient,
+        ).getOrThrow()
+        with(issuer) {
+            val authRequestPrepared = prepareAuthorizationRequest().getOrThrow().also { println(it) }
+            val authorizationCode = UUID.randomUUID().toString()
+            val serverState = authRequestPrepared.state
+            authRequestPrepared
+                .authorizeWithAuthorizationCode(AuthorizationCode(authorizationCode), serverState)
+                .also { println(it) }
+        }
+    }
+
+    @Test
+    fun `ensure dpop proof is sent to par endpoint when authorization code binding is enabled`() = runTest {
+        val mockedHttpClient = mockedHttpClient(
+            credentialIssuerMetadataWellKnownMocker(),
+            authServerWellKnownMocker(),
+            parPostMocker { request ->
+                val headers = request.headers
+                val dpopProof = headers[DPoP]
+                assertNotNull(dpopProof, "no dpop proof sent when authorization code binding was enabled")
+            },
+            tokenPostMocker { request ->
+                with(request) { tokenPostApplyAuthFlowAssertionsAndGetFormData() }
+            },
+        )
+
+        val offer = credentialOffer(mockedHttpClient, CredentialOfferMixedDocTypes_NO_GRANTS)
+        val issuer = Issuer.make(
+            config = OpenId4VCIConfigurationWithDpopSigner.copy(parUsage = ParUsage.Required(authorizationCodeDPoPBinding = true)),
+            credentialOffer = offer,
+            httpClient = mockedHttpClient,
+        ).getOrThrow()
+        with(issuer) {
+            val authRequestPrepared = prepareAuthorizationRequest().getOrThrow().also { println(it) }
+            val authorizationCode = UUID.randomUUID().toString()
+            val serverState = authRequestPrepared.state
+            authRequestPrepared
+                .authorizeWithAuthorizationCode(AuthorizationCode(authorizationCode), serverState)
+                .also { println(it) }
+        }
+    }
 
     private suspend fun credentialOffer(
         httpClient: HttpClient,

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuer.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/PidDevIssuer.kt
@@ -38,7 +38,7 @@ internal object PidDevIssuer :
         encryptionSupportConfig = EncryptionSupportConfig(Curve.P_256, 2048, CredentialResponseEncryptionPolicy.SUPPORTED),
         authorizeIssuanceConfig = AuthorizeIssuanceConfig.FAVOR_SCOPES,
         dPoPUsage = DPoPUsage.Required(CryptoGenerator.ecSigner()),
-        parUsage = ParUsage.Required,
+        parUsage = ParUsage.Required(),
         supportedCredentialReusePolicies = CredentialReusePolicies.Supported(setOf(EudiReusePolicyType.OnceOnly)),
     )
 


### PR DESCRIPTION
This PR converts `ParUsage` to a sealed hierarchy.

When `ParUsage` is either `IfSupported`, or `Required`, the Client also has the ability to opt to disable Authorization Code DPoP Binding (by default enabled).