### PR TITLE
Fix initialization of Wallet Initiated Credential Offer

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialOffer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialOffer.kt
@@ -16,7 +16,7 @@
 package eu.europa.ec.eudi.openid4vci
 
 import eu.europa.ec.eudi.openid4vci.internal.CredentialOfferRequestResolver
-import eu.europa.ec.eudi.openid4vci.internal.createAuthorizationCodeGrantCredentialOfferUri
+import eu.europa.ec.eudi.openid4vci.internal.createAuthorizationCodeGrantCredentialOffer
 import eu.europa.ec.eudi.openid4vci.internal.ensure
 import io.ktor.client.*
 import io.ktor.http.*
@@ -85,12 +85,14 @@ data class CredentialOffer internal constructor(
             credentialConfigurationIdentifiers: List<CredentialConfigurationIdentifier>,
             authorizationServer: HttpsUrl,
         ): Result<CredentialOffer> = runCatchingCancellable {
-            val requestURI = createAuthorizationCodeGrantCredentialOfferUri(
-                credentialIssuerId,
-                credentialConfigurationIdentifiers,
-                authorizationServer,
+            val request = CredentialOfferRequest.PassByValue(
+                createAuthorizationCodeGrantCredentialOffer(
+                    credentialIssuerId,
+                    credentialConfigurationIdentifiers,
+                    authorizationServer,
+                ),
             )
-            val request = CredentialOfferRequest.PassByValue(requestURI)
+
             resolve(
                 requestEncryptionSpecFactory,
                 responseEncryptionSpecFactory,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialOfferRequestResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialOfferRequestResolver.kt
@@ -15,7 +15,6 @@
  */
 package eu.europa.ec.eudi.openid4vci.internal
 
-import com.eygraber.uri.Uri
 import eu.europa.ec.eudi.openid4vci.*
 import eu.europa.ec.eudi.openid4vci.CredentialOfferRequestError.UnableToResolveAuthorizationServerMetadata
 import eu.europa.ec.eudi.openid4vci.CredentialOfferRequestError.UnableToResolveCredentialIssuerMetadata
@@ -237,13 +236,13 @@ private fun GrantsTO.toGrants(credentialIssuerMetadata: CredentialIssuerMetadata
 }.getOrElse { throw CredentialOfferRequestValidationError.InvalidGrants(it).toException() }
 
 /**
- * Creates a new Credential Offer URI using Authorization Code Grant.
+ * Creates and returns serialized a new Credential Offer using Authorization Code Grant.
  *
  * @param credentialIssuerId the Id of the Credential Issuer
  * @param credentialConfigurationIdentifiers the Credential Configuration Identifiers for which to generate the Credential Offer URI; must not be empty
  * @param authorizationServer the Authorization Server
  */
-internal fun createAuthorizationCodeGrantCredentialOfferUri(
+internal fun createAuthorizationCodeGrantCredentialOffer(
     credentialIssuerId: CredentialIssuerId,
     credentialConfigurationIdentifiers: List<CredentialConfigurationIdentifier>,
     authorizationServer: HttpsUrl,
@@ -264,11 +263,7 @@ internal fun createAuthorizationCodeGrantCredentialOfferUri(
         ),
     )
 
-    return Uri.parse(OpenId4VCISpec.CREDENTIAL_OFFER_URI_SCHEME)
-        .buildUpon()
-        .appendQueryParameter(OpenId4VCISpec.CREDENTIAL_OFFER, JsonSupport.encodeToString(credentialOfferRequest))
-        .build()
-        .toString()
+    return JsonSupport.encodeToString(credentialOfferRequest)
 }
 
 internal fun <A : Any, B : Any> DPoPUsage<A>.map(convert: (A) -> B): DPoPUsage<B> =

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuerTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuerTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.openid4vci
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class IssuerTest {
+
+    @Test
+    fun `verify wallet initiated`() = runTest {
+        val mockedHttpClient = mockedHttpClient(
+            credentialIssuerMetadataWellKnownMocker(),
+            authServerWellKnownMocker(AuthServerMetadataVersion.FULL),
+            credentialIssuerMetadataWellKnownMocker(),
+            authServerWellKnownMocker(AuthServerMetadataVersion.FULL),
+        )
+
+        val issuer = Issuer.makeWalletInitiated(
+            OpenId4VCIConfiguration,
+            SampleIssuer.Id,
+            listOf(CredentialConfigurationIdentifier("eu.europa.ec.eudiw.pid_vc_sd_jwt")),
+            mockedHttpClient,
+        ).getOrThrow()
+
+        val credentialOffer = issuer.credentialOffer
+        assertEquals(SampleIssuer.Id, credentialOffer.credentialIssuerIdentifier)
+        assertEquals(1, credentialOffer.credentialConfigurationIdentifiers.size)
+        assertEquals("eu.europa.ec.eudiw.pid_vc_sd_jwt", credentialOffer.credentialConfigurationIdentifiers.first().value)
+        val grants = assertNotNull(credentialOffer.grants)
+        val authorizationCodeGrant = assertNotNull(grants.authorizationCode())
+        assertNull(authorizationCodeGrant.issuerState)
+        assertEquals("https://auth-server.example.com", authorizationCodeGrant.authorizationServer?.value?.toExternalForm())
+    }
+}


### PR DESCRIPTION
This PR fixes the improper initialization of an `Issuer` when using a Wallet Initiated Credential Offer.

Previously `CredentialOfferRequest.PassByValue` contained the Credential Offer Request URI when it should have contained the serialized `CredentialOfferRequestTO`.