### PR TITLE
Relax KeyAttestationJWT checks

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/KeyAttestationJWT.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/KeyAttestationJWT.kt
@@ -18,21 +18,21 @@ package eu.europa.ec.eudi.openid4vci
 import com.nimbusds.jose.JOSEObjectType
 import com.nimbusds.jose.JWSHeader
 import com.nimbusds.jose.jwk.JWK
+import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
-import eu.europa.ec.eudi.openid4vci.internal.JWKJsonObjectSerializer
-import eu.europa.ec.eudi.openid4vci.internal.URLSerializer
-import eu.europa.ec.eudi.openid4vci.internal.ensureSignedOrVerified
-import eu.europa.ec.eudi.openid4vci.internal.ensureSignedWithAllowedAlgorithm
-import eu.europa.ec.eudi.openid4vci.internal.ensureType
-import eu.europa.ec.eudi.openid4vci.internal.ensureValidClaimsSet
+import eu.europa.ec.eudi.openid4vci.internal.*
 import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.net.URL
 
 @ConsistentCopyVisibility
-data class KeyAttestationJWT private constructor(val jwt: String, val header: JWSHeader, val claimsSet: KeyAttestationJWTClaims) {
-    val attestedKeys: List<JWK> get() = claimsSet.attestedKeys.value
+data class KeyAttestationJWT private constructor(
+    val jwt: String,
+    val header: JWSHeader,
+    val claimsSet: JWTClaimsSet,
+    val attestedKeys: AttestedKeys,
+) {
 
     companion object {
         operator fun invoke(jwt: String): KeyAttestationJWT = invoke(SignedJWT.parse(jwt))
@@ -40,10 +40,17 @@ data class KeyAttestationJWT private constructor(val jwt: String, val header: JW
         operator fun invoke(jwt: SignedJWT): KeyAttestationJWT {
             jwt.ensureType(JOSEObjectType(OpenId4VCISpec.KEY_ATTESTATION_JWT_TYPE))
             jwt.ensureSignedOrVerified()
-            jwt.ensureSignedWithAllowedAlgorithm(TS3.ALLOWED_SIGNATURE_ALGORITHMS)
-            val claimsSet = jwt.ensureValidClaimsSet<KeyAttestationJWTClaims>()
-            return KeyAttestationJWT(jwt.serialize(), jwt.header, claimsSet)
+            val attestedKeys = jwt.ensureContainsAttestedKeys()
+            return KeyAttestationJWT(jwt.serialize(), jwt.header, jwt.jwtClaimsSet, attestedKeys)
         }
+
+        private fun SignedJWT.ensureContainsAttestedKeys(): AttestedKeys =
+            runCatchingCancellable {
+                val attestedKeys = jwtClaimsSet.get<AttestedKeys>(OpenId4VCISpec.ATTESTED_KEYS)
+                requireNotNull(attestedKeys) {
+                    "Missing ${OpenId4VCISpec.ATTESTED_KEYS} claim"
+                }
+            }.getOrElse { throw IllegalArgumentException("Invalid Claims Set.", it) }
     }
 }
 
@@ -60,15 +67,25 @@ value class AttestedKeys(
         require(value.none { it.isPrivate }) { "attestedKeys must all be public" }
     }
 
+    val size: Int
+        get() = value.size
+
+    val indices: IntRange
+        get() = value.indices
+
     override fun toString(): String = value.toString()
 }
 
 operator fun AttestedKeys.get(index: Int): JWK = value[index]
 
+/**
+ * Payload of a Key Attestation JWT that is aligned with
+ * [TS3](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts3-wallet-unit-attestation.md#232-content-of-key-attestation-ka).
+ */
 @Serializable
 data class KeyAttestationJWTClaims(
     @Required @SerialName(RFC7519.ISSUED_AT) val issuedAt: InstantAsEpochSecond,
-    @Required @SerialName(RFC7519.EXPIRATION_TIME) val expiresAt: InstantAsEpochSecond,
+    @SerialName(RFC7519.EXPIRATION_TIME) val expiresAt: InstantAsEpochSecond? = null,
     @Required @SerialName(OpenId4VCISpec.ATTESTED_KEYS) val attestedKeys: AttestedKeys,
     @Required @SerialName(OpenId4VCISpec.KEY_STORAGE) val keyStorage: List<AttackPotentialResistance>,
     @Required @SerialName(OpenId4VCISpec.USER_AUTHENTICATION) val userAuthentication: List<AttackPotentialResistance>,
@@ -76,41 +93,7 @@ data class KeyAttestationJWTClaims(
     @SerialName(OpenId4VCISpec.NONCE) val nonce: Nonce? = null,
     @SerialName(TokenStatusListSpec.STATUS) val status: StatusClaim? = null,
     @Required @SerialName(TS3.KEY_STORAGE_STATUS) val keyStorageStatus: KeyStorageStatus,
-) {
-    init {
-        keyStorage.ensureLoAHigh { "keyStorage must contain [${AttackPotentialResistance.Iso18045High}]" }
-        userAuthentication.ensureLoAHigh { "userAuthentication must contain [${AttackPotentialResistance.Iso18045High}]" }
-    }
-
-    companion object {
-        /**
-         * Enforces the TS3 requirement that `key_storage` and `user_authentication` must ensure LoA High, i.e. must contain `iso_18045_high`.
-         */
-        private fun List<AttackPotentialResistance>.ensureLoAHigh(error: () -> String) {
-            require(AttackPotentialResistance.Iso18045High in this) { error() }
-        }
-
-        operator fun invoke(
-            issuedAt: InstantAsEpochSecond,
-            expiresAt: InstantAsEpochSecond,
-            attestedKeys: AttestedKeys,
-            certification: URL,
-            nonce: Nonce?,
-            status: StatusClaim?,
-            keyStorageStatus: KeyStorageStatus,
-        ): KeyAttestationJWTClaims = KeyAttestationJWTClaims(
-            issuedAt = issuedAt,
-            expiresAt = expiresAt,
-            attestedKeys,
-            keyStorage = listOf(AttackPotentialResistance.Iso18045High),
-            userAuthentication = listOf(AttackPotentialResistance.Iso18045High),
-            certification,
-            nonce,
-            status,
-            keyStorageStatus,
-        )
-    }
-}
+)
 
 @Serializable
 data class KeyStorageStatus(

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -17,7 +17,6 @@ package eu.europa.ec.eudi.openid4vci.internal
 
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.crypto.ECDSAVerifier
-import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jwt.SignedJWT
 import eu.europa.ec.eudi.openid4vci.*
 import eu.europa.ec.eudi.openid4vci.internal.http.CNonceAndDPoPNonce
@@ -273,7 +272,7 @@ internal class RequestIssuanceImpl(
         return Proof.Attestation(keyAttestationJwt)
     }
 
-    private fun List<JWK>.assertMatchesBatchIssuanceBatchSize(
+    private fun AttestedKeys.assertMatchesBatchIssuanceBatchSize(
         selectedReusePolicy: EudiReusePolicy?,
     ) = size.assertMatchesBatchIssuanceBatchSize(selectedReusePolicy)
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/Serialization.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/Serialization.kt
@@ -16,6 +16,9 @@
 package eu.europa.ec.eudi.openid4vci.internal
 
 import com.nimbusds.jose.jwk.JWK
+import com.nimbusds.jose.shaded.gson.GsonBuilder
+import com.nimbusds.jose.shaded.gson.Strictness
+import com.nimbusds.jose.shaded.gson.ToNumberPolicy
 import com.nimbusds.jose.util.JSONObjectUtils
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
@@ -40,6 +43,13 @@ internal val JsonSupport: Json = Json {
     ignoreUnknownKeys = true
     prettyPrint = true
 }
+
+internal val GsonSupport = GsonBuilder()
+    .setStrictness(Strictness.STRICT)
+    .serializeNulls()
+    .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+    .disableHtmlEscaping()
+    .create()
 
 internal object LocaleSerializer : KSerializer<Locale> {
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/SignedJWTExtensions.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/SignedJWTExtensions.kt
@@ -19,22 +19,16 @@ import com.nimbusds.jose.JOSEObjectType
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.JWSObject
 import com.nimbusds.jose.crypto.MACSigner
+import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.serializer
 
 internal fun SignedJWT.ensureSignedOrVerified() {
     require(state == JWSObject.State.SIGNED || state == JWSObject.State.VERIFIED) {
         "Provided JWT is not signed"
     }
 }
-
-internal fun SignedJWT.ensureSignedWithAllowedAlgorithm(allowedAlgorithms: Set<JWSAlgorithm>) {
-    require(header.algorithm in allowedAlgorithms) {
-        "Signature algorithm must be one of $allowedAlgorithms"
-    }
-}
-
-internal inline fun <reified T : Any> SignedJWT.ensureValidClaimsSet(): T =
-    jwtClaimsSet.decodeAs<T>().getOrElse { throw IllegalArgumentException("Invalid Claims Set.", it) }
 
 internal fun SignedJWT.ensureSignedNotMAC() {
     ensureSignedOrVerified()
@@ -52,3 +46,10 @@ internal fun SignedJWT.ensureType(expectedType: JOSEObjectType) {
         "Expected SignedJWT `typ` to be '${expectedType.type}', but found '${header.type?.type}' instead"
     }
 }
+
+internal operator fun <T : Any> JWTClaimsSet.get(key: String, deserializer: DeserializationStrategy<T>): T? =
+    claims[key]?.let { value ->
+        JsonSupport.decodeFromString(deserializer, GsonSupport.toJson(value))
+    }
+
+internal inline operator fun <reified T : Any> JWTClaimsSet.get(key: String): T? = this[key, serializer<T>()]

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CryptoGenerator.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CryptoGenerator.kt
@@ -17,7 +17,6 @@ package eu.europa.ec.eudi.openid4vci
 
 import com.nimbusds.jose.JOSEObjectType
 import com.nimbusds.jose.JWSAlgorithm
-import com.nimbusds.jose.JWSHeader
 import com.nimbusds.jose.JWSSigner
 import com.nimbusds.jose.crypto.ECDSASigner
 import com.nimbusds.jose.jwk.Curve
@@ -25,11 +24,9 @@ import com.nimbusds.jose.jwk.ECKey
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.KeyUse
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator
-import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
 import com.nimbusds.oauth2.sdk.id.Issuer
 import com.nimbusds.oauth2.sdk.util.X509CertificateUtils
-import eu.europa.ec.eudi.openid4vci.internal.JsonSupport
 import eu.europa.ec.eudi.openid4vci.internal.fromNimbusEcKey
 import java.net.URI
 import java.security.KeyFactory
@@ -194,33 +191,31 @@ object CryptoGenerator {
         nonce: Nonce? = null,
         preferredKeyStorageStatusPeriod: PositiveDuration? = null,
         algorithm: JWSAlgorithm,
-    ): SignedJWT {
-        val keyAttestationJWTClaims = KeyAttestationJWTClaims(
-            issuedAt = now(),
-            expiresAt = now() + (preferredKeyStorageStatusPeriod?.value ?: 3600.seconds.toJavaDuration()),
-            AttestedKeys(attestedKeys.map { it.toPublicJWK() }),
-            keyStorage = listOf(AttackPotentialResistance.Iso18045High),
-            userAuthentication = listOf(AttackPotentialResistance.Iso18045High),
-            URI.create("https://example.org/certification/wscd/GlobalPlatform/").toURL(),
-            nonce,
-            null,
-            KeyStorageStatus(
-                StatusClaim(
-                    StatusListTokenClaim(
-                        7u,
-                        URI.create("https://revocation_url/wua-type-statuslists/3"),
+    ): SignedJWT =
+        KeyAttestationJWTBuilder(algorithm)
+            .typ(JOSEObjectType(OpenId4VCISpec.KEY_ATTESTATION_JWT_TYPE))
+            .x5c(listOf(certificate))
+            .iat(now())
+            .exp(now() + (preferredKeyStorageStatusPeriod?.value ?: 3600.seconds.toJavaDuration()))
+            .attestedKeys(attestedKeys.map { it.toPublicJWK() })
+            .keyStorage(listOf(AttackPotentialResistance.Iso18045High))
+            .userAuthentication(listOf(AttackPotentialResistance.Iso18045High))
+            .certification(URI.create("https://example.org/certification/wscd/GlobalPlatform/").toURL())
+            .apply {
+                if (null != nonce) {
+                    nonce(nonce)
+                }
+            }
+            .keyStorageStatus(
+                KeyStorageStatus(
+                    StatusClaim(
+                        StatusListTokenClaim(
+                            7u,
+                            URI.create("https://revocation_url/wua-type-statuslists/3"),
+                        ),
                     ),
+                    now() + 90.days.toJavaDuration(),
                 ),
-                now() + 90.days.toJavaDuration(),
-            ),
-        )
-
-        val header = JWSHeader.Builder(algorithm)
-            .type(JOSEObjectType(OpenId4VCISpec.KEY_ATTESTATION_JWT_TYPE))
-            .x509CertChain(listOf(com.nimbusds.jose.util.Base64.encode(certificate.encoded)))
-            .build()
-        val claimsSet = JWTClaimsSet.parse(JsonSupport.encodeToString(keyAttestationJWTClaims))
-
-        return SignedJWT(header, claimsSet).apply { sign(signer) }
-    }
+            )
+            .build(signer)
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/KeyAttestationJWTBuilder.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/KeyAttestationJWTBuilder.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2023-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.openid4vci
+
+import com.nimbusds.jose.JOSEObjectType
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.JWSSigner
+import com.nimbusds.jose.jwk.JWK
+import com.nimbusds.jose.util.Base64
+import com.nimbusds.jose.util.JSONObjectUtils
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import eu.europa.ec.eudi.openid4vci.internal.JsonSupport
+import java.net.URL
+import java.security.cert.X509Certificate
+import java.time.Instant
+import java.util.Date
+
+class KeyAttestationJWTBuilder(signatureAlgorithm: JWSAlgorithm) {
+    private val header = JWSHeader.Builder(signatureAlgorithm)
+    private val claimsSet = JWTClaimsSet.Builder()
+
+    fun typ(typ: JOSEObjectType): KeyAttestationJWTBuilder = apply {
+        header.type(typ)
+    }
+
+    fun x5c(x5c: List<X509Certificate>): KeyAttestationJWTBuilder = apply {
+        header.x509CertChain(x5c.map { Base64.encode(it.encoded) })
+    }
+
+    fun iat(iat: Instant): KeyAttestationJWTBuilder = apply {
+        claimsSet.issueTime(Date.from(iat))
+    }
+
+    fun exp(exp: Instant): KeyAttestationJWTBuilder = apply {
+        claimsSet.expirationTime(Date.from(exp))
+    }
+
+    fun attestedKeys(attestedKeys: List<JWK>): KeyAttestationJWTBuilder = apply {
+        claimsSet.claim(OpenId4VCISpec.ATTESTED_KEYS, attestedKeys.map { it.toJSONObject() })
+    }
+
+    fun keyStorage(keyStorage: List<AttackPotentialResistance>): KeyAttestationJWTBuilder = apply {
+        claimsSet.claim(OpenId4VCISpec.KEY_STORAGE, keyStorage.map { it.value })
+    }
+
+    fun userAuthentication(userAuthentication: List<AttackPotentialResistance>): KeyAttestationJWTBuilder = apply {
+        claimsSet.claim(OpenId4VCISpec.USER_AUTHENTICATION, userAuthentication.map { it.value })
+    }
+
+    fun certification(certification: URL): KeyAttestationJWTBuilder = apply {
+        claimsSet.claim(OpenId4VCISpec.CERTIFICATION, certification.toExternalForm())
+    }
+
+    fun nonce(nonce: Nonce): KeyAttestationJWTBuilder = apply {
+        claimsSet.claim(OpenId4VCISpec.NONCE, nonce.value)
+    }
+
+    fun status(status: StatusClaim): KeyAttestationJWTBuilder = apply {
+        claimsSet.claim(TokenStatusListSpec.STATUS, JSONObjectUtils.parse(JsonSupport.encodeToString(status)))
+    }
+
+    fun keyStorageStatus(keyStorageStatus: KeyStorageStatus): KeyAttestationJWTBuilder = apply {
+        claimsSet.claim(TS3.KEY_STORAGE_STATUS, JSONObjectUtils.parse(JsonSupport.encodeToString(keyStorageStatus)))
+    }
+
+    fun build(): SignedJWT = SignedJWT(header.build(), claimsSet.build())
+
+    fun build(signer: JWSSigner): SignedJWT = build().apply { sign(signer) }
+}

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/KeyAttestationJWTTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/KeyAttestationJWTTest.kt
@@ -17,38 +17,27 @@ package eu.europa.ec.eudi.openid4vci
 
 import com.nimbusds.jose.JOSEObjectType
 import com.nimbusds.jose.JWSAlgorithm
-import com.nimbusds.jose.JWSHeader
 import com.nimbusds.jose.JWSSigner
 import com.nimbusds.jose.crypto.ECDSASigner
 import com.nimbusds.jose.crypto.Ed25519Signer
 import com.nimbusds.jose.crypto.MACSigner
 import com.nimbusds.jose.crypto.RSASSASigner
 import com.nimbusds.jose.jwk.Curve
-import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator
 import com.nimbusds.jose.jwk.gen.OctetKeyPairGenerator
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
-import com.nimbusds.jose.util.JSONObjectUtils
-import com.nimbusds.jwt.JWTClaimsSet
-import com.nimbusds.jwt.SignedJWT
 import eu.europa.ec.eudi.openid4vci.CryptoGenerator.randomECSigningKey
-import eu.europa.ec.eudi.openid4vci.internal.JsonSupport
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.MissingFieldException
+import eu.europa.ec.eudi.openid4vci.internal.decodeAs
 import org.junit.jupiter.api.assertThrows
 import java.net.URI
-import java.net.URL
 import java.time.Duration
 import java.time.Instant
 import java.util.*
-import kotlin.collections.map
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
-import kotlin.test.assertTrue
 
-@OptIn(ExperimentalSerializationApi::class)
 class KeyAttestationJWTTest {
 
     val signingKey = randomECSigningKey(Curve.P_256)
@@ -76,32 +65,20 @@ class KeyAttestationJWTTest {
     }
 
     @Test
-    fun `KeyAttestationJWT must have all required claim`() {
+    fun `KeyAttestationJWT must have attested keys`() {
         val jwt = KeyAttestationJWTBuilder(JWSAlgorithm.ES256)
             .typ(JOSEObjectType(OpenId4VCISpec.KEY_ATTESTATION_JWT_TYPE))
-            .build()
-            .apply {
-                sign(signer)
-            }
+            .build(signer)
+
         val exception = assertThrows<IllegalArgumentException> { KeyAttestationJWT(jwt) }
         assertEquals("Invalid Claims Set.", exception.message)
-        val cause = assertIs<MissingFieldException>(exception.cause)
 
-        val requiredFields = listOf(
-            RFC7519.ISSUED_AT,
-            RFC7519.EXPIRATION_TIME,
-            OpenId4VCISpec.ATTESTED_KEYS,
-            OpenId4VCISpec.KEY_STORAGE,
-            OpenId4VCISpec.USER_AUTHENTICATION,
-            OpenId4VCISpec.CERTIFICATION,
-            TS3.KEY_STORAGE_STATUS,
-        )
-        assertEquals(requiredFields.size, cause.missingFields.size)
-        assertTrue(cause.missingFields.containsAll(requiredFields))
+        val cause = assertIs<IllegalArgumentException>(exception.cause)
+        assertEquals("Missing attested_keys claim", cause.message)
     }
 
     @Test
-    fun `KeyAttestationJWT must contain at least 1 attested keys claim`() {
+    fun `KeyAttestationJWT must contain at least 1 attested key`() {
         val jwt = KeyAttestationJWTBuilder(JWSAlgorithm.ES256)
             .typ(JOSEObjectType(OpenId4VCISpec.KEY_ATTESTATION_JWT_TYPE))
             .iat(Instant.now())
@@ -121,10 +98,7 @@ class KeyAttestationJWTTest {
                     Instant.now() + Duration.ofDays(90L),
                 ),
             )
-            .build()
-            .apply {
-                sign(signer)
-            }
+            .build(signer)
 
         val exception = assertThrows<IllegalArgumentException> { KeyAttestationJWT(jwt) }
         assertEquals("Invalid Claims Set.", exception.message)
@@ -167,72 +141,6 @@ class KeyAttestationJWTTest {
     }
 
     @Test
-    fun `KeyAttestationJWT must contain iso_18045_high in key_storage claim`() {
-        val jwt = KeyAttestationJWTBuilder(JWSAlgorithm.ES256)
-            .typ(JOSEObjectType(OpenId4VCISpec.KEY_ATTESTATION_JWT_TYPE))
-            .iat(Instant.now())
-            .exp(Instant.now() + Duration.ofDays(1L))
-            .attestedKeys(listOf(ECKeyGenerator(Curve.P_256).generate().toPublicJWK()))
-            .keyStorage(listOf(AttackPotentialResistance.Iso18045Moderate))
-            .userAuthentication(emptyList())
-            .certification(URI.create("https://example.org/certification/wscd/GlobalPlatform/").toURL())
-            .keyStorageStatus(
-                KeyStorageStatus(
-                    StatusClaim(
-                        StatusListTokenClaim(
-                            7u,
-                            URI.create("https://revocation_url/wua-type-statuslists/3"),
-                        ),
-                    ),
-                    Instant.now() + Duration.ofDays(90L),
-                ),
-            )
-            .build()
-            .apply {
-                sign(signer)
-            }
-
-        val exception = assertThrows<IllegalArgumentException> { KeyAttestationJWT(jwt) }
-        assertEquals("Invalid Claims Set.", exception.message)
-
-        val cause = assertIs<IllegalArgumentException>(exception.cause)
-        assertEquals("keyStorage must contain [iso_18045_high]", cause.message)
-    }
-
-    @Test
-    fun `KeyAttestationJWT must contain iso_18045_high in user_authentication claim`() {
-        val jwt = KeyAttestationJWTBuilder(JWSAlgorithm.ES256)
-            .typ(JOSEObjectType(OpenId4VCISpec.KEY_ATTESTATION_JWT_TYPE))
-            .iat(Instant.now())
-            .exp(Instant.now() + Duration.ofDays(1L))
-            .attestedKeys(listOf(ECKeyGenerator(Curve.P_256).generate().toPublicJWK()))
-            .keyStorage(listOf(AttackPotentialResistance.Iso18045High))
-            .userAuthentication(listOf(AttackPotentialResistance.Iso18045Moderate))
-            .certification(URI.create("https://example.org/certification/wscd/GlobalPlatform/").toURL())
-            .keyStorageStatus(
-                KeyStorageStatus(
-                    StatusClaim(
-                        StatusListTokenClaim(
-                            7u,
-                            URI.create("https://revocation_url/wua-type-statuslists/3"),
-                        ),
-                    ),
-                    Instant.now() + Duration.ofDays(90L),
-                ),
-            )
-            .build()
-            .apply {
-                sign(signer)
-            }
-
-        val exception = assertThrows<IllegalArgumentException> { KeyAttestationJWT(jwt) }
-        assertEquals("Invalid Claims Set.", exception.message)
-
-        val cause = assertIs<IllegalArgumentException>(exception.cause)
-        assertEquals("userAuthentication must contain [iso_18045_high]", cause.message)
-    }
-
-    @Test
     fun `KeyAttestationJWT must be created when valid`() {
         val now = Instant.ofEpochSecond(Instant.now().epochSecond) // drop fraction of seconds, they cannot be encoded in a JWT
         val iat = now
@@ -259,10 +167,7 @@ class KeyAttestationJWTTest {
             .userAuthentication(userAuthentication)
             .certification(certification)
             .keyStorageStatus(keyStorageStatus)
-            .build()
-            .apply {
-                sign(signer)
-            }
+            .build(signer)
 
         val keyAttestationJwt = KeyAttestationJWT(jwt)
         val expectedClaimsSet = KeyAttestationJWTClaims(
@@ -277,11 +182,11 @@ class KeyAttestationJWTTest {
             keyStorageStatus,
         )
 
-        assertEquals(expectedClaimsSet, keyAttestationJwt.claimsSet)
+        assertEquals(expectedClaimsSet, keyAttestationJwt.claimsSet.decodeAs<KeyAttestationJWTClaims>().getOrThrow())
     }
 
     @Test
-    fun `KeyAttestationJWT must be signed with an allowed algorithm`() {
+    fun `KeyAttestationJWT can be signed with any algorithm`() {
         fun create(algorithm: JWSAlgorithm, signer: JWSSigner): KeyAttestationJWT {
             val jwt = KeyAttestationJWTBuilder(algorithm)
                 .typ(JOSEObjectType(OpenId4VCISpec.KEY_ATTESTATION_JWT_TYPE))
@@ -302,87 +207,34 @@ class KeyAttestationJWTTest {
                         Instant.now() + Duration.ofDays(90L),
                     ),
                 )
-                .build()
-                .apply {
-                    sign(signer)
-                }
+                .build(signer)
             return KeyAttestationJWT(jwt)
         }
 
-        // ES256, ES384, ES512 is allowed -- ES256K is deprecated
+        // ES256, ES384, ES512 -- ES256K is deprecated
         create(JWSAlgorithm.ES256, ECDSASigner(ECKeyGenerator(Curve.P_256).generate()))
         create(JWSAlgorithm.ES384, ECDSASigner(ECKeyGenerator(Curve.P_384).generate()))
         create(JWSAlgorithm.ES512, ECDSASigner(ECKeyGenerator(Curve.P_521).generate()))
 
-        // RS256, RS384, RS512, PS256, PS384, PS512 is not allowed
+        // RS256, RS384, RS512, PS256, PS384, PS512
         val rsaSigner = RSASSASigner(RSAKeyGenerator(2048).generate())
         listOf(JWSAlgorithm.RS256, JWSAlgorithm.RS384, JWSAlgorithm.RS512, JWSAlgorithm.PS256, JWSAlgorithm.PS384, JWSAlgorithm.PS512)
             .forEach {
-                val exception = assertThrows<IllegalArgumentException> { create(it, rsaSigner) }
-                assertEquals("Signature algorithm must be one of [ES256, ES384, ES512]", exception.message)
+                create(it, rsaSigner)
             }
 
-        // HS256, HS384, HS512 is not allowed
+        // HS256, HS384, HS512
         val macSigner = MACSigner(Random.nextBytes(512))
         listOf(JWSAlgorithm.HS256, JWSAlgorithm.HS384, JWSAlgorithm.HS512)
             .forEach {
-                val exception = assertThrows<IllegalArgumentException> { create(it, macSigner) }
-                assertEquals("Signature algorithm must be one of [ES256, ES384, ES512]", exception.message)
+                create(it, macSigner)
             }
 
-        // EdDSA, Ed25519 is not allowed -- Nimbus does not provide a JWSSigner for Ed448
+        // EdDSA, Ed25519 -- Nimbus does not provide a JWSSigner for Ed448
         val ed25519Signer = Ed25519Signer(OctetKeyPairGenerator(Curve.Ed25519).generate())
         listOf(JWSAlgorithm.EdDSA, JWSAlgorithm.Ed25519)
             .forEach {
-                val exception = assertThrows<IllegalArgumentException> { create(it, ed25519Signer) }
-                assertEquals("Signature algorithm must be one of [ES256, ES384, ES512]", exception.message)
+                create(it, ed25519Signer)
             }
     }
-}
-
-private class KeyAttestationJWTBuilder(signatureAlgorithm: JWSAlgorithm) {
-    private val header = JWSHeader.Builder(signatureAlgorithm)
-    private val claimsSet = JWTClaimsSet.Builder()
-
-    fun typ(typ: JOSEObjectType): KeyAttestationJWTBuilder = apply {
-        header.type(typ)
-    }
-
-    fun iat(iat: Instant): KeyAttestationJWTBuilder = apply {
-        claimsSet.issueTime(Date.from(iat))
-    }
-
-    fun exp(exp: Instant): KeyAttestationJWTBuilder = apply {
-        claimsSet.expirationTime(Date.from(exp))
-    }
-
-    fun attestedKeys(attestedKeys: List<JWK>): KeyAttestationJWTBuilder = apply {
-        claimsSet.claim(OpenId4VCISpec.ATTESTED_KEYS, attestedKeys.map { it.toJSONObject() })
-    }
-
-    fun keyStorage(keyStorage: List<AttackPotentialResistance>): KeyAttestationJWTBuilder = apply {
-        claimsSet.claim(OpenId4VCISpec.KEY_STORAGE, keyStorage.map { it.value })
-    }
-
-    fun userAuthentication(userAuthentication: List<AttackPotentialResistance>): KeyAttestationJWTBuilder = apply {
-        claimsSet.claim(OpenId4VCISpec.USER_AUTHENTICATION, userAuthentication.map { it.value })
-    }
-
-    fun certification(certification: URL): KeyAttestationJWTBuilder = apply {
-        claimsSet.claim(OpenId4VCISpec.CERTIFICATION, certification.toExternalForm())
-    }
-
-    fun nonce(nonce: Nonce): KeyAttestationJWTBuilder = apply {
-        claimsSet.claim(OpenId4VCISpec.NONCE, nonce.value)
-    }
-
-    fun status(status: StatusClaim): KeyAttestationJWTBuilder = apply {
-        claimsSet.claim(TokenStatusListSpec.STATUS, JSONObjectUtils.parse(JsonSupport.encodeToString(status)))
-    }
-
-    fun keyStorageStatus(keyStorageStatus: KeyStorageStatus): KeyAttestationJWTBuilder = apply {
-        claimsSet.claim(TS3.KEY_STORAGE_STATUS, JSONObjectUtils.parse(JsonSupport.encodeToString(keyStorageStatus)))
-    }
-
-    fun build(): SignedJWT = SignedJWT(header.build(), claimsSet.build())
 }


### PR DESCRIPTION
This PR:

1. Relaxes parsing of Key Attestation JWT
    1. Removes the check that it is signed with a JWSAlgorithm specified in TS3
    2. Removes the checks that its payload is aligned with TS3
2. Requires the presence of `attested_key` claim only in the payload

`KeyAttestationJWTClaims` is still present in the codebase and fully aligned with TS3, to allow users to easily deserialize the payload of a TS3 aligned Key Attestation JWT. LoA checks have also been removed.

Closes #572 