### PR TITLE
Treat key_attestations_required as optional when parsing proof types

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
@@ -64,7 +64,13 @@ enum class ProofType : Serializable {
 sealed interface ProofTypeMeta : Serializable {
     data class Jwt(
         val algorithms: List<JWSAlgorithm>,
-        val keyAttestationRequirement: KeyAttestationRequirement,
+        /**
+         * The issuer's key attestation requirement, or `null` when the metadata omits
+         * `key_attestations_required`. That parameter is OPTIONAL in OpenID4VCI; its absence means
+         * the issuer does not require a key attestation, which is distinct from an empty object
+         * (a key attestation is required, but without additional constraints).
+         */
+        val keyAttestationRequirement: KeyAttestationRequirement?,
     ) : ProofTypeMeta {
         init {
             require(algorithms.isNotEmpty()) { "Supported algorithms in case of JWT cannot be empty" }
@@ -73,7 +79,13 @@ sealed interface ProofTypeMeta : Serializable {
 
     data class Attestation(
         val algorithms: List<JWSAlgorithm>,
-        val keyAttestationRequirement: KeyAttestationRequirement,
+        /**
+         * The issuer's key attestation requirement, or `null` when the metadata omits
+         * `key_attestations_required`. That parameter is OPTIONAL in OpenID4VCI; its absence means
+         * the issuer does not require a key attestation, which is distinct from an empty object
+         * (a key attestation is required, but without additional constraints).
+         */
+        val keyAttestationRequirement: KeyAttestationRequirement?,
     ) : ProofTypeMeta {
         init {
             require(algorithms.isNotEmpty()) { "Supported algorithms in case of Attestation cannot be empty" }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -231,7 +231,7 @@ internal class RequestIssuanceImpl(
     ): Proof.Jwt {
         val proofSigner = proofSpecification.proofSignerProvider(
             cNonce,
-            proofRequirement.keyAttestationRequirement.preferredKeyStorageStatusPeriod,
+            proofRequirement.keyAttestationRequirement?.preferredKeyStorageStatusPeriod,
         )
         val joseAlg = run {
             val javaSigningAlgorithm = proofSigner.javaAlgorithm
@@ -266,7 +266,7 @@ internal class RequestIssuanceImpl(
     ): Proof.Attestation {
         val keyAttestationJwt = proofSpecification.attestationProvider(
             cNonce,
-            proofRequirement.keyAttestationRequirement.preferredKeyStorageStatusPeriod,
+            proofRequirement.keyAttestationRequirement?.preferredKeyStorageStatusPeriod,
         )
         keyAttestationJwt.ensureKeyAttestationJwtAlgIsSupported(proofRequirement)
         keyAttestationJwt.attestedKeys.assertMatchesBatchIssuanceBatchSize(selectedReusePolicy)

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialIssuerMetadataJsonParser.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialIssuerMetadataJsonParser.kt
@@ -645,17 +645,18 @@ private fun proofTypeMeta(type: String, meta: ProofTypeSupportedMetaTO): ProofTy
     when (type) {
         "jwt" -> {
             val algorithms = meta.algorithms.map { JWSAlgorithm.parse(it) }
-            val keyAttestationRequirement = requireNotNull(meta.keyAttestationRequirement?.toDomain()) {
-                "jwt proof must contain 'key_attestations_required'"
-            }
+            // 'key_attestations_required' is OPTIONAL per OpenID4VCI. When it is absent the issuer
+            // does not require a key attestation, so keep the requirement null rather than rejecting
+            // the metadata. (An absent value is distinct from an empty object, which would mean a
+            // key attestation is required without additional constraints.)
+            val keyAttestationRequirement = meta.keyAttestationRequirement?.toDomain()
             ProofTypeMeta.Jwt(algorithms, keyAttestationRequirement)
         }
 
         "attestation" -> {
             val algorithms = meta.algorithms.map { JWSAlgorithm.parse(it) }
-            val keyAttestationRequirement = requireNotNull(meta.keyAttestationRequirement?.toDomain()) {
-                "attestation proof must contain 'key_attestations_required'"
-            }
+            // 'key_attestations_required' is OPTIONAL per OpenID4VCI; see the "jwt" branch above.
+            val keyAttestationRequirement = meta.keyAttestationRequirement?.toDomain()
             ProofTypeMeta.Attestation(algorithms, keyAttestationRequirement)
         }
 

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialIssuerMetadataJsonParserTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialIssuerMetadataJsonParserTest.kt
@@ -22,6 +22,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.time.Duration.Companion.days
 import kotlin.time.toJavaDuration
 
@@ -43,11 +44,11 @@ class CredentialIssuerMetadataJsonParserTest {
 
         val jwtProof = assertNotNull(credentialConfiguration.proofTypesSupported[ProofType.JWT])
         check(jwtProof is ProofTypeMeta.Jwt)
-        assertEquals(1.days.toJavaDuration(), jwtProof.keyAttestationRequirement.preferredKeyStorageStatusPeriod?.value)
+        assertEquals(1.days.toJavaDuration(), jwtProof.keyAttestationRequirement?.preferredKeyStorageStatusPeriod?.value)
 
         val attestationProof = assertNotNull(credentialConfiguration.proofTypesSupported[ProofType.ATTESTATION])
         check(attestationProof is ProofTypeMeta.Attestation)
-        assertEquals(1.days.toJavaDuration(), attestationProof.keyAttestationRequirement.preferredKeyStorageStatusPeriod?.value)
+        assertEquals(1.days.toJavaDuration(), attestationProof.keyAttestationRequirement?.preferredKeyStorageStatusPeriod?.value)
     }
 
     @Test
@@ -61,13 +62,49 @@ class CredentialIssuerMetadataJsonParserTest {
     }
 
     @Test
-    fun `fails when jwt proof does not require key attestation`() {
-        val json = getResourceAsText("well-known/openid-credential-issuer_jwt_proof_no_keyattestation.json")
-        val exception = assertFailsWith<CredentialIssuerMetadataValidationError.InvalidCredentialsSupported> {
-            CredentialIssuerMetadataJsonParser.parseMetaData(json, SampleIssuer.Id)
-        }
-        val cause = assertIs<IllegalArgumentException>(exception.cause)
-        assertEquals("jwt proof must contain 'key_attestations_required'", cause.message)
+    fun `absent key_attestations_required is parsed as no key attestation requirement`() {
+        // 'key_attestations_required' is OPTIONAL in OpenID4VCI; when it is absent the issuer does
+        // not require a key attestation, so the parsed requirement is null.
+        val json = getResourceAsText("well-known/openid-credential-issuer_absent_key_attestations_required.json")
+        val credentialIssuerMetadata = CredentialIssuerMetadataJsonParser.parseMetaData(json, SampleIssuer.Id)
+
+        val credentialConfiguration =
+            assertNotNull(
+                credentialIssuerMetadata.credentialConfigurationsSupported[
+                    CredentialConfigurationIdentifier("eu.europa.ec.eudiw.pid_vc_sd_jwt"),
+                ],
+            )
+
+        val jwtProof = assertNotNull(credentialConfiguration.proofTypesSupported[ProofType.JWT])
+        check(jwtProof is ProofTypeMeta.Jwt)
+        assertNull(jwtProof.keyAttestationRequirement)
+
+        val attestationProof = assertNotNull(credentialConfiguration.proofTypesSupported[ProofType.ATTESTATION])
+        check(attestationProof is ProofTypeMeta.Attestation)
+        assertNull(attestationProof.keyAttestationRequirement)
+    }
+
+    @Test
+    fun `empty key_attestations_required is parsed as an unconstrained key attestation requirement`() {
+        // An empty 'key_attestations_required' object means a key attestation IS required but
+        // without additional constraints, which is distinct from the field being absent.
+        val json = getResourceAsText("well-known/openid-credential-issuer_empty_key_attestations_required.json")
+        val credentialIssuerMetadata = CredentialIssuerMetadataJsonParser.parseMetaData(json, SampleIssuer.Id)
+
+        val credentialConfiguration =
+            assertNotNull(
+                credentialIssuerMetadata.credentialConfigurationsSupported[
+                    CredentialConfigurationIdentifier("eu.europa.ec.eudiw.pid_vc_sd_jwt"),
+                ],
+            )
+
+        val jwtProof = assertNotNull(credentialConfiguration.proofTypesSupported[ProofType.JWT])
+        check(jwtProof is ProofTypeMeta.Jwt)
+        assertEquals(KeyAttestationRequirement(null, null, null), jwtProof.keyAttestationRequirement)
+
+        val attestationProof = assertNotNull(credentialConfiguration.proofTypesSupported[ProofType.ATTESTATION])
+        check(attestationProof is ProofTypeMeta.Attestation)
+        assertEquals(KeyAttestationRequirement(null, null, null), attestationProof.keyAttestationRequirement)
     }
 
     @Test

--- a/src/test/resources/well-known/openid-credential-issuer_absent_key_attestations_required.json
+++ b/src/test/resources/well-known/openid-credential-issuer_absent_key_attestations_required.json
@@ -1,0 +1,89 @@
+{
+  "credential_issuer": "https://credential-issuer.example.com",
+  "authorization_servers": [
+    "https://auth-server.example.com"
+  ],
+  "credential_endpoint": "https://credential-issuer.example.com/credentials",
+  "nonce_endpoint": "https://credential-issuer.example.com/nonce",
+  "deferred_credential_endpoint": "https://credential-issuer.example.com/credentials/deferred",
+  "notification_endpoint": "https://credential-issuer.example.com/notification",
+  "batch_credential_issuance": {
+    "batch_size": 3
+  },
+  "credential_identifiers_supported": true,
+  "credential_configurations_supported": {
+    "eu.europa.ec.eudiw.pid_vc_sd_jwt": {
+      "format": "dc+sd-jwt",
+      "scope": "eu.europa.ec.eudiw.pid_vc_sd_jwt",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "RS256"
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ]
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ]
+        }
+      },
+      "vct": "eu.europa.ec.eudiw.pid.1",
+      "credential_metadata": {
+        "claims": [
+          {
+            "path": [
+              "given_name"
+            ],
+            "display": [
+              {
+                "name": "Given Name",
+                "locale": "en-US"
+              }
+            ]
+          },
+          {
+            "path": [
+              "family_name"
+            ],
+            "display": [
+              {
+                "name": "Surname",
+                "locale": "en-US"
+              }
+            ]
+          },
+          {
+            "path": [
+              "birth_date"
+            ]
+          }
+        ],
+        "display": [
+          {
+            "name": "Personal Identification Data ",
+            "locale": "en-US",
+            "logo": {
+              "uri": "https://examplestate.com/public/pid.png",
+              "alt_text": "a square logo of a university"
+            },
+            "background_color": "#12107c",
+            "text_color": "#FFFFFF"
+          }
+        ]
+      }
+    }
+  },
+  "display": [
+    {
+      "name": "credential-issuer.example.com",
+      "locale": "en-US"
+    }
+  ]
+}

--- a/src/test/resources/well-known/openid-credential-issuer_empty_key_attestations_required.json
+++ b/src/test/resources/well-known/openid-credential-issuer_empty_key_attestations_required.json
@@ -26,7 +26,14 @@
           "proof_signing_alg_values_supported": [
             "RS256",
             "ES256"
-          ]
+          ],
+          "key_attestations_required": {}
+        },
+        "attestation": {
+          "proof_signing_alg_values_supported": [
+            "ES256"
+          ],
+          "key_attestations_required": {}
         }
       },
       "vct": "eu.europa.ec.eudiw.pid.1",


### PR DESCRIPTION
https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html says: *`key_attestations_required`: OPTIONAL*.

Further, absent is different from empty (both are allowed): *If the Credential Issuer does not require a key attestation, this parameter MUST NOT be present in the metadata. If both key_storage and user_authentication parameters are absent, the key_attestations_required parameter may be empty, indicating a key attestation is needed without additional constraints.*

The metadata parser in this library previously (wrongly) asserted that key_attestations_required is present.

This PR fixes this.