### PR TITLE
Fix Credential Reuse Policy parsing

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialReusePolicy.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialReusePolicy.kt
@@ -124,15 +124,9 @@ sealed interface EudiReusePolicy {
             reissueTriggerUnused: Int? = null,
             reissueTriggerLifetimeLeft: Duration? = null,
         ): List<EudiReusePolicy> {
-            val normalizedDetails = details.distinct()
+            require(details.isNotEmpty()) { "details must not be empty" }
 
-            require(normalizedDetails.isNotEmpty()) { "details must not be empty" }
-            require(normalizedDetails.size == details.size) {
-                "details must not contain duplicate values"
-            }
-            validateBaseMethodCombination(normalizedDetails)
-
-            return normalizedDetails.map { detail ->
+            return details.map { detail ->
                 when (detail) {
                     EudiReusePolicyType.OnceOnly -> OnceOnly(
                         batchSize = requireNotNull(batchSize) {
@@ -177,15 +171,6 @@ sealed interface EudiReusePolicy {
             }
         }
 
-        private fun validateBaseMethodCombination(details: List<EudiReusePolicyType>) {
-            val hasOnceOnly = EudiReusePolicyType.OnceOnly in details
-            val hasLimitedTime = EudiReusePolicyType.LimitedTime in details
-
-            require(hasOnceOnly.xor(hasLimitedTime)) {
-                "details must contain exactly one base method: once_only or limited_time"
-            }
-        }
-
         private fun validateBatchSize(batchSize: Int) {
             require(batchSize > 1) { "batch_size must be greater than 1" }
         }
@@ -226,6 +211,7 @@ sealed interface CredentialReusePolicy : Serializable {
         init {
             require(options.isNotEmpty()) { "options must not be empty for arf_annex_ii policy" }
             validateNoOverlappingDetails(options)
+            validateBaseMethodCombination(options)
         }
 
         companion object {
@@ -235,6 +221,15 @@ sealed interface CredentialReusePolicy : Serializable {
                 val optionTypes = options.map { it::class }
                 require(optionTypes.size == optionTypes.toSet().size) {
                     "When multiple policy options are defined, each option type must be unique"
+                }
+            }
+
+            private fun validateBaseMethodCombination(options: List<EudiReusePolicy>) {
+                val hasOnceOnly = options.any { it is EudiReusePolicy.OnceOnly }
+                val hasLimitedTime = options.any { it is EudiReusePolicy.LimitedTime }
+
+                require(hasOnceOnly.xor(hasLimitedTime)) {
+                    "details must contain exactly one base method: once_only or limited_time"
                 }
             }
         }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialReusePolicy.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialReusePolicy.kt
@@ -125,6 +125,7 @@ sealed interface EudiReusePolicy {
             reissueTriggerLifetimeLeft: Duration? = null,
         ): List<EudiReusePolicy> {
             require(details.isNotEmpty()) { "details must not be empty" }
+            require(details.distinct().size == details.size) { "details must not contain duplicate values" }
 
             return details.map { detail ->
                 when (detail) {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialIssuerMetadataJsonParser.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialIssuerMetadataJsonParser.kt
@@ -89,9 +89,10 @@ private data class CredentialReusePolicyTO(
     fun toDomain(): CredentialReusePolicy =
         when (id) {
             ETSI119472Part3.REUSE_POLICY_ARF_ANNEX_II -> {
-                val parsed = options?.flatMap {
-                    JsonSupport.decodeFromJsonElement<ArfAnnex2CredentialReusePolicyOptionTO>(it).toDomain()
-                }.orEmpty()
+                val parsed = options.orEmpty()
+                    .flatMap {
+                        JsonSupport.decodeFromJsonElement<ArfAnnex2CredentialReusePolicyOptionTO>(it).toDomain()
+                    }
                 CredentialReusePolicy.EUDI(parsed)
             }
             else -> CredentialReusePolicy.None

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CredentialReusePolicyTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CredentialReusePolicyTest.kt
@@ -76,41 +76,6 @@ internal class CredentialReusePolicyTest {
     }
 
     @Test
-    fun `fails when rotating-batch is used without a base detail`() {
-        assertFailsWith<IllegalArgumentException> {
-            EudiReusePolicy.fromDetails(
-                details = listOf(EudiReusePolicyType.RotatingBatch),
-                batchSize = 10,
-                reissueTriggerLifetimeLeft = 100.seconds,
-            )
-        }
-    }
-
-    @Test
-    fun `fails when per-relying-party is used without a base detail`() {
-        assertFailsWith<IllegalArgumentException> {
-            EudiReusePolicy.fromDetails(
-                details = listOf(EudiReusePolicyType.PerRelyingParty),
-                batchSize = 10,
-                reissueTriggerUnused = 2,
-                reissueTriggerLifetimeLeft = 100.seconds,
-            )
-        }
-    }
-
-    @Test
-    fun `fails when details contains both once_only and limited_time`() {
-        assertFailsWith<IllegalArgumentException> {
-            EudiReusePolicy.fromDetails(
-                details = listOf(EudiReusePolicyType.OnceOnly, EudiReusePolicyType.LimitedTime),
-                batchSize = 10,
-                reissueTriggerUnused = 2,
-                reissueTriggerLifetimeLeft = 100.seconds,
-            )
-        }
-    }
-
-    @Test
     fun `fails when once_only is missing batch_size`() {
         assertFailsWith<IllegalArgumentException> {
             EudiReusePolicy.fromDetails(
@@ -283,9 +248,9 @@ internal class CredentialReusePolicyTest {
                 EudiReusePolicy.LimitedTime(
                     reissueTriggerLifetimeLeft = 885433.seconds,
                 ),
-                EudiReusePolicy.OnceOnly(
+                EudiReusePolicy.RotatingBatch(
                     batchSize = 10,
-                    reissueTriggerUnused = 4,
+                    reissueTriggerLifetimeLeft = 885433.seconds,
                 ),
             ),
         )

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CredentialReusePolicyTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CredentialReusePolicyTest.kt
@@ -146,6 +146,17 @@ internal class CredentialReusePolicyTest {
     }
 
     @Test
+    fun `fails when duplicate details are provided`() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            EudiReusePolicy.fromDetails(
+                details = listOf(EudiReusePolicyType.LimitedTime, EudiReusePolicyType.LimitedTime),
+                reissueTriggerLifetimeLeft = 100.seconds,
+            )
+        }
+        assertEquals("details must not contain duplicate values", error.message)
+    }
+
+    @Test
     fun `fromDetails returns once_only and per_relying_party options for combined details`() {
         val options = EudiReusePolicy.fromDetails(
             details = listOf(

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/DefaultCredentialIssuerMetadataResolverTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/DefaultCredentialIssuerMetadataResolverTest.kt
@@ -468,6 +468,33 @@ internal class DefaultCredentialIssuerMetadataResolverTest {
     }
 
     @Test
+    internal fun `resolution fails with duplicate details in credential reuse policies`() = runTest {
+        suspend fun test(resource: String) {
+            val credentialIssuerId = SampleIssuer.Id
+
+            val resolver = resolver(
+                credentialIssuerMetaDataHandler(
+                    credentialIssuerId,
+                    resource,
+                ),
+            )
+
+            val error =
+                assertFailsWith<InvalidCredentialsSupported> {
+                    resolver.resolve(
+                        credentialIssuerId,
+                        IssuerMetadataPolicy.IgnoreSigned,
+                    ).getOrThrow()
+                }
+            val cause = assertIs<IllegalArgumentException>(error.cause)
+            assertEquals("details must not contain duplicate values", cause.message)
+        }
+
+        test("eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_duplicate_details_compact.json")
+        test("eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_duplicate_details_expanded.json")
+    }
+
+    @Test
     internal fun `resolution fails when no base credential reuse policy is present`() = runTest {
         suspend fun test(resource: String) {
             val credentialIssuerId = SampleIssuer.Id

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/DefaultCredentialIssuerMetadataResolverTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/DefaultCredentialIssuerMetadataResolverTest.kt
@@ -367,44 +367,131 @@ internal class DefaultCredentialIssuerMetadataResolverTest {
 
     @Test
     internal fun `resolution succeeds with credential reuse policy`() = runTest {
-        val credentialIssuerId = SampleIssuer.Id
+        suspend fun test(resource: String) {
+            val credentialIssuerId = SampleIssuer.Id
 
-        val resolver = resolver(
-            credentialIssuerMetaDataHandler(
-                credentialIssuerId,
-                "eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy.json",
-            ),
-        )
-        val metaData =
-            assertDoesNotThrow { resolver.resolve(credentialIssuerId, IssuerMetadataPolicy.IgnoreSigned).getOrThrow() }
+            val resolver = resolver(
+                credentialIssuerMetaDataHandler(
+                    credentialIssuerId,
+                    resource,
+                ),
+            )
 
-        val pidMsoMdoc = metaData.credentialConfigurationsSupported[CredentialConfigurationIdentifier("PID_msoMdoc")]
-        val msoMdocPolicy = pidMsoMdoc?.credentialMetadata?.credentialReusePolicy
-        assertTrue(msoMdocPolicy is CredentialReusePolicy.EUDI)
-        assertEquals(3, msoMdocPolicy.options.size)
-        assertIs<EudiReusePolicy.LimitedTime>(msoMdocPolicy.options[0])
-        val msoMdocRotatingBatch = assertIs<EudiReusePolicy.RotatingBatch>(msoMdocPolicy.options[1])
-        assertEquals(5, msoMdocRotatingBatch.batchSize)
-        assertEquals(655433.seconds, msoMdocRotatingBatch.reissueTriggerLifetimeLeft)
-        val msoMdocOption = assertIs<EudiReusePolicy.PerRelyingParty>(msoMdocPolicy.options[2])
-        assertEquals(5, msoMdocOption.batchSize)
-        assertEquals(655433.seconds, msoMdocOption.reissueTriggerLifetimeLeft)
+            val metaData = resolver.resolve(credentialIssuerId, IssuerMetadataPolicy.IgnoreSigned).getOrThrow()
 
-        val pidSdJwt = metaData.credentialConfigurationsSupported[CredentialConfigurationIdentifier("PID_SdJwtVc")]
-        val sdJwtPolicy = pidSdJwt?.credentialMetadata?.credentialReusePolicy
-        assertTrue(sdJwtPolicy is CredentialReusePolicy.EUDI)
-        assertEquals(4, sdJwtPolicy.options.size)
-        assertIs<EudiReusePolicy.LimitedTime>(sdJwtPolicy.options[0])
-        val sdJwtRotatingBatch = assertIs<EudiReusePolicy.RotatingBatch>(sdJwtPolicy.options[1])
-        assertEquals(40, sdJwtRotatingBatch.batchSize)
-        assertEquals(655433.seconds, sdJwtRotatingBatch.reissueTriggerLifetimeLeft)
-        val sdJwtOnceOnly = assertIs<EudiReusePolicy.OnceOnly>(sdJwtPolicy.options[2])
-        assertEquals(60, sdJwtOnceOnly.batchSize)
-        assertEquals(10, sdJwtOnceOnly.reissueTriggerUnused)
-        val sdJwtPerRelyingParty = assertIs<EudiReusePolicy.PerRelyingParty>(sdJwtPolicy.options[3])
-        assertEquals(60, sdJwtPerRelyingParty.batchSize)
-        assertEquals(10, sdJwtPerRelyingParty.reissueTriggerUnused)
-        assertEquals(777543.seconds, sdJwtPerRelyingParty.reissueTriggerLifetimeLeft)
+            val pidMsoMdoc = assertNotNull(metaData.credentialConfigurationsSupported[CredentialConfigurationIdentifier("PID_msoMdoc")])
+
+            val msoMdocPolicy = assertIs<CredentialReusePolicy.EUDI>(pidMsoMdoc.credentialMetadata?.credentialReusePolicy)
+            assertEquals(3, msoMdocPolicy.options.size)
+            assertNotNull(msoMdocPolicy.options.firstOrNull { it is EudiReusePolicy.LimitedTime })
+
+            val msoMdocRotatingBatch = assertNotNull(msoMdocPolicy.options.firstOrNull { it is EudiReusePolicy.RotatingBatch })
+            assertEquals(5, msoMdocRotatingBatch.batchSize)
+            assertEquals(655433.seconds, msoMdocRotatingBatch.reissueTriggerLifetimeLeft)
+
+            val msoMdocOption = assertNotNull(msoMdocPolicy.options.firstOrNull { it is EudiReusePolicy.PerRelyingParty })
+            assertEquals(5, msoMdocOption.batchSize)
+            assertEquals(655433.seconds, msoMdocOption.reissueTriggerLifetimeLeft)
+
+            val pidSdJwt = assertNotNull(metaData.credentialConfigurationsSupported[CredentialConfigurationIdentifier("PID_SdJwtVc")])
+
+            val sdJwtPolicy = assertIs<CredentialReusePolicy.EUDI>(pidSdJwt.credentialMetadata?.credentialReusePolicy)
+            assertEquals(3, sdJwtPolicy.options.size)
+            assertNotNull(sdJwtPolicy.options.firstOrNull { it is EudiReusePolicy.LimitedTime })
+
+            val sdJwtRotatingBatch = assertNotNull(sdJwtPolicy.options.firstOrNull { it is EudiReusePolicy.RotatingBatch })
+            assertEquals(40, sdJwtRotatingBatch.batchSize)
+            assertEquals(655433.seconds, sdJwtRotatingBatch.reissueTriggerLifetimeLeft)
+
+            val sdJwtPerRelyingParty = assertNotNull(sdJwtPolicy.options.firstOrNull { it is EudiReusePolicy.PerRelyingParty })
+            assertEquals(40, sdJwtPerRelyingParty.batchSize)
+            assertEquals(10, sdJwtPerRelyingParty.reissueTriggerUnused)
+            assertEquals(655433.seconds, sdJwtPerRelyingParty.reissueTriggerLifetimeLeft)
+        }
+
+        test("eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_compact.json")
+        test("eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_expanded.json")
+    }
+
+    @Test
+    internal fun `resolution fails with credential reuse policy both once only and limited time`() = runTest {
+        suspend fun test(resource: String) {
+            val credentialIssuerId = SampleIssuer.Id
+
+            val resolver = resolver(
+                credentialIssuerMetaDataHandler(
+                    credentialIssuerId,
+                    resource,
+                ),
+            )
+
+            val error =
+                assertFailsWith<InvalidCredentialsSupported> {
+                    resolver.resolve(
+                        credentialIssuerId,
+                        IssuerMetadataPolicy.IgnoreSigned,
+                    ).getOrThrow()
+                }
+            val cause = assertIs<IllegalArgumentException>(error.cause)
+            assertEquals("details must contain exactly one base method: once_only or limited_time", cause.message)
+        }
+
+        test("eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_both_once_only_limited_time_compact.json")
+        test("eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_both_once_only_limited_time_expanded.json")
+    }
+
+    @Test
+    internal fun `resolution fails with duplicate credential reuse policies`() = runTest {
+        suspend fun test(resource: String) {
+            val credentialIssuerId = SampleIssuer.Id
+
+            val resolver = resolver(
+                credentialIssuerMetaDataHandler(
+                    credentialIssuerId,
+                    resource,
+                ),
+            )
+
+            val error =
+                assertFailsWith<InvalidCredentialsSupported> {
+                    resolver.resolve(
+                        credentialIssuerId,
+                        IssuerMetadataPolicy.IgnoreSigned,
+                    ).getOrThrow()
+                }
+            val cause = assertIs<IllegalArgumentException>(error.cause)
+            assertEquals("When multiple policy options are defined, each option type must be unique", cause.message)
+        }
+
+        test("eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_duplicates_compact.json")
+        test("eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_duplicates_expanded.json")
+    }
+
+    @Test
+    internal fun `resolution fails when no base credential reuse policy is present`() = runTest {
+        suspend fun test(resource: String) {
+            val credentialIssuerId = SampleIssuer.Id
+
+            val resolver = resolver(
+                credentialIssuerMetaDataHandler(
+                    credentialIssuerId,
+                    resource,
+                ),
+            )
+
+            val error =
+                assertFailsWith<InvalidCredentialsSupported> {
+                    resolver.resolve(
+                        credentialIssuerId,
+                        IssuerMetadataPolicy.IgnoreSigned,
+                    ).getOrThrow()
+                }
+            val cause = assertIs<IllegalArgumentException>(error.cause)
+            assertEquals("details must contain exactly one base method: once_only or limited_time", cause.message)
+        }
+
+        test("eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_only_rotating_batch.json")
+        test("eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_only_per_relying_party.json")
     }
 
     @Test

--- a/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_both_once_only_limited_time_compact.json
+++ b/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_both_once_only_limited_time_compact.json
@@ -1,0 +1,168 @@
+{
+  "credential_issuer": "https://credential-issuer.example.com",
+  "authorization_servers": [
+    "https://keycloak-eudi.netcompany-intrasoft.com/realms/pid-issuer-realm"
+  ],
+  "credential_endpoint": "https://credential-issuer.example.com/credentials",
+  "nonce_endpoint": "https://credential-issuer.example.com/nonce",
+  "deferred_credential_endpoint": "https://credential-issuer.example.com/credentials/deferred",
+  "notification_endpoint": "https://credential-issuer.example.com/notification",
+  "credential_request_encryption": {
+    "jwks": {
+      "keys": [
+        {
+          "kty": "EC",
+          "use": "enc",
+          "crv": "P-256",
+          "alg": "ECDH-ES",
+          "kid": "encKey-0",
+          "x": "TmcsNF6JpWjP85wKfBXKybHaJNowtp6jCuToppDosdw",
+          "y": "egzDuJuSxyypCE0qUoo1oKOnslpaw1Om-flQ4knafas",
+          "iat": 1755352588
+        }
+      ]
+    },
+    "enc_values_supported": [
+      "XC20P"
+    ],
+    "zip_values_supported": [
+      "DEF"
+    ],
+    "encryption_required": true
+  },
+  "credential_response_encryption": {
+    "alg_values_supported": [
+      "ECDH-ES",
+      "ECDH-ES+A128KW",
+      "ECDH-ES+A192KW",
+      "ECDH-ES+A256KW",
+      "RSA-OAEP-256",
+      "RSA-OAEP-384",
+      "RSA-OAEP-512"
+    ],
+    "enc_values_supported": [
+      "XC20P"
+    ],
+    "zip_values_supported": [
+      "DEF"
+    ],
+    "encryption_required": true
+  },
+  "batch_credential_issuance": {
+    "batch_size": 2
+  },
+  "credential_identifiers_supported": true,
+  "credential_configurations_supported": {
+    "PID_msoMdoc": {
+      "format": "mso_mdoc",
+      "scope": "PID_msoMdoc",
+      "doctype": "eu.europa.ec.eudi.pid.1",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        -7,
+        -35,
+        -36
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        }
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "EU PID",
+            "locale": "en-US"
+          }
+        ],
+        "credential_reuse_policy": {
+          "id": "arf_annex_ii",
+          "options": [
+            {
+              "details": ["limited_time", "rotating-batch", "per-relying-party"],
+              "batch_size": 5,
+              "reissue_trigger_lifetime_left": 655433,
+              "reissue_trigger_unused": 3
+            }
+          ]
+        }
+      }
+    },
+    "PID_SdJwtVc": {
+      "format": "dc+sd-jwt",
+      "scope": "PID_SdJwtVc",
+      "vct": "eu.europa.ec.eudi.pid.1",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        }
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "EU PID SD-JWT",
+            "locale": "en-US"
+          }
+        ],
+        "credential_reuse_policy": {
+          "id": "arf_annex_ii",
+          "options": [
+            {
+              "details": ["limited_time", "rotating-batch", "per-relying-party", "once_only"],
+              "batch_size": 40,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 655433
+            }
+          ]
+        }
+      }
+    }
+  },
+  "display": [
+    {
+      "name": "credential-issuer.example.com",
+      "locale": "en-US",
+      "logo": {
+        "uri": "https://credential-issuer.example.com/logo.png",
+        "alt_text": "Credential Issuer Logo"
+      }
+    }
+  ]
+}

--- a/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_both_once_only_limited_time_expanded.json
+++ b/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_both_once_only_limited_time_expanded.json
@@ -1,0 +1,198 @@
+{
+  "credential_issuer": "https://credential-issuer.example.com",
+  "authorization_servers": [
+    "https://keycloak-eudi.netcompany-intrasoft.com/realms/pid-issuer-realm"
+  ],
+  "credential_endpoint": "https://credential-issuer.example.com/credentials",
+  "nonce_endpoint": "https://credential-issuer.example.com/nonce",
+  "deferred_credential_endpoint": "https://credential-issuer.example.com/credentials/deferred",
+  "notification_endpoint": "https://credential-issuer.example.com/notification",
+  "credential_request_encryption": {
+    "jwks": {
+      "keys": [
+        {
+          "kty": "EC",
+          "use": "enc",
+          "crv": "P-256",
+          "alg": "ECDH-ES",
+          "kid": "encKey-0",
+          "x": "TmcsNF6JpWjP85wKfBXKybHaJNowtp6jCuToppDosdw",
+          "y": "egzDuJuSxyypCE0qUoo1oKOnslpaw1Om-flQ4knafas",
+          "iat": 1755352588
+        }
+      ]
+    },
+    "enc_values_supported": [
+      "XC20P"
+    ],
+    "zip_values_supported": [
+      "DEF"
+    ],
+    "encryption_required": true
+  },
+  "credential_response_encryption": {
+    "alg_values_supported": [
+      "ECDH-ES",
+      "ECDH-ES+A128KW",
+      "ECDH-ES+A192KW",
+      "ECDH-ES+A256KW",
+      "RSA-OAEP-256",
+      "RSA-OAEP-384",
+      "RSA-OAEP-512"
+    ],
+    "enc_values_supported": [
+      "XC20P"
+    ],
+    "zip_values_supported": [
+      "DEF"
+    ],
+    "encryption_required": true
+  },
+  "batch_credential_issuance": {
+    "batch_size": 2
+  },
+  "credential_identifiers_supported": true,
+  "credential_configurations_supported": {
+    "PID_msoMdoc": {
+      "format": "mso_mdoc",
+      "scope": "PID_msoMdoc",
+      "doctype": "eu.europa.ec.eudi.pid.1",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        -7,
+        -35,
+        -36
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        }
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "EU PID",
+            "locale": "en-US"
+          }
+        ],
+        "credential_reuse_policy": {
+          "id": "arf_annex_ii",
+          "options": [
+            {
+              "details": ["limited_time"],
+              "batch_size": 5,
+              "reissue_trigger_lifetime_left": 655433,
+              "reissue_trigger_unused": 3
+            },
+            {
+              "details": ["rotating-batch"],
+              "batch_size": 5,
+              "reissue_trigger_lifetime_left": 655433,
+              "reissue_trigger_unused": 3
+            },
+            {
+              "details": ["per-relying-party"],
+              "batch_size": 5,
+              "reissue_trigger_lifetime_left": 655433,
+              "reissue_trigger_unused": 3
+            }
+          ]
+        }
+      }
+    },
+    "PID_SdJwtVc": {
+      "format": "dc+sd-jwt",
+      "scope": "PID_SdJwtVc",
+      "vct": "eu.europa.ec.eudi.pid.1",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        }
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "EU PID SD-JWT",
+            "locale": "en-US"
+          }
+        ],
+        "credential_reuse_policy": {
+          "id": "arf_annex_ii",
+          "options": [
+            {
+              "details": ["limited_time"],
+              "batch_size": 40,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 655433
+            },
+            {
+              "details": ["rotating-batch"],
+              "batch_size": 40,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 655433
+            },
+            {
+              "details": ["per-relying-party"],
+              "batch_size": 40,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 655433
+            },
+            {
+              "details": ["once_only"],
+              "batch_size": 40,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 655433
+            }
+          ]
+        }
+      }
+    }
+  },
+  "display": [
+    {
+      "name": "credential-issuer.example.com",
+      "locale": "en-US",
+      "logo": {
+        "uri": "https://credential-issuer.example.com/logo.png",
+        "alt_text": "Credential Issuer Logo"
+      }
+    }
+  ]
+}

--- a/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_compact.json
+++ b/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_compact.json
@@ -1,0 +1,168 @@
+{
+  "credential_issuer": "https://credential-issuer.example.com",
+  "authorization_servers": [
+    "https://keycloak-eudi.netcompany-intrasoft.com/realms/pid-issuer-realm"
+  ],
+  "credential_endpoint": "https://credential-issuer.example.com/credentials",
+  "nonce_endpoint": "https://credential-issuer.example.com/nonce",
+  "deferred_credential_endpoint": "https://credential-issuer.example.com/credentials/deferred",
+  "notification_endpoint": "https://credential-issuer.example.com/notification",
+  "credential_request_encryption": {
+    "jwks": {
+      "keys": [
+        {
+          "kty": "EC",
+          "use": "enc",
+          "crv": "P-256",
+          "alg": "ECDH-ES",
+          "kid": "encKey-0",
+          "x": "TmcsNF6JpWjP85wKfBXKybHaJNowtp6jCuToppDosdw",
+          "y": "egzDuJuSxyypCE0qUoo1oKOnslpaw1Om-flQ4knafas",
+          "iat": 1755352588
+        }
+      ]
+    },
+    "enc_values_supported": [
+      "XC20P"
+    ],
+    "zip_values_supported": [
+      "DEF"
+    ],
+    "encryption_required": true
+  },
+  "credential_response_encryption": {
+    "alg_values_supported": [
+      "ECDH-ES",
+      "ECDH-ES+A128KW",
+      "ECDH-ES+A192KW",
+      "ECDH-ES+A256KW",
+      "RSA-OAEP-256",
+      "RSA-OAEP-384",
+      "RSA-OAEP-512"
+    ],
+    "enc_values_supported": [
+      "XC20P"
+    ],
+    "zip_values_supported": [
+      "DEF"
+    ],
+    "encryption_required": true
+  },
+  "batch_credential_issuance": {
+    "batch_size": 2
+  },
+  "credential_identifiers_supported": true,
+  "credential_configurations_supported": {
+    "PID_msoMdoc": {
+      "format": "mso_mdoc",
+      "scope": "PID_msoMdoc",
+      "doctype": "eu.europa.ec.eudi.pid.1",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        -7,
+        -35,
+        -36
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        }
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "EU PID",
+            "locale": "en-US"
+          }
+        ],
+        "credential_reuse_policy": {
+          "id": "arf_annex_ii",
+          "options": [
+            {
+              "details": ["limited_time", "rotating-batch", "per-relying-party"],
+              "batch_size": 5,
+              "reissue_trigger_lifetime_left": 655433,
+              "reissue_trigger_unused": 3
+            }
+          ]
+        }
+      }
+    },
+    "PID_SdJwtVc": {
+      "format": "dc+sd-jwt",
+      "scope": "PID_SdJwtVc",
+      "vct": "eu.europa.ec.eudi.pid.1",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        }
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "EU PID SD-JWT",
+            "locale": "en-US"
+          }
+        ],
+        "credential_reuse_policy": {
+          "id": "arf_annex_ii",
+          "options": [
+            {
+              "details": ["limited_time", "rotating-batch", "per-relying-party"],
+              "batch_size": 40,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 655433
+            }
+          ]
+        }
+      }
+    }
+  },
+  "display": [
+    {
+      "name": "credential-issuer.example.com",
+      "locale": "en-US",
+      "logo": {
+        "uri": "https://credential-issuer.example.com/logo.png",
+        "alt_text": "Credential Issuer Logo"
+      }
+    }
+  ]
+}

