### PR TITLE
Fix 579

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/AuthorizeIssuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/AuthorizeIssuance.kt
@@ -115,15 +115,16 @@ interface AuthorizeIssuance {
      * [AuthorizedRequest] state.
      *
      * @param authorizationCode The authorization code returned from authorization server via front-channel
-     * @param serverState The state returned from authorization server via front-channel
+     * @param serverState The state returned from the authorization server via front-channel
      * @param authDetailsOption Defines if upon access token request extra authorization details will be set to fine grain the
      * scope of the access token.
-     * @return an issuance request in authorized state
+     * @return an issuance request in an authorized state
      */
     suspend fun AuthorizationRequestPrepared.authorizeWithAuthorizationCode(
         authorizationCode: AuthorizationCode,
         serverState: String,
         authDetailsOption: AccessTokenOption = AccessTokenOption.AsRequested,
+        issuer: String? = null,
     ): Result<AuthorizedRequest>
 
     /**

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/AuthorizeIssuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/AuthorizeIssuance.kt
@@ -116,8 +116,10 @@ interface AuthorizeIssuance {
      *
      * @param authorizationCode The authorization code returned from authorization server via front-channel
      * @param serverState The state returned from the authorization server via front-channel
-     * @param authDetailsOption Defines if upon access token request extra authorization details will be set to fine grain the
-     * scope of the access token.
+     * @param authDetailsOption Defines if upon access token request extra authorization details will be set to fine grain the scope of the access token.
+     * @param issuer The issuer of the access token, as provided to the redirection URI (the last step of authorization code grant) via parameter `iss`.
+     * It is optional and can be omited (defaulting to `null`) in case of Pre-Authorized Code Flow or if [OpenId4VCIConfig.authResponseIssChecking] is
+     * set to [AuthorizationResponseIssChecking.Never].
      * @return an issuance request in an authorized state
      */
     suspend fun AuthorizationRequestPrepared.authorizeWithAuthorizationCode(

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
@@ -142,6 +142,9 @@ fun interface RegistrationCertificatePolicy {
  * @param issuerMetadataPolicy policy concerning signed metadata usage
  * @param supportedCredentialReusePolicies the reuse policies supported by the wallet, used to validate against credential issuer metadata.
  * @param proofs proofs supported by the Wallet
+ * @param authResponseIssChecking Wallet's policy concerning the validation of the `iss` parameter
+ * present in the authorization response, as described by the Authorization Server metadata field
+ * `authorization_response_iss_parameter_supported`
  */
 data class OpenId4VCIConfig(
     val clientAuthentication: ClientAuthentication,
@@ -155,6 +158,7 @@ data class OpenId4VCIConfig(
     val supportedCredentialReusePolicies: CredentialReusePolicies? = null,
     val proofs: ProofsConfig = ProofsConfig.Default,
     val registrationCertificatePolicy: RegistrationCertificatePolicy? = null,
+    val authResponseIssChecking: AuthorizationResponseIssChecking = AuthorizationResponseIssChecking.Never,
 ) {
 
     init {
@@ -184,18 +188,20 @@ data class OpenId4VCIConfig(
         supportedCredentialReusePolicies: CredentialReusePolicies? = null,
         proofs: ProofsConfig = ProofsConfig.Default,
         registrationCertificatePolicy: RegistrationCertificatePolicy? = null,
+        authResponseIssChecking: AuthorizationResponseIssChecking = AuthorizationResponseIssChecking.Never,
     ) : this(
-        ClientAuthentication.None(clientId),
-        authFlowRedirectionURI,
-        encryptionSupportConfig,
-        authorizeIssuanceConfig,
-        dPoPUsage,
-        parUsage,
-        clock,
-        issuerMetadataPolicy,
-        supportedCredentialReusePolicies,
-        proofs,
-        registrationCertificatePolicy,
+        clientAuthentication = ClientAuthentication.None(clientId),
+        authFlowRedirectionURI = authFlowRedirectionURI,
+        encryptionSupportConfig = encryptionSupportConfig,
+        authorizeIssuanceConfig = authorizeIssuanceConfig,
+        dPoPUsage = dPoPUsage,
+        parUsage = parUsage,
+        clock = clock,
+        issuerMetadataPolicy = issuerMetadataPolicy,
+        supportedCredentialReusePolicies = supportedCredentialReusePolicies,
+        proofs = proofs,
+        registrationCertificatePolicy = registrationCertificatePolicy,
+        authResponseIssChecking = authResponseIssChecking,
     )
 }
 
@@ -268,6 +274,46 @@ sealed interface ParUsage : java.io.Serializable {
     data class IfSupported(val authorizationCodeDPoPBinding: Boolean = true) : ParUsage
 
     data class Required(val authorizationCodeDPoPBinding: Boolean = true) : ParUsage
+}
+
+/**
+ * Wallet's policy in regard to validating the `iss` parameter present in the authorization response,
+ * as described by the Authorization Server metadata field `authorization_response_iss_parameter_supported`.
+ *
+ * The `iss` parameter is used to mitigate mix-up attacks, by allowing the Wallet to verify that the
+ * authorization response was issued by the expected Authorization Server.
+ *
+ * - [Never]: The Wallet never validates the `iss` parameter of the authorization response.
+ * - [IfSupported]: The Wallet validates the `iss` parameter only when the Authorization Server
+ *   advertises support for it (i.e. `authorization_response_iss_parameter_supported` is `true`).
+ * - [Required]: The Wallet requires the Authorization Server to support the `iss` parameter. If the
+ *   Authorization Server does not advertise support for it, issuance fails. Otherwise, the `iss`
+ *   parameter is validated.
+ */
+sealed interface AuthorizationResponseIssChecking : java.io.Serializable {
+
+    /**
+     * The Wallet never validates the `iss` parameter of the authorization response.
+     */
+    data object Never : AuthorizationResponseIssChecking {
+        private fun readResolve(): Any = Never
+    }
+
+    /**
+     * The Wallet validates the `iss` parameter only when the Authorization Server
+     * advertises support for it.
+     */
+    data object IfSupported : AuthorizationResponseIssChecking {
+        private fun readResolve(): Any = IfSupported
+    }
+
+    /**
+     * The Wallet requires the Authorization Server to support the `iss` parameter.
+     * If the Authorization Server does not advertise support, issuance fails.
+     */
+    data object Required : AuthorizationResponseIssChecking {
+        private fun readResolve(): Any = Required
+    }
 }
 
 /**

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
@@ -38,7 +38,7 @@ sealed interface Credential {
 }
 
 /**
- *  Credential was issued from server and the result is returned inline.
+ *  Credential was issued from the server and the result is returned inline.
  *
  * @param credential The issued credential.
  * @param additionalInfo Optional, information returned by the issuer for the [credential]
@@ -68,7 +68,7 @@ sealed interface SubmissionOutcome : java.io.Serializable {
      * If it was a single issuance request list will contain only one result.
      *
      * @param credentials The credentials issued
-     * @param notificationId The identifier to be used in issuer's notification endpoint.
+     * @param notificationId The identifier to be used in the issuer's notification endpoint.
      * @param selectedCredentialReusePolicy The supported credential reuse policy option selected by the wallet
      * for this issuance, if any.
      */
@@ -83,8 +83,8 @@ sealed interface SubmissionOutcome : java.io.Serializable {
     }
 
     /**
-     * Credential could not be issued immediately. An identifier is returned from server to be used later on
-     * to request the credential from issuer's Deferred Credential Endpoint.
+     * Credential could not be issued immediately. An identifier is returned from the server to be used later on
+     * to request the credential from the issuer's Deferred Credential Endpoint.
      *
      * @param transactionId  A string identifying a Deferred Issuance transaction.
      * @param interval Represents the minimum amount of time before sending a new deferred issuance request.
@@ -105,7 +105,7 @@ sealed interface SubmissionOutcome : java.io.Serializable {
 
 /**
  * Sealed interface to model the payload of an issuance request. Issuance can be requested by providing the credential configuration
- * identifier and a claim set ot by providing a credential identifier retrieved from token endpoint while authorizing an issuance request.
+ * identifier and a claim set ot by providing a credential identifier retrieved from a token endpoint while authorizing an issuance request.
  */
 sealed interface IssuanceRequestPayload {
 
@@ -123,7 +123,7 @@ sealed interface IssuanceRequestPayload {
     ) : IssuanceRequestPayload
 
     /**
-     * Credential configuration based request payload.
+     * Credential configuration based on request payload.
      *
      * @param credentialConfigurationIdentifier The credential configuration identifier
      */
@@ -161,7 +161,7 @@ fun interface RequestIssuance {
      *
      * @param requestPayload the payload of the request
      * @param proofSpecification the specification of proofs to be included in the request
-     * @return the possibly updated [AuthorizedRequest] (if updated it will contain a fresh updated Resource-Server DPoP Nonce)
+     * @return the possibly updated [AuthorizedRequest] (if updated, it will contain a fresh updated Resource-Server DPoP Nonce)
      * and the [SubmissionOutcome]
      */
     suspend fun AuthorizedRequest.request(
@@ -172,7 +172,7 @@ fun interface RequestIssuance {
 
 /**
  * A factory method that based on the issuer's supported encryption and the wallet's configuration creates the encryption specification
- * that the wallet expects in the response of its issuance request.
+ * that the wallet expects in the response to its issuance request.
  */
 fun interface ResponseEncryptionSpecFactory {
 
@@ -189,12 +189,12 @@ fun interface ResponseEncryptionSpecFactory {
                     PayloadCompression.NotSupported -> null
                     is PayloadCompression.Supported ->
                         walletEncryptionSupportConfig.compressionAlgorithms?.intersect(
-                            issuerSupportedPayloadCompression.algorithms,
+                            issuerSupportedPayloadCompression.algorithms.toSet(),
                         )?.firstOrNull()
                 }
 
                 val encryptionMethod = issuerSupportedResponseEncryptedParameters.encryptionMethods
-                    .intersect(walletEncryptionSupportConfig.supportedEncryptionMethods).firstOrNull()
+                    .intersect(walletEncryptionSupportConfig.supportedEncryptionMethods.toSet()).firstOrNull()
                 encryptionMethod?.let { method ->
                     issuerSupportedResponseEncryptedParameters.algorithms.firstNotNullOfOrNull { algorithm ->
                         KeyGenerator.genKeyIfSupported(walletEncryptionSupportConfig, algorithm)
@@ -220,13 +220,15 @@ fun interface RequestEncryptionSpecFactory {
                 val compressionAlg = when (issuerSupportedPayloadCompression) {
                     PayloadCompression.NotSupported -> null
                     is PayloadCompression.Supported ->
-                        walletSupportedCompressionAlgs?.intersect(issuerSupportedPayloadCompression.algorithms)?.firstOrNull()
+                        walletSupportedCompressionAlgs?.intersect(issuerSupportedPayloadCompression.algorithms.toSet())?.firstOrNull()
                 }
 
                 val walletSupportedEncryptionAlgorithms = walletEncryptionSupportConfig.supportedEncryptionAlgorithms
                 val walletSupportedEncryptionMethods = walletEncryptionSupportConfig.supportedEncryptionMethods
                 val encryptionMethod =
-                    issuerSupportedRequestEncryptionParameters.encryptionMethods.intersect(walletSupportedEncryptionMethods).firstOrNull()
+                    issuerSupportedRequestEncryptionParameters.encryptionMethods.intersect(
+                        walletSupportedEncryptionMethods.toSet(),
+                    ).firstOrNull()
                 encryptionMethod?.let { method ->
                     issuerSupportedRequestEncryptionParameters.encryptionKeys.keys
                         .filter { it.algorithm in walletSupportedEncryptionAlgorithms }
@@ -248,6 +250,28 @@ sealed class CredentialIssuanceError(message: String) : Throwable(message) {
     class InvalidAuthorizationState : CredentialIssuanceError("InvalidAuthorizationState")
 
     /**
+     * Indicates that the `iss` parameter returned by the authorization server in the authorization
+     * response doesn't match the issuer included in the authorization server metadata, during
+     * authorization code flow
+     */
+    class InvalidAuthorizationIssuer : CredentialIssuanceError("InvalidAuthorizationIssuer")
+
+    /**
+     * Indicates that the `iss` parameter was expected in the authorization response (because the
+     * authorization server advertises support for it, or the Wallet requires it), but it was missing
+     */
+    class MissingAuthorizationResponseIssuer :
+        CredentialIssuanceError("MissingAuthorizationResponseIssuer")
+
+    /**
+     * Indicates that the Wallet requires the authorization server to support the `iss` parameter in
+     * the authorization response (via `authorization_response_iss_parameter_supported`), but the
+     * authorization server does not advertise support for it
+     */
+    class AuthorizationResponseIssuerParamNotSupported :
+        CredentialIssuanceError("AuthorizationResponseIssuerParamNotSupported")
+
+    /**
      * Failure when placing Pushed Authorization Request to Authorization Server
      */
     data class PushedAuthorizationRequestFailed(
@@ -256,7 +280,7 @@ sealed class CredentialIssuanceError(message: String) : Throwable(message) {
     ) : CredentialIssuanceError("$error+${errorDescription?.let { " description=$it" }}")
 
     /**
-     * Failure when requesting access token from Authorization Server
+     * Failure when requesting an access token from the Authorization Server
      */
     data class AccessTokenRequestFailed(
         val error: String,
@@ -266,6 +290,7 @@ sealed class CredentialIssuanceError(message: String) : Throwable(message) {
     /**
      * Failure when creating an issuance request
      */
+    @Deprecated("This error is not used anymore")
     class InvalidIssuanceRequest(
         message: String,
     ) : CredentialIssuanceError(message)
@@ -283,6 +308,7 @@ sealed class CredentialIssuanceError(message: String) : Throwable(message) {
      * It is marked as irrecoverable because it is raised only after the library
      * has automatically retried to recover from an [InvalidProof] error and failed
      */
+    @Deprecated("This error is not used anymore")
     data class IrrecoverableInvalidProof(val errorDescription: String? = null) :
         CredentialIssuanceError("Irrecoverable invalid proof ")
 
@@ -292,7 +318,7 @@ sealed class CredentialIssuanceError(message: String) : Throwable(message) {
     class InvalidToken : CredentialIssuanceError("InvalidToken")
 
     /**
-     * Invalid transaction id passed to issuance server in the context of deferred credential requests
+     * Invalid transaction id passed to the issuance server in the context of deferred credential requests
      */
     class InvalidTransactionId : CredentialIssuanceError("InvalidTransactionId")
 
@@ -305,12 +331,12 @@ sealed class CredentialIssuanceError(message: String) : Throwable(message) {
     ) : CredentialIssuanceError("UnexpectedTransactionId")
 
     /**
-     *  Requested Credential Configuration is unknown to issuance server
+     *  Requested Credential Configuration is unknown to the issuance server
      */
     class UnknownCredentialConfiguration : CredentialIssuanceError("UnknownCredentialConfiguration")
 
     /**
-     * Requested Credential identifier is unknown to issuance server
+     * Requested Credential identifier is unknown to the issuance server
      */
     class UnknownCredentialIdentifier : CredentialIssuanceError("UnknownCredentialIdentifier")
 
@@ -367,12 +393,12 @@ sealed class CredentialIssuanceError(message: String) : Throwable(message) {
     sealed class ProofGenerationError(message: String) : CredentialIssuanceError(message) {
 
         /**
-         * Proof type provided for specific credential is not supported from issuance server
+         * Proof type provided for a specific credential is not supported from the issuance server
          */
         class ProofTypeNotSupported : ProofGenerationError("ProofTypeNotSupported")
 
         /**
-         * Proof type signing algorithm provided for specific credential is not supported from issuance server
+         * Proof type signing algorithm provided for specific credential is not supported from the issuance server
          */
         class ProofTypeSigningAlgorithmNotSupported :
             ProofGenerationError("ProofTypeSigningAlgorithmNotSupported")
@@ -414,25 +440,25 @@ sealed class CredentialIssuanceError(message: String) : Throwable(message) {
             ResponseEncryptionError("ResponseEncryptionRequiredByWalletButNotSupportedByIssuer")
 
         /**
-         * Response encryption key does not specify 'alg' attribute
+         * Response encryption key does not specify the 'alg' attribute
          */
         class ResponseEncryptionKeyDoesNotSpecifyAlgorithm :
             ResponseEncryptionError("ResponseEncryptionKeyDoesNotSpecifyAlgorithm")
 
         /**
-         * Response encryption algorithm specified in request is not supported from issuance server
+         * Response encryption algorithm specified in the request is not supported from the issuance server
          */
         class ResponseEncryptionAlgorithmNotSupportedByIssuer :
             ResponseEncryptionError("ResponseEncryptionAlgorithmNotSupportedByIssuer")
 
         /**
-         * Response encryption method specified in request is not supported from issuance server
+         * Response encryption method specified in the request is not supported from the issuance server
          */
         class ResponseEncryptionMethodNotSupportedByIssuer :
             ResponseEncryptionError("ResponseEncryptionMethodNotSupportedByIssuer")
 
         /**
-         * Issuer enforces encrypted responses but encryption parameters not provided in request
+         * Issuer enforces encrypted responses, but encryption parameters not provided in request
          */
         class IssuerExpectsResponseEncryptionCryptoMaterialButNotProvided :
             ResponseEncryptionError("IssuerExpectsResponseEncryptionCryptoMaterialButNotProvided")
@@ -456,7 +482,7 @@ sealed class CredentialIssuanceError(message: String) : Throwable(message) {
             ResponseEncryptionError("IssuerDoesNotSupportEncryptedPayloadCompressionAlgorithm")
 
         /**
-         * Response encryption specification is available but no request specification could be created.
+         * Response encryption specification is available, but no request specification could be created.
          */
         class MissingRequiredRequestEncryptionSpecification :
             ResponseEncryptionError("MissingRequiredRequestEncryptionSpecification")

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/AuthorizeIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/AuthorizeIssuanceImpl.kt
@@ -18,10 +18,14 @@ package eu.europa.ec.eudi.openid4vci.internal
 import eu.europa.ec.eudi.openid4vci.*
 import eu.europa.ec.eudi.openid4vci.AccessTokenOption.AsRequested
 import eu.europa.ec.eudi.openid4vci.AccessTokenOption.Limited
+import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.AuthorizationResponseIssuerParamNotSupported
+import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.InvalidAuthorizationIssuer
 import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.InvalidAuthorizationState
+import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.MissingAuthorizationResponseIssuer
 import eu.europa.ec.eudi.openid4vci.internal.http.AuthorizationEndpointClient
 import eu.europa.ec.eudi.openid4vci.internal.http.TokenEndpointClient
 import java.time.Instant
+import com.nimbusds.oauth2.sdk.id.Issuer as NimbusIssuer
 import com.nimbusds.oauth2.sdk.id.State as NimbusState
 
 internal data class TokenResponse(
@@ -84,8 +88,40 @@ internal class AuthorizeIssuanceImpl(
         authorizationCode: AuthorizationCode,
         serverState: String,
         authDetailsOption: AccessTokenOption,
+        issuer: String?,
     ): Result<AuthorizedRequest> = runCatchingCancellable {
         ensure(serverState == state) { InvalidAuthorizationState() }
+        validateAuthorizationResponseIssuer(issuer)
+        requestAccessToken(authorizationCode, authDetailsOption)
+    }
+
+    private fun validateAuthorizationResponseIssuer(iss: String?) {
+        val metadata = credentialOffer.authorizationServerMetadata
+        when (config.authResponseIssChecking) {
+            AuthorizationResponseIssChecking.Never -> Unit
+
+            AuthorizationResponseIssChecking.IfSupported ->
+                if (metadata.supportsAuthorizationResponseIssuerParam()) {
+                    ensure(!iss.isNullOrEmpty()) { MissingAuthorizationResponseIssuer() }
+                    ensure(issuerMatches(iss, metadata.issuer)) { InvalidAuthorizationIssuer() }
+                }
+
+            AuthorizationResponseIssChecking.Required -> {
+                ensure(metadata.supportsAuthorizationResponseIssuerParam()) {
+                    AuthorizationResponseIssuerParamNotSupported()
+                }
+                ensure(!iss.isNullOrEmpty()) { MissingAuthorizationResponseIssuer() }
+                ensure(issuerMatches(iss, metadata.issuer)) { InvalidAuthorizationIssuer() }
+            }
+        }
+    }
+
+    private fun issuerMatches(iss: String, expected: NimbusIssuer): Boolean = iss == expected.value
+
+    private suspend fun AuthorizationRequestPrepared.requestAccessToken(
+        authorizationCode: AuthorizationCode,
+        authDetailsOption: AccessTokenOption,
+    ): AuthorizedRequest {
         val credConfigIdsAsAuthDetails = identifiersSentAsAuthDetails.filter(authDetailsOption)
         val (tokenResponse, newDpopNonce) =
             tokenEndpointClient.requestAccessTokenAuthFlow(
@@ -95,7 +131,7 @@ internal class AuthorizeIssuanceImpl(
                 dpopNonce,
             ).getOrThrow()
 
-        AuthorizedRequest(
+        return AuthorizedRequest(
             accessToken = tokenResponse.accessToken,
             refreshToken = tokenResponse.refreshToken,
             credentialIdentifiers = tokenResponse.authorizationDetails,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialOfferRequestResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialOfferRequestResolver.kt
@@ -16,6 +16,7 @@
 package eu.europa.ec.eudi.openid4vci.internal
 
 import eu.europa.ec.eudi.openid4vci.*
+import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.AuthorizationResponseIssuerParamNotSupported
 import eu.europa.ec.eudi.openid4vci.CredentialOfferRequestError.UnableToResolveAuthorizationServerMetadata
 import eu.europa.ec.eudi.openid4vci.CredentialOfferRequestError.UnableToResolveCredentialIssuerMetadata
 import io.ktor.client.*
@@ -106,13 +107,19 @@ internal class CredentialOfferRequestResolver(
             val grants = credentialOffer.grants?.toGrants(credentialIssuerMetadata)
             val authorizationServer = grants?.authServer() ?: credentialIssuerMetadata.authorizationServers[0]
             val authorizationServerMetadata = fetchAuthServerMetaData(authorizationServer)
-            if (grants is Grants.AuthorizationCode) {
+            val authorizationCodeGrant = grants?.authorizationCode()
+            if (authorizationCodeGrant != null) {
                 ensureNotNull(authorizationServerMetadata.authorizationEndpointURI) {
                     val error =
                         IllegalArgumentException(
                             "Credential Offer requires Authorization Code Grant, but the Authorization Server does not support it",
                         )
                     CredentialOfferRequestValidationError.InvalidGrants(error).toException()
+                }
+                if (config.authResponseIssChecking is AuthorizationResponseIssChecking.Required) {
+                    ensure(authorizationServerMetadata.supportsAuthorizationResponseIssuerParam()) {
+                        AuthorizationResponseIssuerParamNotSupported()
+                    }
                 }
             }
 

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/AuthorizationResponseIssCheckerTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/AuthorizationResponseIssCheckerTest.kt
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2023-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.openid4vci
+
+import com.nimbusds.jose.jwk.Curve
+import io.ktor.client.*
+import io.ktor.client.engine.mock.*
+import io.ktor.http.*
+import kotlinx.coroutines.test.runTest
+import parPostApplyAssertionsAndGetFormData
+import tokenPostApplyAuthFlowAssertionsAndGetFormData
+import java.net.URI
+import java.util.*
+import kotlin.test.*
+
+class AuthorizationResponseIssCheckerTest {
+
+    private val validIss = "https://auth-server.example.com"
+    private val invalidIss = "https://evil.example.com/realms/pid-issuer-realm"
+
+    private fun config(authResponseIssChecking: AuthorizationResponseIssChecking): OpenId4VCIConfig =
+        OpenId4VCIConfig(
+            clientAuthentication = ClientAuthentication.None("MyWallet_ClientId"),
+            authFlowRedirectionURI = URI.create("eudi-wallet//auth"),
+            encryptionSupportConfig = EncryptionSupportConfig(
+                Curve.P_256,
+                2048,
+                CredentialResponseEncryptionPolicy.SUPPORTED,
+            ),
+            proofs = ProofsConfig.Default,
+            authResponseIssChecking = authResponseIssChecking,
+        )
+
+    private suspend fun issuerWith(
+        config: OpenId4VCIConfig,
+        mockedHttpClient: HttpClient,
+        credentialOfferStr: String = CredentialOfferMixedDocTypes_NO_GRANTS,
+    ): Issuer = Issuer.make(
+        config = config,
+        credentialOfferUri = "openid-credential-offer://?credential_offer=$credentialOfferStr",
+        httpClient = mockedHttpClient,
+    ).getIssuerOrThrow()
+
+    @Test
+    fun `IfSupported - valid iss succeeds`() = runTest {
+        val mockedHttpClient = mockedHttpClient(
+            credentialIssuerMetadataWellKnownMocker(),
+            authServerWellKnownMocker(),
+            parPostMocker { with(it) { parPostApplyAssertionsAndGetFormData(false) } },
+            tokenPostMocker { request -> with(request) { tokenPostApplyAuthFlowAssertionsAndGetFormData() } },
+        )
+        val issuer = issuerWith(config(AuthorizationResponseIssChecking.IfSupported), mockedHttpClient)
+        with(issuer) {
+            val authRequestPrepared = prepareAuthorizationRequest().getOrThrow()
+            val code = UUID.randomUUID().toString()
+            authRequestPrepared
+                .authorizeWithAuthorizationCode(AuthorizationCode(code), authRequestPrepared.state, issuer = validIss)
+                .getOrThrow()
+        }
+    }
+
+    @Test
+    fun `IfSupported - mismatched iss fails`() = runTest {
+        val mockedHttpClient = mockedHttpClient(
+            credentialIssuerMetadataWellKnownMocker(),
+            authServerWellKnownMocker(),
+            parPostMocker { with(it) { parPostApplyAssertionsAndGetFormData(false) } },
+            tokenPostMocker { request -> with(request) { tokenPostApplyAuthFlowAssertionsAndGetFormData() } },
+        )
+        val issuer = issuerWith(config(AuthorizationResponseIssChecking.IfSupported), mockedHttpClient)
+        with(issuer) {
+            val authRequestPrepared = prepareAuthorizationRequest().getOrThrow()
+            val code = UUID.randomUUID().toString()
+            authRequestPrepared
+                .authorizeWithAuthorizationCode(AuthorizationCode(code), authRequestPrepared.state, issuer = invalidIss)
+                .fold(
+                    onSuccess = { fail("Expected failure due to mismatched iss") },
+                    onFailure = {
+                        assertTrue(
+                            it is CredentialIssuanceError.InvalidAuthorizationIssuer,
+                            "Expected InvalidAuthorizationIssuer but was $it",
+                        )
+                    },
+                )
+        }
+    }
+
+    @Test
+    fun `IfSupported - missing iss when supported fails`() = runTest {
+        val mockedHttpClient = mockedHttpClient(
+            credentialIssuerMetadataWellKnownMocker(),
+            authServerWellKnownMocker(),
+            parPostMocker { with(it) { parPostApplyAssertionsAndGetFormData(false) } },
+            tokenPostMocker { request -> with(request) { tokenPostApplyAuthFlowAssertionsAndGetFormData() } },
+        )
+        val issuer = issuerWith(config(AuthorizationResponseIssChecking.IfSupported), mockedHttpClient)
+        with(issuer) {
+            val authRequestPrepared = prepareAuthorizationRequest().getOrThrow()
+            val code = UUID.randomUUID().toString()
+            authRequestPrepared
+                .authorizeWithAuthorizationCode(AuthorizationCode(code), authRequestPrepared.state)
+                .fold(
+                    onSuccess = { fail("Expected failure due to missing iss") },
+                    onFailure = {
+                        assertTrue(
+                            it is CredentialIssuanceError.MissingAuthorizationResponseIssuer,
+                            "Expected MissingAuthorizationResponseIssuer but was $it",
+                        )
+                    },
+                )
+        }
+    }
+
+    @Test
+    fun `Never - missing iss succeeds (no check)`() = runTest {
+        val mockedHttpClient = mockedHttpClient(
+            credentialIssuerMetadataWellKnownMocker(),
+            authServerWellKnownMocker(),
+            parPostMocker { with(it) { parPostApplyAssertionsAndGetFormData(false) } },
+            tokenPostMocker { request -> with(request) { tokenPostApplyAuthFlowAssertionsAndGetFormData() } },
+        )
+        val issuer = issuerWith(config(AuthorizationResponseIssChecking.Never), mockedHttpClient)
+        with(issuer) {
+            val authRequestPrepared = prepareAuthorizationRequest().getOrThrow()
+            val code = UUID.randomUUID().toString()
+            authRequestPrepared
+                .authorizeWithAuthorizationCode(AuthorizationCode(code), authRequestPrepared.state)
+                .getOrThrow()
+        }
+    }
+
+    @Test
+    fun `Required - valid iss succeeds`() = runTest {
+        val mockedHttpClient = mockedHttpClient(
+            credentialIssuerMetadataWellKnownMocker(),
+            authServerWellKnownMocker(),
+            parPostMocker { with(it) { parPostApplyAssertionsAndGetFormData(false) } },
+            tokenPostMocker { request -> with(request) { tokenPostApplyAuthFlowAssertionsAndGetFormData() } },
+        )
+        val issuer = issuerWith(config(AuthorizationResponseIssChecking.Required), mockedHttpClient)
+        with(issuer) {
+            val authRequestPrepared = prepareAuthorizationRequest().getOrThrow()
+            val code = UUID.randomUUID().toString()
+            authRequestPrepared
+                .authorizeWithAuthorizationCode(AuthorizationCode(code), authRequestPrepared.state, issuer = validIss)
+                .getOrThrow()
+        }
+    }
+
+    @Test
+    fun `Required - missing iss fails`() = runTest {
+        val mockedHttpClient = mockedHttpClient(
+            credentialIssuerMetadataWellKnownMocker(),
+            authServerWellKnownMocker(),
+            parPostMocker { with(it) { parPostApplyAssertionsAndGetFormData(false) } },
+            tokenPostMocker { request -> with(request) { tokenPostApplyAuthFlowAssertionsAndGetFormData() } },
+        )
+        val issuer = issuerWith(config(AuthorizationResponseIssChecking.Required), mockedHttpClient)
+        with(issuer) {
+            val authRequestPrepared = prepareAuthorizationRequest().getOrThrow()
+            val code = UUID.randomUUID().toString()
+            authRequestPrepared
+                .authorizeWithAuthorizationCode(AuthorizationCode(code), authRequestPrepared.state)
+                .fold(
+                    onSuccess = { fail("Expected failure due to missing iss") },
+                    onFailure = {
+                        assertTrue(
+                            it is CredentialIssuanceError.MissingAuthorizationResponseIssuer,
+                            "Expected MissingAuthorizationResponseIssuer but was $it",
+                        )
+                    },
+                )
+        }
+    }
+
+    @Test
+    fun `Required - AS does not support iss param fails`() = runTest {
+        val mockedHttpClient = mockedHttpClient(
+            credentialIssuerMetadataWellKnownMocker(),
+            authServerWellKnownMockerWithoutIssParam(),
+            parPostMocker { with(it) { parPostApplyAssertionsAndGetFormData(false) } },
+            tokenPostMocker { request -> with(request) { tokenPostApplyAuthFlowAssertionsAndGetFormData() } },
+        )
+        val issuer = issuerWith(config(AuthorizationResponseIssChecking.Required), mockedHttpClient)
+        with(issuer) {
+            val authRequestPrepared = prepareAuthorizationRequest().getOrThrow()
+            val code = UUID.randomUUID().toString()
+            authRequestPrepared
+                .authorizeWithAuthorizationCode(AuthorizationCode(code), authRequestPrepared.state, issuer = validIss)
+                .fold(
+                    onSuccess = { fail("Expected failure because AS does not support iss param") },
+                    onFailure = {
+                        assertTrue(
+                            it is CredentialIssuanceError.AuthorizationResponseIssuerParamNotSupported,
+                            "Expected AuthorizationResponseIssuerParamNotSupported but was $it",
+                        )
+                    },
+                )
+        }
+    }
+
+    private fun authServerWellKnownMockerWithoutIssParam(): RequestMocker =
+        RequestMocker(
+            requestMatcher = { request ->
+                request.url.encodedPath.contains("/.well-known/oauth-authorization-server") && request.method == HttpMethod.Get
+            },
+            responseBuilder = {
+                val content = getResourceAsText("well-known/openid-configuration.json")
+                    .replace(Regex("\"authorization_response_iss_parameter_supported\"\\s*:\\s*true\\s*,?\\s*"), "")
+                respond(
+                    content = content,
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType to listOf("application/json")),
+                )
+            },
+        )
+}


### PR DESCRIPTION
Closes #579 


The PR implements the check described in RFC9207 with regards to the `iss` parameter, as follows:

A new parameter is introduced to the `OpenId4VCIConfig`,  named `authResponseIssChecking`. 
This new parameter can have one of the following values: Never, IfSupported, Required, and allows the caller to opt-in for the RFC9207 of the `iss` parameter, in case of Authorization Code Grant.

If this parameter is set to `Required`, the library would check that the Auhorization Server of the Credential Issuer advertises to its metadata a value for `authorization_response_iss_parameter_supported` equal to true.

In addition, the `AuthorizeIssuance` interface and especially the method 

```kotlin
suspend fun AuthorizationRequestPrepared.authorizeWithAuthorizationCode(
        authorizationCode: AuthorizationCode,
        serverState: String,
        authDetailsOption: AccessTokenOption,
        issuer: String? = null
): Result<AuthorizedRequest>
```
has been updated with the additional parameter `issuer` to allow the caller to pass the `iss` parameter for the redirection URI

Dedicated errors have been introduced : 
- `InvalidAuthorizationIssuer` when the `iss` is not the expected
- `MissingAuthorizationResponseIssuer` when AS misbehaves and doesn't return an `iss` (but advertises that it authorization_response_iss_parameter_supported)
- `AuthorizationResponseIssuerParamNotSupported` in case we have an authorization grant, and the wallet requires the `iss` parameter but the AS doesn't support it.

The above changes do affect the public API, in a non-breaking manner.

To enforce the rule, the caller has to
1) Explicitly set the `authResponseIssChecking` to `IfSupported` or `Required`
2) Extract from the redirection URI the `iss` parameter and call the `authorizeWithAuthorizationCode()` with the `iss` parameter.

Otherwise, the library should behave as previously