--- a/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_duplicate_details_compact.json
+++ b/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_duplicate_details_compact.json
@@ -1,0 +1,168 @@
+{
+  "credential_issuer": "https://credential-issuer.example.com",
+  "authorization_servers": [
+    "https://keycloak-eudi.netcompany-intrasoft.com/realms/pid-issuer-realm"
+  ],
+  "credential_endpoint": "https://credential-issuer.example.com/credentials",
+  "nonce_endpoint": "https://credential-issuer.example.com/nonce",
+  "deferred_credential_endpoint": "https://credential-issuer.example.com/credentials/deferred",
+  "notification_endpoint": "https://credential-issuer.example.com/notification",
+  "credential_request_encryption": {
+    "jwks": {
+      "keys": [
+        {
+          "kty": "EC",
+          "use": "enc",
+          "crv": "P-256",
+          "alg": "ECDH-ES",
+          "kid": "encKey-0",
+          "x": "TmcsNF6JpWjP85wKfBXKybHaJNowtp6jCuToppDosdw",
+          "y": "egzDuJuSxyypCE0qUoo1oKOnslpaw1Om-flQ4knafas",
+          "iat": 1755352588
+        }
+      ]
+    },
+    "enc_values_supported": [
+      "XC20P"
+    ],
+    "zip_values_supported": [
+      "DEF"
+    ],
+    "encryption_required": true
+  },
+  "credential_response_encryption": {
+    "alg_values_supported": [
+      "ECDH-ES",
+      "ECDH-ES+A128KW",
+      "ECDH-ES+A192KW",
+      "ECDH-ES+A256KW",
+      "RSA-OAEP-256",
+      "RSA-OAEP-384",
+      "RSA-OAEP-512"
+    ],
+    "enc_values_supported": [
+      "XC20P"
+    ],
+    "zip_values_supported": [
+      "DEF"
+    ],
+    "encryption_required": true
+  },
+  "batch_credential_issuance": {
+    "batch_size": 2
+  },
+  "credential_identifiers_supported": true,
+  "credential_configurations_supported": {
+    "PID_msoMdoc": {
+      "format": "mso_mdoc",
+      "scope": "PID_msoMdoc",
+      "doctype": "eu.europa.ec.eudi.pid.1",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        -7,
+        -35,
+        -36
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        }
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "EU PID",
+            "locale": "en-US"
+          }
+        ],
+        "credential_reuse_policy": {
+          "id": "arf_annex_ii",
+          "options": [
+            {
+              "details": ["limited_time", "rotating-batch", "per-relying-party"],
+              "batch_size": 5,
+              "reissue_trigger_lifetime_left": 655433,
+              "reissue_trigger_unused": 3
+            }
+          ]
+        }
+      }
+    },
+    "PID_SdJwtVc": {
+      "format": "dc+sd-jwt",
+      "scope": "PID_SdJwtVc",
+      "vct": "eu.europa.ec.eudi.pid.1",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        }
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "EU PID SD-JWT",
+            "locale": "en-US"
+          }
+        ],
+        "credential_reuse_policy": {
+          "id": "arf_annex_ii",
+          "options": [
+            {
+              "details": ["limited_time", "rotating-batch", "per-relying-party", "limited_time", "rotating-batch", "per-relying-party"],
+              "batch_size": 40,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 655433
+            }
+          ]
+        }
+      }
+    }
+  },
+  "display": [
+    {
+      "name": "credential-issuer.example.com",
+      "locale": "en-US",
+      "logo": {
+        "uri": "https://credential-issuer.example.com/logo.png",
+        "alt_text": "Credential Issuer Logo"
+      }
+    }
+  ]
+}

--- a/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_duplicate_details_expanded.json
+++ b/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_duplicate_details_expanded.json
@@ -1,0 +1,210 @@
+{
+  "credential_issuer": "https://credential-issuer.example.com",
+  "authorization_servers": [
+    "https://keycloak-eudi.netcompany-intrasoft.com/realms/pid-issuer-realm"
+  ],
+  "credential_endpoint": "https://credential-issuer.example.com/credentials",
+  "nonce_endpoint": "https://credential-issuer.example.com/nonce",
+  "deferred_credential_endpoint": "https://credential-issuer.example.com/credentials/deferred",
+  "notification_endpoint": "https://credential-issuer.example.com/notification",
+  "credential_request_encryption": {
+    "jwks": {
+      "keys": [
+        {
+          "kty": "EC",
+          "use": "enc",
+          "crv": "P-256",
+          "alg": "ECDH-ES",
+          "kid": "encKey-0",
+          "x": "TmcsNF6JpWjP85wKfBXKybHaJNowtp6jCuToppDosdw",
+          "y": "egzDuJuSxyypCE0qUoo1oKOnslpaw1Om-flQ4knafas",
+          "iat": 1755352588
+        }
+      ]
+    },
+    "enc_values_supported": [
+      "XC20P"
+    ],
+    "zip_values_supported": [
+      "DEF"
+    ],
+    "encryption_required": true
+  },
+  "credential_response_encryption": {
+    "alg_values_supported": [
+      "ECDH-ES",
+      "ECDH-ES+A128KW",
+      "ECDH-ES+A192KW",
+      "ECDH-ES+A256KW",
+      "RSA-OAEP-256",
+      "RSA-OAEP-384",
+      "RSA-OAEP-512"
+    ],
+    "enc_values_supported": [
+      "XC20P"
+    ],
+    "zip_values_supported": [
+      "DEF"
+    ],
+    "encryption_required": true
+  },
+  "batch_credential_issuance": {
+    "batch_size": 2
+  },
+  "credential_identifiers_supported": true,
+  "credential_configurations_supported": {
+    "PID_msoMdoc": {
+      "format": "mso_mdoc",
+      "scope": "PID_msoMdoc",
+      "doctype": "eu.europa.ec.eudi.pid.1",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        -7,
+        -35,
+        -36
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        }
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "EU PID",
+            "locale": "en-US"
+          }
+        ],
+        "credential_reuse_policy": {
+          "id": "arf_annex_ii",
+          "options": [
+            {
+              "details": ["limited_time"],
+              "batch_size": 5,
+              "reissue_trigger_lifetime_left": 655433,
+              "reissue_trigger_unused": 3
+            },
+            {
+              "details": ["rotating-batch"],
+              "batch_size": 5,
+              "reissue_trigger_lifetime_left": 655433,
+              "reissue_trigger_unused": 3
+            },
+            {
+              "details": ["per-relying-party"],
+              "batch_size": 5,
+              "reissue_trigger_lifetime_left": 655433,
+              "reissue_trigger_unused": 3
+            }
+          ]
+        }
+      }
+    },
+    "PID_SdJwtVc": {
+      "format": "dc+sd-jwt",
+      "scope": "PID_SdJwtVc",
+      "vct": "eu.europa.ec.eudi.pid.1",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        }
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "EU PID SD-JWT",
+            "locale": "en-US"
+          }
+        ],
+        "credential_reuse_policy": {
+          "id": "arf_annex_ii",
+          "options": [
+            {
+              "details": ["limited_time", "limited_time"],
+              "batch_size": 40,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 655433
+            },
+            {
+              "details": ["rotating-batch", "rotating-batch"],
+              "batch_size": 40,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 655433
+            },
+            {
+              "details": ["per-relying-party", "per-relying-party"],
+              "batch_size": 40,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 655433
+            },
+            {
+              "details": ["limited_time", "limited_time"],
+              "batch_size": 40,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 655433
+            },
+            {
+              "details": ["rotating-batch", "rotating-batch"],
+              "batch_size": 40,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 655433
+            },
+            {
+              "details": ["per-relying-party", "per-relying-party"],
+              "batch_size": 40,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 655433
+            }
+          ]
+        }
+      }
+    }
+  },
+  "display": [
+    {
+      "name": "credential-issuer.example.com",
+      "locale": "en-US",
+      "logo": {
+        "uri": "https://credential-issuer.example.com/logo.png",
+        "alt_text": "Credential Issuer Logo"
+      }
+    }
+  ]
+}

--- a/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_duplicates_compact.json
+++ b/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_duplicates_compact.json
@@ -1,0 +1,174 @@
+{
+  "credential_issuer": "https://credential-issuer.example.com",
+  "authorization_servers": [
+    "https://keycloak-eudi.netcompany-intrasoft.com/realms/pid-issuer-realm"
+  ],
+  "credential_endpoint": "https://credential-issuer.example.com/credentials",
+  "nonce_endpoint": "https://credential-issuer.example.com/nonce",
+  "deferred_credential_endpoint": "https://credential-issuer.example.com/credentials/deferred",
+  "notification_endpoint": "https://credential-issuer.example.com/notification",
+  "credential_request_encryption": {
+    "jwks": {
+      "keys": [
+        {
+          "kty": "EC",
+          "use": "enc",
+          "crv": "P-256",
+          "alg": "ECDH-ES",
+          "kid": "encKey-0",
+          "x": "TmcsNF6JpWjP85wKfBXKybHaJNowtp6jCuToppDosdw",
+          "y": "egzDuJuSxyypCE0qUoo1oKOnslpaw1Om-flQ4knafas",
+          "iat": 1755352588
+        }
+      ]
+    },
+    "enc_values_supported": [
+      "XC20P"
+    ],
+    "zip_values_supported": [
+      "DEF"
+    ],
+    "encryption_required": true
+  },
+  "credential_response_encryption": {
+    "alg_values_supported": [
+      "ECDH-ES",
+      "ECDH-ES+A128KW",
+      "ECDH-ES+A192KW",
+      "ECDH-ES+A256KW",
+      "RSA-OAEP-256",
+      "RSA-OAEP-384",
+      "RSA-OAEP-512"
+    ],
+    "enc_values_supported": [
+      "XC20P"
+    ],
+    "zip_values_supported": [
+      "DEF"
+    ],
+    "encryption_required": true
+  },
+  "batch_credential_issuance": {
+    "batch_size": 2
+  },
+  "credential_identifiers_supported": true,
+  "credential_configurations_supported": {
+    "PID_msoMdoc": {
+      "format": "mso_mdoc",
+      "scope": "PID_msoMdoc",
+      "doctype": "eu.europa.ec.eudi.pid.1",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        -7,
+        -35,
+        -36
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        }
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "EU PID",
+            "locale": "en-US"
+          }
+        ],
+        "credential_reuse_policy": {
+          "id": "arf_annex_ii",
+          "options": [
+            {
+              "details": ["limited_time", "rotating-batch", "per-relying-party"],
+              "batch_size": 5,
+              "reissue_trigger_lifetime_left": 655433,
+              "reissue_trigger_unused": 3
+            }
+          ]
+        }
+      }
+    },
+    "PID_SdJwtVc": {
+      "format": "dc+sd-jwt",
+      "scope": "PID_SdJwtVc",
+      "vct": "eu.europa.ec.eudi.pid.1",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        }
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "EU PID SD-JWT",
+            "locale": "en-US"
+          }
+        ],
+        "credential_reuse_policy": {
+          "id": "arf_annex_ii",
+          "options": [
+            {
+              "details": ["limited_time", "rotating-batch", "per-relying-party"],
+              "batch_size": 40,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 655433
+            },
+            {
+              "details": ["limited_time", "rotating-batch", "per-relying-party"],
+              "batch_size": 40,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 655433
+            }
+          ]
+        }
+      }
+    }
+  },
+  "display": [
+    {
+      "name": "credential-issuer.example.com",
+      "locale": "en-US",
+      "logo": {
+        "uri": "https://credential-issuer.example.com/logo.png",
+        "alt_text": "Credential Issuer Logo"
+      }
+    }
+  ]
+}

--- a/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_duplicates_expanded.json
+++ b/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_duplicates_expanded.json
@@ -1,0 +1,210 @@
+{
+  "credential_issuer": "https://credential-issuer.example.com",
+  "authorization_servers": [
+    "https://keycloak-eudi.netcompany-intrasoft.com/realms/pid-issuer-realm"
+  ],
+  "credential_endpoint": "https://credential-issuer.example.com/credentials",
+  "nonce_endpoint": "https://credential-issuer.example.com/nonce",
+  "deferred_credential_endpoint": "https://credential-issuer.example.com/credentials/deferred",
+  "notification_endpoint": "https://credential-issuer.example.com/notification",
+  "credential_request_encryption": {
+    "jwks": {
+      "keys": [
+        {
+          "kty": "EC",
+          "use": "enc",
+          "crv": "P-256",
+          "alg": "ECDH-ES",
+          "kid": "encKey-0",
+          "x": "TmcsNF6JpWjP85wKfBXKybHaJNowtp6jCuToppDosdw",
+          "y": "egzDuJuSxyypCE0qUoo1oKOnslpaw1Om-flQ4knafas",
+          "iat": 1755352588
+        }
+      ]
+    },
+    "enc_values_supported": [
+      "XC20P"
+    ],
+    "zip_values_supported": [
+      "DEF"
+    ],
+    "encryption_required": true
+  },
+  "credential_response_encryption": {
+    "alg_values_supported": [
+      "ECDH-ES",
+      "ECDH-ES+A128KW",
+      "ECDH-ES+A192KW",
+      "ECDH-ES+A256KW",
+      "RSA-OAEP-256",
+      "RSA-OAEP-384",
+      "RSA-OAEP-512"
+    ],
+    "enc_values_supported": [
+      "XC20P"
+    ],
+    "zip_values_supported": [
+      "DEF"
+    ],
+    "encryption_required": true
+  },
+  "batch_credential_issuance": {
+    "batch_size": 2
+  },
+  "credential_identifiers_supported": true,
+  "credential_configurations_supported": {
+    "PID_msoMdoc": {
+      "format": "mso_mdoc",
+      "scope": "PID_msoMdoc",
+      "doctype": "eu.europa.ec.eudi.pid.1",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        -7,
+        -35,
+        -36
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        }
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "EU PID",
+            "locale": "en-US"
+          }
+        ],
+        "credential_reuse_policy": {
+          "id": "arf_annex_ii",
+          "options": [
+            {
+              "details": ["limited_time"],
+              "batch_size": 5,
+              "reissue_trigger_lifetime_left": 655433,
+              "reissue_trigger_unused": 3
+            },
+            {
+              "details": ["rotating-batch"],
+              "batch_size": 5,
+              "reissue_trigger_lifetime_left": 655433,
+              "reissue_trigger_unused": 3
+            },
+            {
+              "details": ["per-relying-party"],
+              "batch_size": 5,
+              "reissue_trigger_lifetime_left": 655433,
+              "reissue_trigger_unused": 3
+            }
+          ]
+        }
+      }
+    },
+    "PID_SdJwtVc": {
+      "format": "dc+sd-jwt",
+      "scope": "PID_SdJwtVc",
+      "vct": "eu.europa.ec.eudi.pid.1",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        }
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "EU PID SD-JWT",
+            "locale": "en-US"
+          }
+        ],
+        "credential_reuse_policy": {
+          "id": "arf_annex_ii",
+          "options": [
+            {
+              "details": ["limited_time"],
+              "batch_size": 40,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 655433
+            },
+            {
+              "details": ["rotating-batch"],
+              "batch_size": 40,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 655433
+            },
+            {
+              "details": ["per-relying-party"],
+              "batch_size": 40,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 655433
+            },
+            {
+              "details": ["limited_time"],
+              "batch_size": 40,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 655433
+            },
+            {
+              "details": ["rotating-batch"],
+              "batch_size": 40,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 655433
+            },
+            {
+              "details": ["per-relying-party"],
+              "batch_size": 40,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 655433
+            }
+          ]
+        }
+      }
+    }
+  },
+  "display": [
+    {
+      "name": "credential-issuer.example.com",
+      "locale": "en-US",
+      "logo": {
+        "uri": "https://credential-issuer.example.com/logo.png",
+        "alt_text": "Credential Issuer Logo"
+      }
+    }
+  ]
+}

--- a/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_expanded.json
+++ b/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_expanded.json
@@ -96,7 +96,19 @@
           "id": "arf_annex_ii",
           "options": [
             {
-              "details": ["limited_time", "rotating-batch", "per-relying-party"],
+              "details": ["limited_time"],
+              "batch_size": 5,
+              "reissue_trigger_lifetime_left": 655433,
+              "reissue_trigger_unused": 3
+            },
+            {
+              "details": ["rotating-batch"],
+              "batch_size": 5,
+              "reissue_trigger_lifetime_left": 655433,
+              "reissue_trigger_unused": 3
+            },
+            {
+              "details": ["per-relying-party"],
               "batch_size": 5,
               "reissue_trigger_lifetime_left": 655433,
               "reissue_trigger_unused": 3
@@ -145,15 +157,22 @@
           "id": "arf_annex_ii",
           "options": [
             {
-              "details": ["limited_time", "rotating-batch"],
+              "details": ["limited_time"],
               "batch_size": 40,
+              "reissue_trigger_unused": 10,
               "reissue_trigger_lifetime_left": 655433
             },
             {
-              "details": ["once_only", "per-relying-party"],
-              "batch_size": 60,
+              "details": ["rotating-batch"],
+              "batch_size": 40,
               "reissue_trigger_unused": 10,
-              "reissue_trigger_lifetime_left": 777543
+              "reissue_trigger_lifetime_left": 655433
+            },
+            {
+              "details": ["per-relying-party"],
+              "batch_size": 40,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 655433
             }
           ]
         }

--- a/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_only_per_relying_party.json
+++ b/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_only_per_relying_party.json
@@ -1,0 +1,157 @@
+{
+  "credential_issuer": "https://credential-issuer.example.com",
+  "authorization_servers": [
+    "https://keycloak-eudi.netcompany-intrasoft.com/realms/pid-issuer-realm"
+  ],
+  "credential_endpoint": "https://credential-issuer.example.com/credentials",
+  "nonce_endpoint": "https://credential-issuer.example.com/nonce",
+  "deferred_credential_endpoint": "https://credential-issuer.example.com/credentials/deferred",
+  "notification_endpoint": "https://credential-issuer.example.com/notification",
+  "credential_request_encryption": {
+    "jwks": {
+      "keys": [
+        {
+          "kty": "EC",
+          "use": "enc",
+          "crv": "P-256",
+          "alg": "ECDH-ES",
+          "kid": "encKey-0",
+          "x": "TmcsNF6JpWjP85wKfBXKybHaJNowtp6jCuToppDosdw",
+          "y": "egzDuJuSxyypCE0qUoo1oKOnslpaw1Om-flQ4knafas",
+          "iat": 1755352588
+        }
+      ]
+    },
+    "enc_values_supported": [
+      "XC20P"
+    ],
+    "zip_values_supported": [
+      "DEF"
+    ],
+    "encryption_required": true
+  },
+  "credential_response_encryption": {
+    "alg_values_supported": [
+      "ECDH-ES",
+      "ECDH-ES+A128KW",
+      "ECDH-ES+A192KW",
+      "ECDH-ES+A256KW",
+      "RSA-OAEP-256",
+      "RSA-OAEP-384",
+      "RSA-OAEP-512"
+    ],
+    "enc_values_supported": [
+      "XC20P"
+    ],
+    "zip_values_supported": [
+      "DEF"
+    ],
+    "encryption_required": true
+  },
+  "batch_credential_issuance": {
+    "batch_size": 2
+  },
+  "credential_identifiers_supported": true,
+  "credential_configurations_supported": {
+    "PID_msoMdoc": {
+      "format": "mso_mdoc",
+      "scope": "PID_msoMdoc",
+      "doctype": "eu.europa.ec.eudi.pid.1",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        -7,
+        -35,
+        -36
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        }
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "EU PID",
+            "locale": "en-US"
+          }
+        ]
+      }
+    },
+    "PID_SdJwtVc": {
+      "format": "dc+sd-jwt",
+      "scope": "PID_SdJwtVc",
+      "vct": "eu.europa.ec.eudi.pid.1",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        }
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "EU PID SD-JWT",
+            "locale": "en-US"
+          }
+        ],
+        "credential_reuse_policy": {
+          "id": "arf_annex_ii",
+          "options": [
+            {
+              "details": ["per-relying-party"],
+              "batch_size": 40,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 655433
+            }
+          ]
+        }
+      }
+    }
+  },
+  "display": [
+    {
+      "name": "credential-issuer.example.com",
+      "locale": "en-US",
+      "logo": {
+        "uri": "https://credential-issuer.example.com/logo.png",
+        "alt_text": "Credential Issuer Logo"
+      }
+    }
+  ]
+}

--- a/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_only_rotating_batch.json
+++ b/src/test/resources/eu/europa/ec/eudi/openid4vci/internal/credential_issuer_metadata_with_reuse_policy_only_rotating_batch.json
@@ -1,0 +1,157 @@
+{
+  "credential_issuer": "https://credential-issuer.example.com",
+  "authorization_servers": [
+    "https://keycloak-eudi.netcompany-intrasoft.com/realms/pid-issuer-realm"
+  ],
+  "credential_endpoint": "https://credential-issuer.example.com/credentials",
+  "nonce_endpoint": "https://credential-issuer.example.com/nonce",
+  "deferred_credential_endpoint": "https://credential-issuer.example.com/credentials/deferred",
+  "notification_endpoint": "https://credential-issuer.example.com/notification",
+  "credential_request_encryption": {
+    "jwks": {
+      "keys": [
+        {
+          "kty": "EC",
+          "use": "enc",
+          "crv": "P-256",
+          "alg": "ECDH-ES",
+          "kid": "encKey-0",
+          "x": "TmcsNF6JpWjP85wKfBXKybHaJNowtp6jCuToppDosdw",
+          "y": "egzDuJuSxyypCE0qUoo1oKOnslpaw1Om-flQ4knafas",
+          "iat": 1755352588
+        }
+      ]
+    },
+    "enc_values_supported": [
+      "XC20P"
+    ],
+    "zip_values_supported": [
+      "DEF"
+    ],
+    "encryption_required": true
+  },
+  "credential_response_encryption": {
+    "alg_values_supported": [
+      "ECDH-ES",
+      "ECDH-ES+A128KW",
+      "ECDH-ES+A192KW",
+      "ECDH-ES+A256KW",
+      "RSA-OAEP-256",
+      "RSA-OAEP-384",
+      "RSA-OAEP-512"
+    ],
+    "enc_values_supported": [
+      "XC20P"
+    ],
+    "zip_values_supported": [
+      "DEF"
+    ],
+    "encryption_required": true
+  },
+  "batch_credential_issuance": {
+    "batch_size": 2
+  },
+  "credential_identifiers_supported": true,
+  "credential_configurations_supported": {
+    "PID_msoMdoc": {
+      "format": "mso_mdoc",
+      "scope": "PID_msoMdoc",
+      "doctype": "eu.europa.ec.eudi.pid.1",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        -7,
+        -35,
+        -36
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        }
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "EU PID",
+            "locale": "en-US"
+          }
+        ]
+      }
+    },
+    "PID_SdJwtVc": {
+      "format": "dc+sd-jwt",
+      "scope": "PID_SdJwtVc",
+      "vct": "eu.europa.ec.eudi.pid.1",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "ES256"
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ],
+          "key_attestations_required": {
+
+          }
+        }
+      },
+      "credential_metadata": {
+        "display": [
+          {
+            "name": "EU PID SD-JWT",
+            "locale": "en-US"
+          }
+        ],
+        "credential_reuse_policy": {
+          "id": "arf_annex_ii",
+          "options": [
+            {
+              "details": ["rotating-batch"],
+              "batch_size": 40,
+              "reissue_trigger_unused": 10,
+              "reissue_trigger_lifetime_left": 655433
+            }
+          ]
+        }
+      }
+    }
+  },
+  "display": [
+    {
+      "name": "credential-issuer.example.com",
+      "locale": "en-US",
+      "logo": {
+        "uri": "https://credential-issuer.example.com/logo.png",
+        "alt_text": "Credential Issuer Logo"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR updates the parsing of Credential Reuse Policies and moves the following checks at the `CredentialReusePolicy.EUDI` level rather than at the `EudiReusePolicy` level:

1. only unique details are provided
2. details contains either `once_only` or `limited-time`

With the above changes, the library is now able to successfully parse Credential Reuse Policies like below:
```json
        "credential_reuse_policy": {
          "id": "arf_annex_ii",
          "options": [
            {
              "details": ["limited_time"],
              "batch_size": 40,
              "reissue_trigger_unused": 10,
              "reissue_trigger_lifetime_left": 655433
            },
            {
              "details": ["rotating-batch"],
              "batch_size": 40,
              "reissue_trigger_unused": 10,
              "reissue_trigger_lifetime_left": 655433
            },
            {
              "details": ["per-relying-party"],
              "batch_size": 40,
              "reissue_trigger_unused": 10,
              "reissue_trigger_lifetime_left": 655433
            }
          ]
        }
```

Additionally, this PR adds extra test cases to verify that:
1. When duplicates are encountered, parsing fails
2. When both `once_only`, and `limited-time` is present, parsing fails
3. When none `once_only`, nor `limited-time` is present, parsing fails

Tests cover both compact and expanded forms.