### PR TITLE
Re-introduce JWT Proofs without Key Attestation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,27 +28,27 @@ protocol, focusing on compliance with:
 
 In particular, the library focuses on the wallet's role in and provides the following features:
 
-| Feature                                                                                         | Coverage                                                                                                                                                                                                                                                                                    |
-|-------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [Wallet-initiated issuance](#wallet-initiated-issuance)                                         | ✅                                                                                                                                                                                                                                                                                          |
-| [Resolve a credential offer](#resolve-a-credential-offer)                                       | ✅ Unsigned metadata ✅ signed metadata ❌ [accept-language](#issuer-metadata-accept-language)                                                                                                                                                                                              |
-| [Authorization code flow](#authorization-code-flow)                                             | ✅                                                                                                                                                                                                                                                                                          |
-| [Pre-authorized code flow](#pre-authorized-code-flow)                                           | ✅                                                                                                                                                                                                                                                                                          |
-| mso_mdoc format                                                                                 | ✅                                                                                                                                                                                                                                                                                          |
-| SD-JWT-VC format                                                                                | ✅                                                                                                                                                                                                                                                                                          |
-| W3C VC DM                                                                                       | VC Signed as a JWT, Not Using JSON-LD                                                                                                                                                                                                                                                       |
-| [Place credential request](#place-credential-request)                                           | ✅ Including automatic handling of `invalid_proof`                                                                                                                                                                                                                                          |
-| [Query for deferred credentials](#query-for-deferred-credentials)                               | ✅ Including automatic refresh of `access_token`                                                                                                                                                                                                                                            |
-| [Query for deferred credentials at a later time](#query-for-deferred-credentials-at-later-time) | ✅ Including automatic refresh of `access_token`                                                                                                                                                                                                                                            |
-| [Notify credential issuer](#notify-credential-issuer)                                           | ✅                                                                                                                                                                                                                                                                                          | 
-| Proof                                                                                           | ✅ JWT with [Key Attestation](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-key-attestations) in JOSE Header (`key_attestation`), <br /> ✅ [Attestation](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-key-attestations) |
-| Credential request encryption                                                                   | ✅                                                                                                                                                                                                                                                                                          |
-| Credential response encryption                                                                  | ✅                                                                                                                                                                                                                                                                                          |
-| [Pushed authorization requests](#pushed-authorization-requests)                                 | ✅ Used by default, if supported by issuer                                                                                                                                                                                                                                                  |
-| [Demonstrating Proof of Possession (DPoP)](#demonstrating-proof-of-possession-dpop)             | ✅ Including Authorization Code binding when using Pushed Authorization Requests (enabled by default)                                                                                                                                                                                       |
-| [PKCE](#proof-key-for-code-exchange-by-oauth-public-clients-pkce)                               | ✅                                                                                                                                                                                                                                                                                          |
-| Wallet authentication                                                                           | ✅ public client, <br/>✅ [Attestation-Based Client Authentication](#oauth-20-attestation-based-client-authentication)                                                                                                                                                                      |
-| Use issuer's nonce endpoint to get c_nonce for proofs                                           | ✅                                                                                                                                                                                                                                                                                          |
+| Feature                                                                                         | Coverage                                                                                                                                                                                                                                                                                                                                                                                                    |
+|-------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [Wallet-initiated issuance](#wallet-initiated-issuance)                                         | ✅                                                                                                                                                                                                                                                                                                                                                                                                          |
+| [Resolve a credential offer](#resolve-a-credential-offer)                                       | ✅ Unsigned metadata ✅ signed metadata ❌ [accept-language](#issuer-metadata-accept-language)                                                                                                                                                                                                                                                                                                              |
+| [Authorization code flow](#authorization-code-flow)                                             | ✅                                                                                                                                                                                                                                                                                                                                                                                                          |
+| [Pre-authorized code flow](#pre-authorized-code-flow)                                           | ✅                                                                                                                                                                                                                                                                                                                                                                                                          |
+| mso_mdoc format                                                                                 | ✅                                                                                                                                                                                                                                                                                                                                                                                                          |
+| SD-JWT-VC format                                                                                | ✅                                                                                                                                                                                                                                                                                                                                                                                                          |
+| W3C VC DM                                                                                       | VC Signed as a JWT, Not Using JSON-LD                                                                                                                                                                                                                                                                                                                                                                       |
+| [Place credential request](#place-credential-request)                                           | ✅ Including automatic handling of `invalid_proof`                                                                                                                                                                                                                                                                                                                                                          |
+| [Query for deferred credentials](#query-for-deferred-credentials)                               | ✅ Including automatic refresh of `access_token`                                                                                                                                                                                                                                                                                                                                                            |
+| [Query for deferred credentials at a later time](#query-for-deferred-credentials-at-later-time) | ✅ Including automatic refresh of `access_token`                                                                                                                                                                                                                                                                                                                                                            |
+| [Notify credential issuer](#notify-credential-issuer)                                           | ✅                                                                                                                                                                                                                                                                                                                                                                                                          | 
+| Proof                                                                                           | ✅ [JWT](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-jwt-proof-type), <br /> ✅ JWT with [Key Attestation](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-key-attestations) in JOSE Header (`key_attestation`), <br /> ✅ [Attestation](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-key-attestations) |
+| Credential request encryption                                                                   | ✅                                                                                                                                                                                                                                                                                                                                                                                                          |
+| Credential response encryption                                                                  | ✅                                                                                                                                                                                                                                                                                                                                                                                                          |
+| [Pushed authorization requests](#pushed-authorization-requests)                                 | ✅ Used by default, if supported by issuer                                                                                                                                                                                                                                                                                                                                                                  |
+| [Demonstrating Proof of Possession (DPoP)](#demonstrating-proof-of-possession-dpop)             | ✅ Including Authorization Code binding when using Pushed Authorization Requests (enabled by default)                                                                                                                                                                                                                                                                                                       |
+| [PKCE](#proof-key-for-code-exchange-by-oauth-public-clients-pkce)                               | ✅                                                                                                                                                                                                                                                                                                                                                                                                          |
+| Wallet authentication                                                                           | ✅ public client, <br/>✅ [Attestation-Based Client Authentication](#oauth-20-attestation-based-client-authentication)                                                                                                                                                                                                                                                                                      |
+| Use issuer's nonce endpoint to get c_nonce for proofs                                           | ✅                                                                                                                                                                                                                                                                                                                                                                                                          |
 
 
 ## Disclaimer
@@ -391,7 +391,8 @@ import eu.europa.ec.eudi.openid4vci.*
 // Specifies the type of proof to be included in the credential issuance request.
 // This can be one of the following, depending on the credential issuer's requirements and the wallet's capabilities:
 // - ProofSpecification.NoProof: No proof is included in the request.
-// - ProofSpecification.JwtProof: JWT-based proof with key attestation, requires a Signer for KeyAttestationJWT; Signer must correspond to the first attested key of the KeyAttestationJWT per ETSI TS 119 472-3 V1.1.1.
+// - ProofSpecification.JwtProofsWithoutKeyAttestation: JWT-based proofs without key attestation, requires a BatchSigner for JwtBindingKey;
+// - ProofSpecification.JwtProofWithKeyAttestation: JWT-based proof with key attestation, requires a Signer for KeyAttestationJWT; Signer must correspond to the first attested key of the KeyAttestationJWT per ETSI TS 119 472-3 V1.1.1.
 // - ProofSpecification.AttestationProof: Uses a pre-generated KeyAttestationJWT as proof.
 val proofSpecification: ProofSpecification = ...
 
@@ -412,7 +413,13 @@ val (updatedAuthorizedRequest, outcome) =
 
 > [!TIP]
 > Provided that credential issuer supports batch issuance, to request the issuance of multiple instances of the credential, 
-> use a JWT-based proof or an Attestation proof that contains a KeyAttestationJWT with multiple attested keys. 
+> use:
+>
+> * multiple JWT-based proofs without Key Attestation
+> * a single JWT-based proof that contains a KeyAttestationJWT with multiple attested keys
+> * a single Attestation proof that contains a KeyAttestationJWT with multiple attested keys 
+>
+> When using JWT-based proof with Key Attestation or Attestation proof, the rules of ETSI TS 119 472-3 V1.1.1 apply.
 
 > [!NOTE]
 > 
@@ -652,8 +659,9 @@ val openId4VCIConfig = OpenId4VCIConfig(
     supportedCredentialReusePolicies = CredentialReusePolicies.Supported(setOf(EudiReusePolicyType.OnceOnly, EudiReusePolicyType.LimitedTime)), // which reuse methods are supported
     proofs = ProofsConfig(
         isNoProofSupported = true, // whether attestations that require no proofs are supported
-        jwtProof = ProofsConfig.SupportedJwtProof(setOf(JWSAlgorithm.ES256, JWSAlgorithm.ES384, JWSAlgorithm.ES512)), // whether jwt proofs are supported
-        attestationProof = ProofsConfig.SupportedAttestationProof(setOf(JWSAlgorithm.ES256, JWSAlgorithm.ES384, JWSAlgorithm.ES512)), // whether attestation proofs are supported
+        jwtProofWithKeyAttestation = ProofsConfig.SupportedJwtProof(setOf(JWSAlgorithm.ES256, JWSAlgorithm.ES384, JWSAlgorithm.ES512)), // whether jwt proofs with key attestation are supported
+        attestationProof = ProofsConfig.SupportedAttestationProof(setOf(JWSAlgorithm.ES256, JWSAlgorithm.ES384, JWSAlgorithm.ES512)), // whether attestation proofs are supported,
+        jwtProofsWithoutKeyAttestation = ProofsConfig.SupportedJwtProof(setOf(JWSAlgorithm.ES256, JWSAlgorithm.ES384, JWSAlgorithm.ES512)), // whether jwt proofs without key attestation are supported
     ),
     registrationCertificatePolicy = RegistrationCertificatePolicy { accessCertificate, registrationCertificate, issuanceContext -> ... },
     grants = SupportedGrants.Both,
@@ -705,11 +713,20 @@ otherwise it will fall back to a regular authorization request.
 
 ### Proof Types Supported
 
-The current version of the library supports JWT proofs that contain KeyAttestationJWTs and Attestation proofs.
+The current version of the library supports:
+
+* JWT proofs that don't contain KeyAttestationJWTs
+* JWT proofs that contain KeyAttestationJWTs 
+* Attestation proofs
 
 > [!IMPORTANT]
 >
-> Per ETSI TS 119 472-3 V1.1.1, Credential Requests may contain a single proof.
+> When using:
+>
+> * JWT proofs that contain KeyAttestationJWTs
+> * Attestation proofs
+> 
+> The rules of ETSI TS 119 472-3 V1.1.1 apply i.e., Credential Requests may contain a single proof.
 > 
 > The KeyAttestationJWT used in a JWT proof, or as an Attestation proof, must be a valid Key Attestation per ARF's Technical Specification 3.
 
@@ -784,10 +801,6 @@ Library will check that the authorization server of the issuer:
 Finally, library supports Client Attestation POP JWT [challenges](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-07.html#name-challenge-retrieval) using: 
 * either the Challenge Endpoint, if advertised by the authorization server in claim `challenge_endpoint` of its metadata
 * or the `OAuth-Client-Attestation-Challenge` HTTP Header
-
-> [!IMPORTANT]
->
-> The provisioned ClientAttestationJWT must be a valid Wallet Instance Attestation per ARF's Technical Specification 3
 
 ## Features not supported
 

--- a/README.md
+++ b/README.md
@@ -721,14 +721,21 @@ The current version of the library supports:
 
 > [!IMPORTANT]
 >
+> By default, the library enables support for the following Proof Types:
+>
+> * JWT proofs that contain KeyAttestationJWTs
+> * Attestation proofs
+> 
+> To enable support for JWT Proofs without Key Attestation, provide a properly configured `ProofsConfig` instance.
+
+> [!IMPORTANT]
+>
 > When using:
 >
 > * JWT proofs that contain KeyAttestationJWTs
 > * Attestation proofs
 > 
 > The rules of ETSI TS 119 472-3 V1.1.1 apply i.e., Credential Requests may contain a single proof.
-> 
-> The KeyAttestationJWT used in a JWT proof, or as an Attestation proof, must be a valid Key Attestation per ARF's Technical Specification 3.
 
 
 ### Demonstrating Proof of Possession (DPoP)

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
@@ -505,40 +505,52 @@ data class ProofsConfig(
      * Indicates support for JWT Proofs.
      *
      * @property supportedAlgorithms the signing algorithms supported by the Wallet
+     * @property keyAttestationRequired whether Key Attestations are required for JWT Proofs
      */
-    data class SupportedJwtProof(val supportedAlgorithms: Set<JWSAlgorithm>)
+    data class SupportedJwtProof(
+        val supportedAlgorithms: Set<JWSAlgorithm>,
+        val keyAttestationRequired: Boolean,
+    ) {
+        init {
+            require(supportedAlgorithms.isNotEmpty()) { "At least one supported algorithm must be provided." }
+        }
+    }
 
     /**
      * Indicates support for Attestation Proofs.
      *
      * @property supportedAlgorithms the signing algorithms supported by the Wallet
      */
-    data class SupportedAttestationProof(val supportedAlgorithms: Set<JWSAlgorithm>)
+    data class SupportedAttestationProof(val supportedAlgorithms: Set<JWSAlgorithm>) {
+        init {
+            require(supportedAlgorithms.isNotEmpty()) { "At least one supported algorithm must be provided." }
+        }
+    }
 
     companion object {
         /**
          * A [ProofsConfig] instance for Wallets that support issuance of attestations that require no proofs, and attestations that
-         * require either JWT Proofs or Attestation Proofs signed with either ES256, ES384, or ES512.
+         * require either JWT Proofs with Key Attestations or Attestation Proofs signed with either ES256, ES384, or ES512.
          */
         val Default: ProofsConfig
             get() {
                 val supportedAlgorithms = setOf(JWSAlgorithm.ES256, JWSAlgorithm.ES384, JWSAlgorithm.ES512)
                 return ProofsConfig(
                     true,
-                    SupportedJwtProof(supportedAlgorithms),
+                    SupportedJwtProof(supportedAlgorithms, true),
                     SupportedAttestationProof(supportedAlgorithms),
                 )
             }
 
         /**
-         * Creates a [ProofsConfig] instance for a Wallet that supports issueance of attestations that require
-         * either JWT Proofs or Attestation Proofs signed with one of the provided JWS Algorithms.
+         * Creates a [ProofsConfig] instance for a Wallet that supports issuance of attestations that require
+         * either JWT Proofs with Key Attestation, or Attestation Proofs signed with one of the provided JWS Algorithms.
          */
         operator fun invoke(first: JWSAlgorithm, vararg remaining: JWSAlgorithm): ProofsConfig {
             val supportedAlgorithms = setOf(first, *remaining)
             return ProofsConfig(
                 isNoProofSupported = false,
-                jwtProof = SupportedJwtProof(supportedAlgorithms),
+                jwtProof = SupportedJwtProof(supportedAlgorithms, true),
                 attestationProof = SupportedAttestationProof(supportedAlgorithms),
             )
         }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Config.kt
@@ -492,25 +492,23 @@ sealed interface IssuerMetadataPolicy {
  * Wallet supported proofs.
  *
  * @property isNoProofSupported whether the Wallet supports issuance of attestations that require no proofs
- * @property jwtProof whether the Wallet supports JWT Proofs
- * @property attestationProof whether the Wallet supports Attestation Proofs
+ * @property jwtProofWithKeyAttestation whether the Wallet supports JWT Proof with Key Attestation
+ * @property attestationProof whether the Wallet supports Attestation Proof
+ * @property jwtProofsWithoutKeyAttestation whether the Wallet supports JWT Proofs without Key Attestation
  */
 data class ProofsConfig(
     val isNoProofSupported: Boolean,
-    val jwtProof: SupportedJwtProof?,
+    val jwtProofWithKeyAttestation: SupportedJwtProof?,
     val attestationProof: SupportedAttestationProof?,
+    val jwtProofsWithoutKeyAttestation: SupportedJwtProof?,
 ) {
 
     /**
      * Indicates support for JWT Proofs.
      *
      * @property supportedAlgorithms the signing algorithms supported by the Wallet
-     * @property keyAttestationRequired whether Key Attestations are required for JWT Proofs
      */
-    data class SupportedJwtProof(
-        val supportedAlgorithms: Set<JWSAlgorithm>,
-        val keyAttestationRequired: Boolean,
-    ) {
+    data class SupportedJwtProof(val supportedAlgorithms: Set<JWSAlgorithm>) {
         init {
             require(supportedAlgorithms.isNotEmpty()) { "At least one supported algorithm must be provided." }
         }
@@ -536,9 +534,10 @@ data class ProofsConfig(
             get() {
                 val supportedAlgorithms = setOf(JWSAlgorithm.ES256, JWSAlgorithm.ES384, JWSAlgorithm.ES512)
                 return ProofsConfig(
-                    true,
-                    SupportedJwtProof(supportedAlgorithms, true),
-                    SupportedAttestationProof(supportedAlgorithms),
+                    isNoProofSupported = true,
+                    jwtProofWithKeyAttestation = SupportedJwtProof(supportedAlgorithms),
+                    attestationProof = SupportedAttestationProof(supportedAlgorithms),
+                    jwtProofsWithoutKeyAttestation = null,
                 )
             }
 
@@ -550,8 +549,9 @@ data class ProofsConfig(
             val supportedAlgorithms = setOf(first, *remaining)
             return ProofsConfig(
                 isNoProofSupported = false,
-                jwtProof = SupportedJwtProof(supportedAlgorithms, true),
+                jwtProofWithKeyAttestation = SupportedJwtProof(supportedAlgorithms),
                 attestationProof = SupportedAttestationProof(supportedAlgorithms),
+                jwtProofsWithoutKeyAttestation = null,
             )
         }
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/CredentialConfiguration.kt
@@ -64,7 +64,7 @@ enum class ProofType : Serializable {
 sealed interface ProofTypeMeta : Serializable {
     data class Jwt(
         val algorithms: List<JWSAlgorithm>,
-        val keyAttestationRequirement: KeyAttestationRequirement,
+        val keyAttestationRequirement: KeyAttestationRequirement?,
     ) : ProofTypeMeta {
         init {
             require(algorithms.isNotEmpty()) { "Supported algorithms in case of JWT cannot be empty" }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
@@ -140,7 +140,7 @@ sealed interface ProofSpecification {
 
     sealed interface JwtProof : ProofSpecification {
         data class WithoutKeyAttestation(
-            val proofSigner: Signer<JwtBindingKey>,
+            val proofSigner: BatchSigner<JwtBindingKey>,
         ) : JwtProof
 
         data class WithKeyAttestation(

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
@@ -154,7 +154,7 @@ sealed interface ProofSpecification {
 /**
  * An interface for submitting a credential issuance request.
  */
-fun interface RequestIssuance {
+interface RequestIssuance {
 
     /**
      * Places a request to the credential issuance endpoint.
@@ -171,6 +171,23 @@ fun interface RequestIssuance {
     suspend fun AuthorizedRequest.request(
         requestPayload: IssuanceRequestPayload,
         proofSpecification: ProofSpecification,
+    ): Result<AuthorizedRequestAnd<SubmissionOutcome>>
+
+    /**
+     * Places a request to the credential issuance endpoint using JWT Proofs without Key Attestation.
+     *
+     * If the [AuthorizedRequest] contains authorization details for the requested
+     * [IssuanceRequestPayload.credentialConfigurationIdentifier], then the [requestPayload] must be
+     * [IssuanceRequestPayload.IdentifierBased] and the credential identifier must be one of the authorized identifiers.
+     *
+     * @param requestPayload the payload of the request
+     * @param proofSigner a signer to sign the JWT Proofs to be included in the request
+     * @return the possibly updated [AuthorizedRequest] (if updated, it will contain a fresh updated Resource-Server DPoP Nonce)
+     * and the [SubmissionOutcome]
+     */
+    suspend fun AuthorizedRequest.request(
+        requestPayload: IssuanceRequestPayload,
+        proofSigner: BatchSigner<JwtBindingKey>,
     ): Result<AuthorizedRequestAnd<SubmissionOutcome>>
 }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
@@ -138,9 +138,15 @@ sealed interface ProofSpecification {
 
     data object NoProof : ProofSpecification
 
-    data class JwtProof(
-        val proofSignerProvider: suspend (Nonce?, PositiveDuration?) -> Signer<KeyAttestationJWT>,
-    ) : ProofSpecification
+    sealed interface JwtProof : ProofSpecification {
+        data class WithoutKeyAttestation(
+            val proofSigner: Signer<JwtBindingKey>,
+        ) : JwtProof
+
+        data class WithKeyAttestation(
+            val proofSignerProvider: suspend (Nonce?, PositiveDuration?) -> Signer<KeyAttestationJWT>,
+        ) : JwtProof
+    }
 
     data class AttestationProof(
         val attestationProvider: suspend (Nonce?, PositiveDuration?) -> KeyAttestationJWT,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
@@ -154,7 +154,7 @@ sealed interface ProofSpecification {
 /**
  * An interface for submitting a credential issuance request.
  */
-interface RequestIssuance {
+fun interface RequestIssuance {
 
     /**
      * Places a request to the credential issuance endpoint.

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
@@ -138,15 +138,13 @@ sealed interface ProofSpecification {
 
     data object NoProof : ProofSpecification
 
-    sealed interface JwtProof : ProofSpecification {
-        data class WithoutKeyAttestation(
-            val proofSigner: BatchSigner<JwtBindingKey>,
-        ) : JwtProof
+    data class JwtProofWithKeyAttestation(
+        val proofSignerProvider: suspend (Nonce?, PositiveDuration?) -> Signer<KeyAttestationJWT>,
+    ) : ProofSpecification
 
-        data class WithKeyAttestation(
-            val proofSignerProvider: suspend (Nonce?, PositiveDuration?) -> Signer<KeyAttestationJWT>,
-        ) : JwtProof
-    }
+    data class JwtProofsWithoutKeyAttestation(
+        val proofSigner: BatchSigner<JwtBindingKey>,
+    ) : ProofSpecification
 
     data class AttestationProof(
         val attestationProvider: suspend (Nonce?, PositiveDuration?) -> KeyAttestationJWT,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Issuance.kt
@@ -172,23 +172,6 @@ interface RequestIssuance {
         requestPayload: IssuanceRequestPayload,
         proofSpecification: ProofSpecification,
     ): Result<AuthorizedRequestAnd<SubmissionOutcome>>
-
-    /**
-     * Places a request to the credential issuance endpoint using JWT Proofs without Key Attestation.
-     *
-     * If the [AuthorizedRequest] contains authorization details for the requested
-     * [IssuanceRequestPayload.credentialConfigurationIdentifier], then the [requestPayload] must be
-     * [IssuanceRequestPayload.IdentifierBased] and the credential identifier must be one of the authorized identifiers.
-     *
-     * @param requestPayload the payload of the request
-     * @param proofSigner a signer to sign the JWT Proofs to be included in the request
-     * @return the possibly updated [AuthorizedRequest] (if updated, it will contain a fresh updated Resource-Server DPoP Nonce)
-     * and the [SubmissionOutcome]
-     */
-    suspend fun AuthorizedRequest.request(
-        requestPayload: IssuanceRequestPayload,
-        proofSigner: BatchSigner<JwtBindingKey>,
-    ): Result<AuthorizedRequestAnd<SubmissionOutcome>>
 }
 
 /**

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Signers.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/Signers.kt
@@ -40,6 +40,17 @@ data class SignOperation<out PUB>(
 )
 
 /**
+ * Represents a batch of signing operations that can be executed together.
+ *
+ * @param PUB The type of the public material used in the signing operations.
+ * @property operations A list of [SignOperation] instances specifying the individual signing operations
+ * to be performed in the batch.
+ */
+data class BatchSignOperation<out PUB>(
+    val operations: List<SignOperation<PUB>>,
+)
+
+/**
  * Represents a generic Signer interface that manages signing operations.
  *
  * @param PUB The type of the public material used in the signing process.
@@ -68,6 +79,51 @@ interface Signer<out PUB> {
      *               no action will be performed.
      */
     suspend fun release(signOperation: SignOperation<@UnsafeVariance PUB>?)
+
+    companion object
+}
+
+/**
+ * Defines an interface for batch signing operations.
+ *
+ * This interface is intended for managing batches of signing operations, allowing
+ * for the authentication of a batch and the ability to release resources associated
+ * with a batch. Implementations should provide the logic for authenticating signing
+ * operations and releasing resources appropriately.
+ *
+ * @param PUB The type of the public material used in the signing operations.
+ */
+interface BatchSigner<out PUB> {
+
+    /**
+     * The algorithm that will be used for signing
+     */
+    val javaAlgorithm: String
+
+    /**
+     * Authenticates a batch signing operation.
+     *
+     * The method initiates the process of authenticating signing operations that are
+     * structured as a batch. Authentication ensures that the signing operations
+     * meet the required security and validity conditions.
+     *
+     * @return A [BatchSignOperation] instance containing the authenticated batch of
+     * signing operations. The returned batch encapsulates the verified operations
+     * that can be securely executed.
+     */
+    suspend fun authenticate(): BatchSignOperation<PUB>
+
+    /**
+     * Releases the resources associated with a batch of signing operations.
+     *
+     * This method is intended to clean up and release any allocated resources corresponding
+     * to the provided batch of signing operations. It takes an optional `BatchSignOp` parameter
+     * and ensures that any necessary cleanup for the batch is performed.
+     *
+     * @param signOps An optional [BatchSignOperation] instance containing the batch of signing operations
+     *                to be released. If `null`, no operation is performed.
+     */
+    suspend fun release(signOps: BatchSignOperation<@UnsafeVariance PUB>?)
 
     companion object
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialIssuanceRequest.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialIssuanceRequest.kt
@@ -38,23 +38,23 @@ internal data class CredentialIssuanceRequest(
     companion object {
         internal fun byCredentialId(
             credentialIdentifier: CredentialIdentifier,
-            proof: Proof?,
+            proofs: List<Proof>,
             encryptionSpecs: ExchangeEncryptionSpecification,
         ): CredentialIssuanceRequest =
             CredentialIssuanceRequest(
                 CredentialConfigurationReference.ByCredentialId(credentialIdentifier),
-                listOfNotNull(proof),
+                proofs,
                 encryptionSpecs,
             )
 
         internal fun byCredentialConfigurationId(
             credentialConfigurationId: CredentialConfigurationIdentifier,
-            proof: Proof?,
+            proofs: List<Proof>,
             encryptionSpecs: ExchangeEncryptionSpecification,
         ): CredentialIssuanceRequest =
             CredentialIssuanceRequest(
                 CredentialConfigurationReference.ByCredentialConfigurationId(credentialConfigurationId),
-                listOfNotNull(proof),
+                proofs,
                 encryptionSpecs,
             )
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/JwtProofSigners.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/JwtProofSigners.kt
@@ -29,7 +29,7 @@ internal data class JwtProofClaims(
     @SerialName("nonce") val nonce: String? = null,
 )
 
-internal class JwtProofSigner(
+internal class KeyAttestationJwtProofSigner(
     private val algorithm: JWSAlgorithm,
     private val signOperation: SignOperation<KeyAttestationJWT>,
     private val keyIndex: Int,
@@ -50,4 +50,31 @@ private fun JsonObjectBuilder.keyAttestationHeader(keyAttestation: KeyAttestatio
     put("typ", OpenId4VCISpec.JWT_PROOF_TYPE)
     put(OpenId4VCISpec.JOSE_HEADER_KEY_ID, keyIndex.toString())
     put(OpenId4VCISpec.JOSE_HEADER_KEY_ATTESTATION, keyAttestation.jwt)
+}
+
+internal class NoKeyAttestationJwtProofSigner(
+    private val algorithm: JWSAlgorithm,
+    private val signOperation: SignOperation<JwtBindingKey>,
+) {
+    suspend fun sign(claims: JwtProofClaims): String =
+        JwtSigner<JwtProofClaims, JwtBindingKey>(
+            signOperation = signOperation,
+            algorithm = algorithm,
+            customizeHeader = { pubKey -> jwtProofHeader(pubKey) },
+        ).sign(claims)
+}
+
+private fun JsonObjectBuilder.jwtProofHeader(key: JwtBindingKey) {
+    put("typ", OpenId4VCISpec.JWT_PROOF_TYPE)
+    when (key) {
+        is JwtBindingKey.Did -> {
+            put(OpenId4VCISpec.JOSE_HEADER_KEY_ID, key.identity)
+        }
+        is JwtBindingKey.Jwk -> {
+            put(OpenId4VCISpec.JOSE_HEADER_JWK, key.jwk.publicJwkAsJsonElement())
+        }
+        is JwtBindingKey.X509 -> {
+            put(OpenId4VCISpec.JOSE_HEADER_X5C, key.chain.asJsonElement())
+        }
+    }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/JwtProofSigners.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/JwtProofSigners.kt
@@ -52,13 +52,13 @@ private fun JsonObjectBuilder.keyAttestationHeader(keyAttestation: KeyAttestatio
     put(OpenId4VCISpec.JOSE_HEADER_KEY_ATTESTATION, keyAttestation.jwt)
 }
 
-internal class NoKeyAttestationJwtProofSigner(
+internal class NoKeyAttestationJwtProofsSigner(
     private val algorithm: JWSAlgorithm,
-    private val signOperation: SignOperation<JwtBindingKey>,
+    private val batchSignOperation: BatchSignOperation<JwtBindingKey>,
 ) {
-    suspend fun sign(claims: JwtProofClaims): String =
-        JwtSigner<JwtProofClaims, JwtBindingKey>(
-            signOperation = signOperation,
+    suspend fun sign(claims: JwtProofClaims): List<Pair<JwtBindingKey, String>> =
+        BatchJwtSigner<JwtProofClaims, JwtBindingKey>(
+            batchSignOperation = batchSignOperation,
             algorithm = algorithm,
             customizeHeader = { pubKey -> jwtProofHeader(pubKey) },
         ).sign(claims)

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/JwtSigner.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/JwtSigner.kt
@@ -16,6 +16,7 @@
 package eu.europa.ec.eudi.openid4vci.internal
 
 import com.nimbusds.jose.JWSAlgorithm
+import eu.europa.ec.eudi.openid4vci.BatchSignOperation
 import eu.europa.ec.eudi.openid4vci.SignOperation
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
@@ -52,6 +53,39 @@ internal interface JwtSigner<in Claims, out PUB> {
             algorithm: JWSAlgorithm,
             noinline customizeHeader: JsonObjectBuilder.(PUB) -> Unit = {},
         ): JwtSigner<Claims, PUB> = invoke(serializer(), signOperation, algorithm, customizeHeader)
+    }
+}
+
+/**
+ * An interface for performing batch JWT signing operations. This interface allows signing multiple claims
+ * using a batch of signing operations, producing a list of signed JWTs paired with their corresponding public materials.
+ *
+ * @param Claims The type of the claims to be signed.
+ * @param PUB The type of the public material associated with the signed JWT.
+ */
+internal fun interface BatchJwtSigner<in Claims, out PUB> {
+    suspend fun sign(claims: Claims): List<Pair<PUB, String>>
+
+    companion object {
+
+        operator fun <Claims, PUB> invoke(
+            serializer: KSerializer<Claims>,
+            batchSignOperation: BatchSignOperation<PUB>,
+            algorithm: JWSAlgorithm,
+            customizeHeader: JsonObjectBuilder.(PUB) -> Unit = {},
+        ): BatchJwtSigner<Claims, PUB> = BatchJwtSigner { claims ->
+            batchSignOperation.operations.map { signOperation ->
+                val jwtSigner = JwtSigner(serializer, signOperation, algorithm, customizeHeader)
+                val jwt = jwtSigner.sign(claims)
+                jwtSigner.publicMaterial to jwt
+            }
+        }
+
+        inline operator fun <reified Claims, PUB> invoke(
+            batchSignOperation: BatchSignOperation<PUB>,
+            algorithm: JWSAlgorithm,
+            noinline customizeHeader: JsonObjectBuilder.(PUB) -> Unit = {},
+        ): BatchJwtSigner<Claims, PUB> = invoke(serializer(), batchSignOperation, algorithm, customizeHeader)
     }
 }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -503,30 +503,39 @@ private fun ProofsConfig.ensureCompatibleWith(issuerSupportedProofTypes: ProofTy
         }
 
         else -> {
-            val supportsJwtProof = run {
-                val issuerSupportedJwtProof = issuerSupportedProofTypes.jwtProof
-                if (null != jwtProof && null != issuerSupportedJwtProof) {
-                    val commonSupportedAlgorithms =
-                        jwtProof.supportedAlgorithms.intersect(
-                            issuerSupportedJwtProof.algorithms.toSet(),
-                        )
-
-                    val keyAttestationSupportedWhenRequired =
-                        (jwtProof.keyAttestationRequired && null != issuerSupportedJwtProof.keyAttestationRequirement) ||
-                            (!jwtProof.keyAttestationRequired && null == issuerSupportedJwtProof.keyAttestationRequirement)
-
-                    commonSupportedAlgorithms.isNotEmpty() && keyAttestationSupportedWhenRequired
-                } else {
-                    false
+            val supportsJwtProofWithKeyAttestation = run {
+                jwtProofWithKeyAttestation?.let { jwtProofWithKeyAttestation ->
+                    val issuerSupportedJwtProof = issuerSupportedProofTypes.jwtProof
+                    issuerSupportedJwtProof?.let { issuerSupportedJwtProof ->
+                        null != issuerSupportedJwtProof.keyAttestationRequirement &&
+                            jwtProofWithKeyAttestation.supportedAlgorithms.intersect(
+                                issuerSupportedJwtProof.algorithms.toSet(),
+                            ).isNotEmpty()
+                    }
                 }
-            }
+            } ?: false
 
-            val supportsAttestationProof = null != attestationProof &&
+            val supportsJwtProofsWithoutKeyAttestation = run {
+                jwtProofsWithoutKeyAttestation?.let { jwtProofsWithoutKeyAttestation ->
+                    val issuerSupportedJwtProof = issuerSupportedProofTypes.jwtProof
+                    issuerSupportedJwtProof?.let { issuerSupportedJwtProof ->
+                        null == issuerSupportedJwtProof.keyAttestationRequirement &&
+                            jwtProofsWithoutKeyAttestation.supportedAlgorithms.intersect(
+                                issuerSupportedJwtProof.algorithms.toSet(),
+                            ).isNotEmpty()
+                    }
+                }
+            } ?: false
+
+            val supportsAttestationProof = attestationProof?.let { attestationProof ->
                 attestationProof.supportedAlgorithms.intersect(
                     issuerSupportedProofTypes.attestationProof?.algorithms.orEmpty().toSet(),
                 ).isNotEmpty()
+            } ?: false
 
-            require(supportsJwtProof || supportsAttestationProof) { "Wallet doesn't support any of the advertised Proofs" }
+            require(supportsJwtProofWithKeyAttestation || supportsJwtProofsWithoutKeyAttestation || supportsAttestationProof) {
+                "Wallet doesn't support any of the advertised Proofs"
+            }
         }
     }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -114,12 +114,23 @@ internal class RequestIssuanceImpl(
         return when (proofSpecification) {
             is ProofSpecification.NoProof -> null to null
 
-            is ProofSpecification.JwtProof -> {
+            is ProofSpecification.JwtProof.WithKeyAttestation -> {
                 val cNonceAndDPoPNonce = cNonce()
-                val proof = jwtProof(
+                val proof = jwtProofWithKeyAttestation(
                     proofRequirement as ProofTypeMeta.Jwt,
                     proofSpecification,
                     selectedReusePolicy,
+                    grant,
+                    cNonceAndDPoPNonce?.cnonce,
+                )
+                proof to cNonceAndDPoPNonce?.dpopNonce
+            }
+
+            is ProofSpecification.JwtProof.WithoutKeyAttestation -> {
+                val cNonceAndDPoPNonce = cNonce()
+                val proof = jwtProofWithoutKeyAttestation(
+                    proofRequirement as ProofTypeMeta.Jwt,
+                    proofSpecification,
                     grant,
                     cNonceAndDPoPNonce?.cnonce,
                 )
@@ -158,6 +169,18 @@ internal class RequestIssuanceImpl(
                     "Credential configuration doesn't support JWT proofs."
                 }
                 check(proofRequirement is ProofTypeMeta.Jwt)
+                when (this) {
+                    is ProofSpecification.JwtProof.WithKeyAttestation -> {
+                        requireNotNull(proofRequirement.keyAttestationRequirement) {
+                            "Credential configuration does not support key attestation."
+                        }
+                    }
+                    is ProofSpecification.JwtProof.WithoutKeyAttestation -> {
+                        require(null == proofRequirement.keyAttestationRequirement) {
+                            "Credential configuration requires key attestation."
+                        }
+                    }
+                }
                 proofRequirement
             }
 
@@ -221,13 +244,14 @@ internal class RequestIssuanceImpl(
         }
     }
 
-    private suspend fun jwtProof(
+    private suspend fun jwtProofWithKeyAttestation(
         proofRequirement: ProofTypeMeta.Jwt,
-        proofSpecification: ProofSpecification.JwtProof,
+        proofSpecification: ProofSpecification.JwtProof.WithKeyAttestation,
         selectedReusePolicy: EudiReusePolicy?,
         grant: Grant,
         cNonce: Nonce?,
     ): Proof.Jwt {
+        checkNotNull(proofRequirement.keyAttestationRequirement)
         val proofSigner = proofSpecification.proofSignerProvider(
             cNonce,
             proofRequirement.keyAttestationRequirement.preferredKeyStorageStatusPeriod,
@@ -240,12 +264,31 @@ internal class RequestIssuanceImpl(
         val jwtProof = proofSigner.use { operation ->
             operation.publicMaterial.ensureKeyAttestationJwtAlgIsSupported(proofRequirement)
             operation.publicMaterial.attestedKeys.assertMatchesBatchIssuanceBatchSize(selectedReusePolicy)
-            val signer = JwtProofSigner(joseAlg, operation, ETSI119472Part3.KEY_ATTESTATION_JWT_PROOF_SIGNING_KEY_INDEX)
+            val signer = KeyAttestationJwtProofSigner(joseAlg, operation, ETSI119472Part3.KEY_ATTESTATION_JWT_PROOF_SIGNING_KEY_INDEX)
             val signedJwt = signer.sign(claims)
             SignedJWT.parse(signedJwt)
         }
         verifyKeyAttestationJwtProofSignature(jwtProof)
         return Proof.Jwt(jwtProof)
+    }
+
+    private suspend fun jwtProofWithoutKeyAttestation(
+        proofRequirement: ProofTypeMeta.Jwt,
+        proofSpecification: ProofSpecification.JwtProof.WithoutKeyAttestation,
+        grant: Grant,
+        cNonce: Nonce?,
+    ): Proof.Jwt {
+        check(null == proofRequirement.keyAttestationRequirement)
+
+        val joseAlg = run {
+            val javaSigningAlgorithm = proofSpecification.proofSigner.javaAlgorithm
+            javaSigningAlgorithm.toSupportedJoseAlgorithm(proofRequirement)
+        }
+        return proofSpecification.proofSigner.use { operation ->
+            val proofSigner = NoKeyAttestationJwtProofSigner(joseAlg, operation)
+            val claims = jwtProofClaims(cNonce = cNonce, grant = grant)
+            Proof.Jwt(SignedJWT.parse(proofSigner.sign(claims)))
+        }
     }
 
     private fun KeyAttestationJWT.ensureKeyAttestationJwtAlgIsSupported(
@@ -444,10 +487,24 @@ private fun ProofsConfig.ensureCompatibleWith(issuerSupportedProofTypes: ProofTy
         }
 
         else -> {
-            val supportsJwtProof = null != jwtProof &&
-                jwtProof.supportedAlgorithms.intersect(
-                    issuerSupportedProofTypes.jwtProof?.algorithms.orEmpty().toSet(),
-                ).isNotEmpty()
+            val supportsJwtProof = run {
+                val issuerSupportedJwtProof = issuerSupportedProofTypes.jwtProof
+                if (null != jwtProof && null != issuerSupportedJwtProof) {
+                    val commonSupportedAlgorithms =
+                        jwtProof.supportedAlgorithms.intersect(
+                            issuerSupportedJwtProof.algorithms.toSet(),
+                        )
+
+                    val keyAttestationSupportedWhenRequired =
+                        (jwtProof.keyAttestationRequired && null != issuerSupportedJwtProof.keyAttestationRequirement) ||
+                            (!jwtProof.keyAttestationRequired && null == issuerSupportedJwtProof.keyAttestationRequirement)
+
+                    commonSupportedAlgorithms.isNotEmpty() && keyAttestationSupportedWhenRequired
+                } else {
+                    false
+                }
+            }
+
             val supportsAttestationProof = null != attestationProof &&
                 attestationProof.supportedAlgorithms.intersect(
                     issuerSupportedProofTypes.attestationProof?.algorithms.orEmpty().toSet(),

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -74,9 +74,53 @@ internal class RequestIssuanceImpl(
             ).getOrThrow()
 
         // Update state (maybe) with new Dpop Nonce from resource server
-        val updatedAuthorizedRequest =
-            this.withResourceServerDpopNonce(newResourceServerDpopNonce ?: proofsOrAuthRequestDpopNonce)
-        updatedAuthorizedRequest to outcome.withSelectedCredentialReusePolicy(selectedCredentialReusePolicy).toPub()
+        val updatedAuthorizedRequest = withResourceServerDpopNonce(newResourceServerDpopNonce ?: proofsOrAuthRequestDpopNonce)
+
+        // When JWT Proofs without Key Attestation are used, Credential Reuse Policy is not applicable
+        val updatedOutcome =
+            if (proofSpecification is ProofSpecification.JwtProofsWithoutKeyAttestation) {
+                outcome
+            } else {
+                outcome.withSelectedCredentialReusePolicy(selectedCredentialReusePolicy)
+            }
+        updatedAuthorizedRequest to updatedOutcome.toPub()
+    }
+
+    override suspend fun AuthorizedRequest.request(
+        requestPayload: IssuanceRequestPayload,
+        proofSigner: BatchSigner<JwtBindingKey>,
+    ): Result<AuthorizedRequestAnd<SubmissionOutcome>> = runCatchingCancellable {
+        validateRequestPayload(requestPayload, credentialIdentifiers.orEmpty())
+
+        val credentialConfiguration = credentialSupportedById(requestPayload.credentialConfigurationIdentifier)
+        config.proofs.ensureCompatibleWith(credentialConfiguration.proofTypesSupported)
+
+        val proofSpecification = ProofSpecification.JwtProofsWithoutKeyAttestation(proofSigner)
+        val proofRequirement = proofSpecification.ensureCompatibleWith(credentialConfiguration)
+        check(proofRequirement is ProofTypeMeta.Jwt)
+        check(null == proofRequirement.keyAttestationRequirement)
+
+        val cNonceAndDPoPNonce = cNonce()
+        val proofs = jwtProofsWithoutKeyAttestation(
+            proofRequirement,
+            ProofSpecification.JwtProofsWithoutKeyAttestation(proofSigner),
+            grant,
+            cNonceAndDPoPNonce?.cnonce,
+        )
+
+        // Place the request
+        val credentialRequest = buildRequest(requestPayload, proofs, credentialIdentifiers.orEmpty())
+        val proofsOrAuthRequestDpopNonce = cNonceAndDPoPNonce?.dpopNonce ?: resourceServerDpopNonce
+        val (outcome, newResourceServerDpopNonce) =
+            credentialEndpointClient.placeIssuanceRequest(
+                accessToken,
+                proofsOrAuthRequestDpopNonce,
+                credentialRequest,
+            ).getOrThrow()
+
+        // Update state (maybe) with new Dpop Nonce from resource server
+        val updatedAuthorizedRequest = withResourceServerDpopNonce(newResourceServerDpopNonce ?: proofsOrAuthRequestDpopNonce)
+        updatedAuthorizedRequest to outcome.toPub()
     }
 
     private fun validateRequestPayload(
@@ -131,7 +175,6 @@ internal class RequestIssuanceImpl(
                 val proofs = jwtProofsWithoutKeyAttestation(
                     proofRequirement as ProofTypeMeta.Jwt,
                     proofSpecification,
-                    selectedReusePolicy,
                     grant,
                     cNonceAndDPoPNonce?.cnonce,
                 )
@@ -279,7 +322,6 @@ internal class RequestIssuanceImpl(
     private suspend fun jwtProofsWithoutKeyAttestation(
         proofRequirement: ProofTypeMeta.Jwt,
         proofSpecification: ProofSpecification.JwtProofsWithoutKeyAttestation,
-        selectedReusePolicy: EudiReusePolicy?,
         grant: Grant,
         cNonce: Nonce?,
     ): List<Proof.Jwt> {
@@ -290,7 +332,7 @@ internal class RequestIssuanceImpl(
             javaSigningAlgorithm.toSupportedJoseAlgorithm(proofRequirement)
         }
         return proofSpecification.proofSigner.use { operation ->
-            operation.assertMatchesBatchIssuanceBatchSize(selectedReusePolicy) // TODO: Is this applicable here?
+            operation.assertMatchesBatchIssuanceBatchSize()
             val proofsSigner = NoKeyAttestationJwtProofsSigner(joseAlg, operation)
             val claims = jwtProofClaims(cNonce = cNonce, grant = grant)
             proofsSigner.sign(claims).map {
@@ -323,10 +365,15 @@ internal class RequestIssuanceImpl(
         return Proof.Attestation(keyAttestationJwt)
     }
 
-    private fun BatchSignOperation<JwtBindingKey>.assertMatchesBatchIssuanceBatchSize(
-        selectedReusePolicy: EudiReusePolicy?,
-    ) {
-        operations.size.assertMatchesBatchIssuanceBatchSize(selectedReusePolicy)
+    private fun BatchSignOperation<JwtBindingKey>.assertMatchesBatchIssuanceBatchSize() {
+        if (operations.size > 1) {
+            ensure(batchCredentialIssuance is BatchCredentialIssuance.Supported) {
+                CredentialIssuanceError.IssuerDoesNotSupportBatchIssuance()
+            }
+            ensure(operations.size <= batchCredentialIssuance.batchSize) {
+                CredentialIssuanceError.IssuerBatchSizeLimitExceeded(batchCredentialIssuance.batchSize)
+            }
+        }
     }
 
     private fun AttestedKeys.assertMatchesBatchIssuanceBatchSize(

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -103,7 +103,7 @@ internal class RequestIssuanceImpl(
         val cNonceAndDPoPNonce = cNonce()
         val proofs = jwtProofsWithoutKeyAttestation(
             proofRequirement,
-            ProofSpecification.JwtProofsWithoutKeyAttestation(proofSigner),
+            proofSpecification,
             grant,
             cNonceAndDPoPNonce?.cnonce,
         )

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -114,7 +114,7 @@ internal class RequestIssuanceImpl(
         return when (proofSpecification) {
             is ProofSpecification.NoProof -> emptyList<Proof>() to null
 
-            is ProofSpecification.JwtProof.WithKeyAttestation -> {
+            is ProofSpecification.JwtProofWithKeyAttestation -> {
                 val cNonceAndDPoPNonce = cNonce()
                 val proof = jwtProofWithKeyAttestation(
                     proofRequirement as ProofTypeMeta.Jwt,
@@ -126,7 +126,7 @@ internal class RequestIssuanceImpl(
                 listOf(proof) to cNonceAndDPoPNonce?.dpopNonce
             }
 
-            is ProofSpecification.JwtProof.WithoutKeyAttestation -> {
+            is ProofSpecification.JwtProofsWithoutKeyAttestation -> {
                 val cNonceAndDPoPNonce = cNonce()
                 val proofs = jwtProofsWithoutKeyAttestation(
                     proofRequirement as ProofTypeMeta.Jwt,
@@ -164,23 +164,26 @@ internal class RequestIssuanceImpl(
                 null
             }
 
-            is ProofSpecification.JwtProof -> {
+            is ProofSpecification.JwtProofWithKeyAttestation -> {
                 val proofRequirement = proofTypesSupported[ProofType.JWT]
                 requireNotNull(proofRequirement) {
                     "Credential configuration doesn't support JWT proofs."
                 }
                 check(proofRequirement is ProofTypeMeta.Jwt)
-                when (this) {
-                    is ProofSpecification.JwtProof.WithKeyAttestation -> {
-                        requireNotNull(proofRequirement.keyAttestationRequirement) {
-                            "Credential configuration does not support key attestation."
-                        }
-                    }
-                    is ProofSpecification.JwtProof.WithoutKeyAttestation -> {
-                        require(null == proofRequirement.keyAttestationRequirement) {
-                            "Credential configuration requires key attestation."
-                        }
-                    }
+                requireNotNull(proofRequirement.keyAttestationRequirement) {
+                    "Credential configuration does not support key attestation."
+                }
+                proofRequirement
+            }
+
+            is ProofSpecification.JwtProofsWithoutKeyAttestation -> {
+                val proofRequirement = proofTypesSupported[ProofType.JWT]
+                requireNotNull(proofRequirement) {
+                    "Credential configuration doesn't support JWT proofs."
+                }
+                check(proofRequirement is ProofTypeMeta.Jwt)
+                require(null == proofRequirement.keyAttestationRequirement) {
+                    "Credential configuration requires key attestation."
                 }
                 proofRequirement
             }
@@ -247,7 +250,7 @@ internal class RequestIssuanceImpl(
 
     private suspend fun jwtProofWithKeyAttestation(
         proofRequirement: ProofTypeMeta.Jwt,
-        proofSpecification: ProofSpecification.JwtProof.WithKeyAttestation,
+        proofSpecification: ProofSpecification.JwtProofWithKeyAttestation,
         selectedReusePolicy: EudiReusePolicy?,
         grant: Grant,
         cNonce: Nonce?,
@@ -275,7 +278,7 @@ internal class RequestIssuanceImpl(
 
     private suspend fun jwtProofsWithoutKeyAttestation(
         proofRequirement: ProofTypeMeta.Jwt,
-        proofSpecification: ProofSpecification.JwtProof.WithoutKeyAttestation,
+        proofSpecification: ProofSpecification.JwtProofsWithoutKeyAttestation,
         selectedReusePolicy: EudiReusePolicy?,
         grant: Grant,
         cNonce: Nonce?,
@@ -287,7 +290,7 @@ internal class RequestIssuanceImpl(
             javaSigningAlgorithm.toSupportedJoseAlgorithm(proofRequirement)
         }
         return proofSpecification.proofSigner.use { operation ->
-            operation.assertMatchesBatchIssuanceBatchSize(selectedReusePolicy)
+            operation.assertMatchesBatchIssuanceBatchSize(selectedReusePolicy) // TODO: Is this applicable here?
             val proofsSigner = NoKeyAttestationJwtProofsSigner(joseAlg, operation)
             val claims = jwtProofClaims(cNonce = cNonce, grant = grant)
             proofsSigner.sign(claims).map {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -54,7 +54,19 @@ internal class RequestIssuanceImpl(
     ): Result<AuthorizedRequestAnd<SubmissionOutcome>> = runCatchingCancellable {
         validateRequestPayload(requestPayload, credentialIdentifiers.orEmpty())
         val credentialConfiguration = credentialSupportedById(requestPayload.credentialConfigurationIdentifier)
-        val selectedCredentialReusePolicy = selectCredentialReusePolicy(credentialConfiguration)
+
+        // Credential Reuse Policies are applicable only when using:
+        // JWT Proof with Key Attestation,
+        // or Attestation Proof
+        val selectedCredentialReusePolicy = when (proofSpecification) {
+            is ProofSpecification.JwtProofWithKeyAttestation,
+            is ProofSpecification.AttestationProof,
+            -> selectCredentialReusePolicy(credentialConfiguration)
+
+            ProofSpecification.NoProof,
+            is ProofSpecification.JwtProofsWithoutKeyAttestation,
+            -> null
+        }
 
         val (proofs, proofsDpopNonce) = buildProofs(
             proofSpecification,
@@ -76,13 +88,7 @@ internal class RequestIssuanceImpl(
         // Update state (maybe) with new Dpop Nonce from resource server
         val updatedAuthorizedRequest = withResourceServerDpopNonce(newResourceServerDpopNonce ?: proofsOrAuthRequestDpopNonce)
 
-        // When JWT Proofs without Key Attestation are used, Credential Reuse Policy is not applicable
-        val updatedOutcome =
-            if (proofSpecification is ProofSpecification.JwtProofsWithoutKeyAttestation) {
-                outcome
-            } else {
-                outcome.withSelectedCredentialReusePolicy(selectedCredentialReusePolicy)
-            }
+        val updatedOutcome = outcome.withSelectedCredentialReusePolicy(selectedCredentialReusePolicy)
         updatedAuthorizedRequest to updatedOutcome.toPub()
     }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -86,43 +86,6 @@ internal class RequestIssuanceImpl(
         updatedAuthorizedRequest to updatedOutcome.toPub()
     }
 
-    override suspend fun AuthorizedRequest.request(
-        requestPayload: IssuanceRequestPayload,
-        proofSigner: BatchSigner<JwtBindingKey>,
-    ): Result<AuthorizedRequestAnd<SubmissionOutcome>> = runCatchingCancellable {
-        validateRequestPayload(requestPayload, credentialIdentifiers.orEmpty())
-
-        val credentialConfiguration = credentialSupportedById(requestPayload.credentialConfigurationIdentifier)
-        config.proofs.ensureCompatibleWith(credentialConfiguration.proofTypesSupported)
-
-        val proofSpecification = ProofSpecification.JwtProofsWithoutKeyAttestation(proofSigner)
-        val proofRequirement = proofSpecification.ensureCompatibleWith(credentialConfiguration)
-        check(proofRequirement is ProofTypeMeta.Jwt)
-        check(null == proofRequirement.keyAttestationRequirement)
-
-        val cNonceAndDPoPNonce = cNonce()
-        val proofs = jwtProofsWithoutKeyAttestation(
-            proofRequirement,
-            proofSpecification,
-            grant,
-            cNonceAndDPoPNonce?.cnonce,
-        )
-
-        // Place the request
-        val credentialRequest = buildRequest(requestPayload, proofs, credentialIdentifiers.orEmpty())
-        val proofsOrAuthRequestDpopNonce = cNonceAndDPoPNonce?.dpopNonce ?: resourceServerDpopNonce
-        val (outcome, newResourceServerDpopNonce) =
-            credentialEndpointClient.placeIssuanceRequest(
-                accessToken,
-                proofsOrAuthRequestDpopNonce,
-                credentialRequest,
-            ).getOrThrow()
-
-        // Update state (maybe) with new Dpop Nonce from resource server
-        val updatedAuthorizedRequest = withResourceServerDpopNonce(newResourceServerDpopNonce ?: proofsOrAuthRequestDpopNonce)
-        updatedAuthorizedRequest to outcome.toPub()
-    }
-
     private fun validateRequestPayload(
         requestPayload: IssuanceRequestPayload,
         authorizationDetails: Map<CredentialConfigurationIdentifier, List<CredentialIdentifier>>,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/RequestIssuanceImpl.kt
@@ -56,13 +56,13 @@ internal class RequestIssuanceImpl(
         val credentialConfiguration = credentialSupportedById(requestPayload.credentialConfigurationIdentifier)
         val selectedCredentialReusePolicy = selectCredentialReusePolicy(credentialConfiguration)
 
-        val (proof, proofsDpopNonce) = buildProof(
+        val (proofs, proofsDpopNonce) = buildProofs(
             proofSpecification,
             selectedCredentialReusePolicy,
             requestPayload.credentialConfigurationIdentifier,
             grant,
         )
-        val credentialRequest = buildRequest(requestPayload, proof, credentialIdentifiers.orEmpty())
+        val credentialRequest = buildRequest(requestPayload, proofs, credentialIdentifiers.orEmpty())
 
         // Place the request
         val proofsOrAuthRequestDpopNonce = proofsDpopNonce ?: resourceServerDpopNonce
@@ -101,18 +101,18 @@ internal class RequestIssuanceImpl(
         }
     }
 
-    private suspend fun buildProof(
+    private suspend fun buildProofs(
         proofSpecification: ProofSpecification,
         selectedReusePolicy: EudiReusePolicy?,
         credentialConfigId: CredentialConfigurationIdentifier,
         grant: Grant,
-    ): Pair<Proof?, Nonce?> {
+    ): Pair<List<Proof>, Nonce?> {
         val credentialConfiguration = credentialSupportedById(credentialConfigId)
         config.proofs.ensureCompatibleWith(credentialConfiguration.proofTypesSupported)
         val proofRequirement = proofSpecification.ensureCompatibleWith(credentialConfiguration)
 
         return when (proofSpecification) {
-            is ProofSpecification.NoProof -> null to null
+            is ProofSpecification.NoProof -> emptyList<Proof>() to null
 
             is ProofSpecification.JwtProof.WithKeyAttestation -> {
                 val cNonceAndDPoPNonce = cNonce()
@@ -123,18 +123,19 @@ internal class RequestIssuanceImpl(
                     grant,
                     cNonceAndDPoPNonce?.cnonce,
                 )
-                proof to cNonceAndDPoPNonce?.dpopNonce
+                listOf(proof) to cNonceAndDPoPNonce?.dpopNonce
             }
 
             is ProofSpecification.JwtProof.WithoutKeyAttestation -> {
                 val cNonceAndDPoPNonce = cNonce()
-                val proof = jwtProofWithoutKeyAttestation(
+                val proofs = jwtProofsWithoutKeyAttestation(
                     proofRequirement as ProofTypeMeta.Jwt,
                     proofSpecification,
+                    selectedReusePolicy,
                     grant,
                     cNonceAndDPoPNonce?.cnonce,
                 )
-                proof to cNonceAndDPoPNonce?.dpopNonce
+                proofs to cNonceAndDPoPNonce?.dpopNonce
             }
 
             is ProofSpecification.AttestationProof -> {
@@ -145,7 +146,7 @@ internal class RequestIssuanceImpl(
                     selectedReusePolicy,
                     cNonceAndDPoPNonce?.cnonce,
                 )
-                proof to cNonceAndDPoPNonce?.dpopNonce
+                listOf(proof) to cNonceAndDPoPNonce?.dpopNonce
             }
         }
     }
@@ -272,12 +273,13 @@ internal class RequestIssuanceImpl(
         return Proof.Jwt(jwtProof)
     }
 
-    private suspend fun jwtProofWithoutKeyAttestation(
+    private suspend fun jwtProofsWithoutKeyAttestation(
         proofRequirement: ProofTypeMeta.Jwt,
         proofSpecification: ProofSpecification.JwtProof.WithoutKeyAttestation,
+        selectedReusePolicy: EudiReusePolicy?,
         grant: Grant,
         cNonce: Nonce?,
-    ): Proof.Jwt {
+    ): List<Proof.Jwt> {
         check(null == proofRequirement.keyAttestationRequirement)
 
         val joseAlg = run {
@@ -285,9 +287,12 @@ internal class RequestIssuanceImpl(
             javaSigningAlgorithm.toSupportedJoseAlgorithm(proofRequirement)
         }
         return proofSpecification.proofSigner.use { operation ->
-            val proofSigner = NoKeyAttestationJwtProofSigner(joseAlg, operation)
+            operation.assertMatchesBatchIssuanceBatchSize(selectedReusePolicy)
+            val proofsSigner = NoKeyAttestationJwtProofsSigner(joseAlg, operation)
             val claims = jwtProofClaims(cNonce = cNonce, grant = grant)
-            Proof.Jwt(SignedJWT.parse(proofSigner.sign(claims)))
+            proofsSigner.sign(claims).map {
+                Proof.Jwt(SignedJWT.parse(it.second))
+            }
         }
     }
 
@@ -315,9 +320,17 @@ internal class RequestIssuanceImpl(
         return Proof.Attestation(keyAttestationJwt)
     }
 
+    private fun BatchSignOperation<JwtBindingKey>.assertMatchesBatchIssuanceBatchSize(
+        selectedReusePolicy: EudiReusePolicy?,
+    ) {
+        operations.size.assertMatchesBatchIssuanceBatchSize(selectedReusePolicy)
+    }
+
     private fun AttestedKeys.assertMatchesBatchIssuanceBatchSize(
         selectedReusePolicy: EudiReusePolicy?,
-    ) = size.assertMatchesBatchIssuanceBatchSize(selectedReusePolicy)
+    ) {
+        size.assertMatchesBatchIssuanceBatchSize(selectedReusePolicy)
+    }
 
     private fun Int.assertMatchesBatchIssuanceBatchSize(
         selectedReusePolicy: EudiReusePolicy?,
@@ -409,13 +422,13 @@ internal class RequestIssuanceImpl(
 
     private fun buildRequest(
         requestPayload: IssuanceRequestPayload,
-        proof: Proof?,
+        proofs: List<Proof>,
         authorizationDetails: Map<CredentialConfigurationIdentifier, List<CredentialIdentifier>>,
     ): CredentialIssuanceRequest = when (requestPayload) {
         is IssuanceRequestPayload.ConfigurationBased -> {
             CredentialIssuanceRequest.byCredentialConfigurationId(
                 requestPayload.credentialConfigurationIdentifier,
-                proof,
+                proofs,
                 exchangeEncryptionSpecification,
             )
         }
@@ -424,7 +437,7 @@ internal class RequestIssuanceImpl(
             requestPayload.ensureAuthorized(authorizationDetails)
             CredentialIssuanceRequest.byCredentialId(
                 requestPayload.credentialIdentifier,
-                proof,
+                proofs,
                 exchangeEncryptionSpecification,
             )
         }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/SigningOps.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/SigningOps.kt
@@ -44,6 +44,20 @@ internal suspend fun <PUB, R> Signer<PUB>.use(block: suspend (SignOperation<PUB>
     }
 }
 
+@OptIn(ExperimentalContracts::class)
+internal suspend fun <PUB, R> BatchSigner<PUB>.use(block: suspend (BatchSignOperation<PUB>) -> R): R {
+    contract {
+        callsInPlace(block, InvocationKind.AT_MOST_ONCE)
+    }
+
+    val signOps = authenticate()
+    try {
+        return block(signOps)
+    } finally {
+        release(signOps)
+    }
+}
+
 internal fun ByteArray.transcodeSignatureToConcat(alg: JWSAlgorithm): ByteArray {
     if (!JWSAlgorithm.Family.EC.contains(alg)) {
         return this
@@ -92,6 +106,34 @@ internal fun SignFunction.Companion.forJavaPrivateKey(
         }
     }
 
+internal fun <PUB> BatchSigner.Companion.fromECPrivateKeys(
+    signingAlgorithm: String,
+    ecKeyPairs: Map<ECPrivateKey, PUB>,
+    secureRandom: SecureRandom?,
+    provider: String?,
+): BatchSigner<PUB> = object : BatchSigner<PUB> {
+
+    override val javaAlgorithm: String
+        get() = signingAlgorithm
+
+    override suspend fun authenticate(): BatchSignOperation<PUB> {
+        val signOperations = ecKeyPairs.map {
+            val sign = SignFunction.forJavaPrivateKey(
+                signingAlgorithm,
+                it.key,
+                secureRandom,
+                provider,
+            )
+            SignOperation(sign, it.value)
+        }
+        return BatchSignOperation(signOperations)
+    }
+
+    override suspend fun release(signOps: BatchSignOperation<PUB>?) {
+        // Nothing to do for releasing
+    }
+}
+
 internal fun <PUB> Signer.Companion.fromEcPrivateKey(
     signingAlgorithm: String,
     privateKey: ECPrivateKey,
@@ -111,6 +153,26 @@ internal fun <PUB> Signer.Companion.fromEcPrivateKey(
     override suspend fun release(signOperation: SignOperation<PUB>?) {
         // Nothing to do for releasing
     }
+}
+
+internal fun <PUB> BatchSigner.Companion.fromNimbusEcKeys(
+    ecKeyPairs: Map<ECKey, PUB>,
+    secureRandom: SecureRandom?,
+    provider: String?,
+): BatchSigner<PUB> {
+    require(ecKeyPairs.isNotEmpty()) { "At least one EC key pair must be provided" }
+    ecKeyPairs.forEach {
+        require(it.key.isPrivate) { "All EC keys must be private keys" }
+    }
+    val signatureAlgorithm = ecKeyPairs.entries.first().key.curve.toJavaSigningAlg()
+    return fromECPrivateKeys(
+        signatureAlgorithm,
+        ecKeyPairs.map {
+            it.key.toECPrivateKey() to it.value
+        }.toMap(),
+        secureRandom,
+        provider,
+    )
 }
 
 internal fun <KI> Signer.Companion.fromNimbusEcKey(

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/SigningOps.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/SigningOps.kt
@@ -167,11 +167,13 @@ internal fun <PUB> BatchSigner.Companion.fromNimbusEcKeys(
         require(key.curve == firstCurve) { "All EC keys must use the same curve, but found ${key.curve}" }
     }
     val signatureAlgorithm = firstCurve.toJavaSigningAlg()
+    val javaKeys = ecKeyPairs.map { it.key.toECPrivateKey() to it.value }
+    require(javaKeys.distinctBy { it.first }.size == javaKeys.size) {
+        "Multiple EC keys resolve to the same Java private key (duplicate D value)."
+    }
     return fromECPrivateKeys(
         signatureAlgorithm,
-        ecKeyPairs.map {
-            it.key.toECPrivateKey() to it.value
-        }.toMap(),
+        javaKeys.toMap(),
         secureRandom,
         provider,
     )

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/SigningOps.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/SigningOps.kt
@@ -161,10 +161,12 @@ internal fun <PUB> BatchSigner.Companion.fromNimbusEcKeys(
     provider: String?,
 ): BatchSigner<PUB> {
     require(ecKeyPairs.isNotEmpty()) { "At least one EC key pair must be provided" }
-    ecKeyPairs.forEach {
-        require(it.key.isPrivate) { "All EC keys must be private keys" }
+    val firstCurve = ecKeyPairs.entries.first().key.curve
+    ecKeyPairs.forEach { (key, _) ->
+        require(key.isPrivate) { "All EC keys must be private keys" }
+        require(key.curve == firstCurve) { "All EC keys must use the same curve, but found ${key.curve}" }
     }
-    val signatureAlgorithm = ecKeyPairs.entries.first().key.curve.toJavaSigningAlg()
+    val signatureAlgorithm = firstCurve.toJavaSigningAlg()
     return fromECPrivateKeys(
         signatureAlgorithm,
         ecKeyPairs.map {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialIssuerMetadataJsonParser.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vci/internal/http/CredentialIssuerMetadataJsonParser.kt
@@ -640,9 +640,7 @@ private fun proofTypeMeta(type: String, meta: ProofTypeSupportedMetaTO): ProofTy
     when (type) {
         "jwt" -> {
             val algorithms = meta.algorithms.map { JWSAlgorithm.parse(it) }
-            val keyAttestationRequirement = requireNotNull(meta.keyAttestationRequirement?.toDomain()) {
-                "jwt proof must contain 'key_attestations_required'"
-            }
+            val keyAttestationRequirement = meta.keyAttestationRequirement?.toDomain()
             ProofTypeMeta.Jwt(algorithms, keyAttestationRequirement)
         }
 

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CryptoGenerator.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CryptoGenerator.kt
@@ -82,7 +82,7 @@ object CryptoGenerator {
                 provider = null,
             )
         }
-        return ProofSpecification.JwtProof(signerProvider)
+        return ProofSpecification.JwtProof.WithKeyAttestation(signerProvider)
     }
 
     fun attestationProofSpec(

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CryptoGenerator.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/CryptoGenerator.kt
@@ -28,6 +28,7 @@ import com.nimbusds.jwt.SignedJWT
 import com.nimbusds.oauth2.sdk.id.Issuer
 import com.nimbusds.oauth2.sdk.util.X509CertificateUtils
 import eu.europa.ec.eudi.openid4vci.internal.fromNimbusEcKey
+import eu.europa.ec.eudi.openid4vci.internal.fromNimbusEcKeys
 import java.net.URI
 import java.security.KeyFactory
 import java.security.cert.CertificateFactory
@@ -61,12 +62,12 @@ object CryptoGenerator {
         )
     }
 
-    fun jwtProofSpec(
+    fun jwtProofWithKeyAttestationSpec(
         curve: Curve = Curve.P_256,
         attestedKeysCount: Int = 3,
         keyAttestationJwt: suspend (List<JWK>, Nonce?, PositiveDuration?) -> KeyAttestationJWT = CryptoGenerator::keyAttestationJwt,
         assertions: (Nonce?, PositiveDuration?) -> Unit = { _, _ -> },
-    ): ProofSpecification {
+    ): ProofSpecification.JwtProofWithKeyAttestation {
         val ecKeys = List(attestedKeysCount) { randomECSigningKey(curve) }
         val signerProvider: suspend (Nonce?, PositiveDuration?) -> Signer<KeyAttestationJWT> = { cNonce, preferredKeyStorageStatusPeriod ->
             assertions(cNonce, preferredKeyStorageStatusPeriod)
@@ -82,7 +83,20 @@ object CryptoGenerator {
                 provider = null,
             )
         }
-        return ProofSpecification.JwtProof.WithKeyAttestation(signerProvider)
+        return ProofSpecification.JwtProofWithKeyAttestation(signerProvider)
+    }
+
+    fun jwtProofsWithoutKeyAttestation(
+        curve: Curve = Curve.P_256,
+        keysNo: Int = 1,
+    ): ProofSpecification.JwtProofsWithoutKeyAttestation {
+        val ecKeys = List(keysNo) { randomECSigningKey(curve) }
+        val batchSigner = BatchSigner.fromNimbusEcKeys(
+            ecKeyPairs = ecKeys.associateWith { JwtBindingKey.Jwk(it.toPublicJWK()) },
+            secureRandom = null,
+            provider = null,
+        )
+        return ProofSpecification.JwtProofsWithoutKeyAttestation(batchSigner)
     }
 
     fun attestationProofSpec(
@@ -90,7 +104,7 @@ object CryptoGenerator {
         keysNo: Int = 3,
         keyAttestationJwt: suspend (List<JWK>, Nonce?, PositiveDuration?) -> KeyAttestationJWT = CryptoGenerator::keyAttestationJwt,
         assertions: (Nonce?, PositiveDuration?) -> Unit = { _, _ -> },
-    ) =
+    ): ProofSpecification.AttestationProof =
         ProofSpecification.AttestationProof { nonce, preferredKeyStorageStatusPeriod ->
             assertions(nonce, preferredKeyStorageStatusPeriod)
             keyAttestationJwt(

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceBatchRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceBatchRequestTest.kt
@@ -16,7 +16,7 @@
 package eu.europa.ec.eudi.openid4vci
 
 import com.nimbusds.jwt.SignedJWT
-import eu.europa.ec.eudi.openid4vci.CryptoGenerator.jwtProofSpec
+import eu.europa.ec.eudi.openid4vci.CryptoGenerator.jwtProofWithKeyAttestationSpec
 import eu.europa.ec.eudi.openid4vci.internal.http.CredentialRequestTO
 import eu.europa.ec.eudi.openid4vci.internal.http.CredentialResponseSuccessTO
 import kotlinx.coroutines.test.runTest
@@ -82,7 +82,7 @@ class IssuanceBatchRequestTest {
             CredentialConfigurationIdentifier(PID_MsoMdoc),
         )
         val (_, outcome) = with(issuer) {
-            authorizedRequest.request(request, jwtProofSpec(attestedKeysCount = 3)).getOrThrow()
+            authorizedRequest.request(request, jwtProofWithKeyAttestationSpec(attestedKeysCount = 3)).getOrThrow()
         }
         when (outcome) {
             is SubmissionOutcome.Failed -> {

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceBatchRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceBatchRequestTest.kt
@@ -15,84 +15,146 @@
  */
 package eu.europa.ec.eudi.openid4vci
 
-import com.nimbusds.jwt.SignedJWT
 import eu.europa.ec.eudi.openid4vci.CryptoGenerator.jwtProofWithKeyAttestationSpec
-import eu.europa.ec.eudi.openid4vci.internal.http.CredentialRequestTO
-import eu.europa.ec.eudi.openid4vci.internal.http.CredentialResponseSuccessTO
+import eu.europa.ec.eudi.openid4vci.CryptoGenerator.jwtProofsWithoutKeyAttestation
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.buildJsonObject
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import kotlin.test.*
 
 class IssuanceBatchRequestTest {
 
-    @Test
-    fun `successful batch issuance`() = runTest {
-        val issuerMetadataVersion = IssuerMetadataVersion.ENCRYPTION_REQUIRED
-        val mockedKtorHttpClientFactory = mockedHttpClient(
-            credentialIssuerMetadataWellKnownMocker(issuerMetadataVersion = issuerMetadataVersion),
-            authServerWellKnownMocker(),
-            parPostMocker(),
-            tokenPostMocker(),
-            nonceEndpointMocker(),
-            singleIssuanceRequestMocker(
-                responseBuilder = {
-                    encryptionAwareResponseDataBuilder(it, issuerMetadataVersion) {
-                        Json.encodeToString(
-                            CredentialResponseSuccessTO(
-                                credentials = listOf(
-                                    buildJsonObject {
-                                        put("credential", JsonPrimitive("issued_credential_content_mso_mdoc0"))
-                                    },
-                                    buildJsonObject {
-                                        put("credential", JsonPrimitive("issued_credential_content_mso_mdoc1"))
-                                    },
-                                    buildJsonObject {
-                                        put("credential", JsonPrimitive("issued_credential_content_mso_mdoc2"))
-                                    },
-                                ),
-                            ),
-                        )
-                    }
-                },
-                requestValidator = { request ->
-                    encryptionAwareRequestValidator<CredentialRequestTO>(request, issuerMetadataVersion) {
-                        assertNotNull(
-                            it.proofs,
-                            "Proofs expected but received none",
-                        )
-                        val jwtProofs = it.proofs.jwtProofs
-                        assertNotNull(jwtProofs, "Jwt Proofs expected")
-                        assertEquals(1, jwtProofs.size, "Exactly one Jwt Proof expected")
-                        val keyAttestation =
-                            KeyAttestationJWT(SignedJWT.parse(jwtProofs.first()).header.getCustomParam("key_attestation") as String)
-                        assertEquals(3, keyAttestation.attestedKeys.size, "Exactly three attested keys expected")
-                    }
-                },
-            ),
-        )
-        val (authorizedRequest, issuer) =
-            authorizeRequestForCredentialOffer(
-                credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
-                httpClient = mockedKtorHttpClientFactory,
-            )
+    @Nested
+    @DisplayName("JWT Proof with Key Attestation")
+    inner class JwtProofWithKeyAttestation {
 
-        val request = IssuanceRequestPayload.ConfigurationBased(
-            CredentialConfigurationIdentifier(PID_MsoMdoc),
-        )
-        val (_, outcome) = with(issuer) {
-            authorizedRequest.request(request, jwtProofWithKeyAttestationSpec(attestedKeysCount = 3)).getOrThrow()
+        @Test
+        fun `successful batch issuance`() = runTest {
+            val issuerMetadataVersion = IssuerMetadataVersion.ENCRYPTION_REQUIRED
+            val mockedKtorHttpClientFactory = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(issuerMetadataVersion = issuerMetadataVersion),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                tokenPostMocker(),
+                nonceEndpointMocker(),
+                singleIssuanceRequestMocker(
+                    responseBuilder = encryptionAwareSuccessCredentialResponseResponseDataBuilder(issuerMetadataVersion, 3),
+                    requestValidator = encryptionAwareJwtProofWithKeyAttestationRequestValidator(issuerMetadataVersion, 3),
+                ),
+            )
+            val (authorizedRequest, issuer) =
+                authorizeRequestForCredentialOffer(
+                    credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
+                    httpClient = mockedKtorHttpClientFactory,
+                )
+
+            val request = IssuanceRequestPayload.ConfigurationBased(
+                CredentialConfigurationIdentifier(PID_MsoMdoc),
+            )
+            val (_, outcome) = with(issuer) {
+                authorizedRequest.request(request, jwtProofWithKeyAttestationSpec(attestedKeysCount = 3)).getOrThrow()
+            }
+            when (outcome) {
+                is SubmissionOutcome.Failed -> {
+                    fail(outcome.error.message)
+                }
+                is SubmissionOutcome.Deferred -> {
+                    fail("Got deferred")
+                }
+                is SubmissionOutcome.Success -> {
+                    outcome.credentials.forEach { assertIs<IssuedCredential>(it) }
+                }
+            }
         }
-        when (outcome) {
-            is SubmissionOutcome.Failed -> {
-                fail(outcome.error.message)
+    }
+
+    @Nested
+    @DisplayName("JWT Proofs without Key Attestation")
+    inner class JwtProofsWithoutKeyAttestation {
+
+        @Test
+        fun `successful batch issuance`() = runTest {
+            val issuerMetadataVersion = IssuerMetadataVersion.ONLY_JWT_PROOFS_WITHOUT_KEY_ATTESTATION_SUPPORTED
+            val mockedKtorHttpClientFactory = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(issuerMetadataVersion = issuerMetadataVersion),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                tokenPostMocker(),
+                nonceEndpointMocker(),
+                singleIssuanceRequestMocker(
+                    responseBuilder = encryptionAwareSuccessCredentialResponseResponseDataBuilder(issuerMetadataVersion, 3),
+                    requestValidator = encryptionAwareJwtProofsWithoutKeyAttestationRequestValidator(issuerMetadataVersion, 3),
+                ),
+            )
+            val (authorizedRequest, issuer) =
+                authorizeRequestForCredentialOffer(
+                    config = OpenId4VCIConfigurationOnlyPlainJwtProofs,
+                    credentialOfferStr = CredentialOfferWithSdJwtVc_NO_GRANTS,
+                    httpClient = mockedKtorHttpClientFactory,
+                )
+
+            val request = IssuanceRequestPayload.ConfigurationBased(
+                CredentialConfigurationIdentifier(PID_SdJwtVC),
+            )
+            val (_, outcome) = with(issuer) {
+                authorizedRequest.request(request, jwtProofsWithoutKeyAttestation(keysNo = 3)).getOrThrow()
             }
-            is SubmissionOutcome.Deferred -> {
-                fail("Got deferred")
+            val issuedCredentials = assertIs<SubmissionOutcome.Success>(outcome).credentials
+            assertEquals(3, issuedCredentials.size, "Expected 3 Credentials to be issued")
+        }
+
+        @Test
+        fun `fails when sending more proofs that allowed batch size`() = runTest {
+            val issuerMetadataVersion = IssuerMetadataVersion.ONLY_JWT_PROOFS_WITHOUT_KEY_ATTESTATION_SUPPORTED
+            val mockedKtorHttpClientFactory = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(issuerMetadataVersion = issuerMetadataVersion),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                tokenPostMocker(),
+                nonceEndpointMocker(),
+            )
+            val (authorizedRequest, issuer) =
+                authorizeRequestForCredentialOffer(
+                    config = OpenId4VCIConfigurationOnlyPlainJwtProofs,
+                    credentialOfferStr = CredentialOfferWithSdJwtVc_NO_GRANTS,
+                    httpClient = mockedKtorHttpClientFactory,
+                )
+
+            val request = IssuanceRequestPayload.ConfigurationBased(
+                CredentialConfigurationIdentifier(PID_SdJwtVC),
+            )
+            val error = assertFailsWith<CredentialIssuanceError.IssuerBatchSizeLimitExceeded> {
+                with(issuer) {
+                    authorizedRequest.request(request, jwtProofsWithoutKeyAttestation(keysNo = 4)).getOrThrow()
+                }
             }
-            is SubmissionOutcome.Success -> {
-                outcome.credentials.forEach { assertIs<IssuedCredential>(it) }
+            assertEquals(3, error.batchSize)
+        }
+
+        @Test
+        fun `fails when issuer does not support batch credential issuance`() = runTest {
+            val issuerMetadataVersion = IssuerMetadataVersion.NO_BATCH
+            val mockedKtorHttpClientFactory = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(issuerMetadataVersion = issuerMetadataVersion),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                tokenPostMocker(),
+                nonceEndpointMocker(),
+            )
+            val (authorizedRequest, issuer) =
+                authorizeRequestForCredentialOffer(
+                    config = OpenId4VCIConfigurationOnlyPlainJwtProofs,
+                    credentialOfferStr = CredentialOfferWithSdJwtVc_NO_GRANTS,
+                    httpClient = mockedKtorHttpClientFactory,
+                )
+
+            val request = IssuanceRequestPayload.ConfigurationBased(
+                CredentialConfigurationIdentifier(PID_SdJwtVC),
+            )
+            assertFailsWith<CredentialIssuanceError.IssuerDoesNotSupportBatchIssuance> {
+                with(issuer) {
+                    authorizedRequest.request(request, jwtProofsWithoutKeyAttestation(keysNo = 3)).getOrThrow()
+                }
             }
         }
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceDeferredRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceDeferredRequestTest.kt
@@ -16,7 +16,7 @@
 package eu.europa.ec.eudi.openid4vci
 
 import com.nimbusds.jose.jwk.Curve
-import eu.europa.ec.eudi.openid4vci.CryptoGenerator.jwtProofSpec
+import eu.europa.ec.eudi.openid4vci.CryptoGenerator.jwtProofWithKeyAttestationSpec
 import eu.europa.ec.eudi.openid4vci.internal.http.DeferredRequestTO
 import io.ktor.http.*
 import io.ktor.http.content.*
@@ -53,7 +53,7 @@ class IssuanceDeferredRequestTest {
                 CredentialConfigurationIdentifier(PID_SdJwtVC),
             )
             val (newAuthorizedRequest, outcome) =
-                authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+                authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
             assertIs<SubmissionOutcome.Deferred>(outcome)
 
             val (_, requestDeferredIssuance) =
@@ -95,7 +95,7 @@ class IssuanceDeferredRequestTest {
                 CredentialConfigurationIdentifier(PID_SdJwtVC),
             )
             val (newAuthorizedRequest, outcome) =
-                authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+                authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
             assertIs<SubmissionOutcome.Deferred>(outcome)
 
             val (_, requestDeferredIssuance) =
@@ -134,7 +134,7 @@ class IssuanceDeferredRequestTest {
                 CredentialConfigurationIdentifier(PID_SdJwtVC),
             )
             val (newAuthorizedRequest, outcome) =
-                authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+                authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
             assertIs<SubmissionOutcome.Deferred>(outcome)
 
             assertFailsWith<CredentialIssuanceError.UnexpectedTransactionId> {
@@ -189,7 +189,7 @@ class IssuanceDeferredRequestTest {
                 CredentialConfigurationIdentifier(PID_SdJwtVC),
             )
             val (newAuthorized, outcome) =
-                authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+                authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
 
             assertIs<SubmissionOutcome.Deferred>(outcome)
 

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceIssuerMetadataVersionTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceIssuerMetadataVersionTest.kt
@@ -25,7 +25,7 @@ import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
 import com.nimbusds.jwt.JWTClaimsSet
 import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.RequestEncryptionError.IssuerRequiresEncryptedRequestButEncryptionSpecCannotBeFormulated
 import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.ResponseEncryptionError.*
-import eu.europa.ec.eudi.openid4vci.CryptoGenerator.jwtProofSpec
+import eu.europa.ec.eudi.openid4vci.CryptoGenerator.jwtProofWithKeyAttestationSpec
 import eu.europa.ec.eudi.openid4vci.internal.http.CredentialRequestTO
 import eu.europa.ec.eudi.openid4vci.internal.http.CredentialResponseSuccessTO
 import eu.europa.ec.eudi.openid4vci.internal.http.DeferredRequestTO
@@ -182,7 +182,7 @@ class IssuanceIssuerMetadataVersionTest {
             with(issuer) {
                 val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-                authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+                authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
             }
         }
 
@@ -233,7 +233,7 @@ class IssuanceIssuerMetadataVersionTest {
             with(issuer) {
                 val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-                authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+                authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
             }
         }
 
@@ -284,7 +284,7 @@ class IssuanceIssuerMetadataVersionTest {
             with(issuer) {
                 val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-                authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+                authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
             }
         }
 
@@ -377,7 +377,7 @@ class IssuanceIssuerMetadataVersionTest {
             with(issuer) {
                 val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-                authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+                authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
             }
         }
 
@@ -432,7 +432,7 @@ class IssuanceIssuerMetadataVersionTest {
             with(issuer) {
                 val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-                val (_, outcome) = authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+                val (_, outcome) = authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
                 assertIs<SubmissionOutcome.Success>(outcome)
             }
         }
@@ -496,7 +496,7 @@ class IssuanceIssuerMetadataVersionTest {
             with(issuer) {
                 val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-                val (_, outcome) = authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+                val (_, outcome) = authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
                 assertIs<SubmissionOutcome.Success>(outcome)
             }
         }
@@ -542,7 +542,7 @@ class IssuanceIssuerMetadataVersionTest {
             val (_, outcome) = with(issuer) {
                 authorizedRequest.request(
                     IssuanceRequestPayload.ConfigurationBased(CredentialConfigurationIdentifier(PID_MsoMdoc)),
-                    jwtProofSpec(Curve.P_256),
+                    jwtProofWithKeyAttestationSpec(Curve.P_256),
                 ).getOrThrow()
             }
             assertIs<SubmissionOutcome.Success>(outcome)
@@ -580,7 +580,7 @@ class IssuanceIssuerMetadataVersionTest {
                     CredentialConfigurationIdentifier(PID_SdJwtVC),
                 )
                 val (newAuthorizedRequest, outcome) =
-                    authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+                    authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
                 assertIs<SubmissionOutcome.Deferred>(outcome)
 
                 assertFailsWith<CredentialIssuanceError.InvalidResponseContentType>(
@@ -643,7 +643,7 @@ class IssuanceIssuerMetadataVersionTest {
                     CredentialConfigurationIdentifier(PID_SdJwtVC),
                 )
                 val (newAuthorizedRequest, outcome) =
-                    authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+                    authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
                 assertIs<SubmissionOutcome.Deferred>(outcome)
 
                 val (_, deferredOutcome) = newAuthorizedRequest.queryForDeferredCredential(outcome.transactionId).getOrThrow()
@@ -704,7 +704,7 @@ class IssuanceIssuerMetadataVersionTest {
                 CredentialConfigurationIdentifier(PID_SdJwtVC),
             )
             val (newAuthorizedRequest, outcome) =
-                authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+                authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
             assertIs<SubmissionOutcome.Deferred>(outcome)
 
             val (_, deferredOutcome) =

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceNotificationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceNotificationTest.kt
@@ -16,7 +16,7 @@
 package eu.europa.ec.eudi.openid4vci
 
 import com.nimbusds.jose.jwk.Curve
-import eu.europa.ec.eudi.openid4vci.CryptoGenerator.jwtProofSpec
+import eu.europa.ec.eudi.openid4vci.CryptoGenerator.jwtProofWithKeyAttestationSpec
 import eu.europa.ec.eudi.openid4vci.internal.http.NotificationEventTO
 import eu.europa.ec.eudi.openid4vci.internal.http.NotificationTO
 import io.ktor.client.engine.mock.*
@@ -73,7 +73,7 @@ class IssuanceNotificationTest {
             val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
             val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
             val (newAuthorizedRequest, outcome) =
-                authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+                authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
             assertIs<SubmissionOutcome.Success>(outcome)
 
             val issuedCredential = outcome.credentials.firstOrNull()

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
@@ -284,8 +284,8 @@ class IssuanceSingleRequestTest {
                         "c_nonce expected to be found in proof but was not",
                     )
                     assertEquals(
-                        cNonce,
                         nonceValue,
+                        cNonce,
                         "Expected c_nonce $nonceValue but found $cNonce",
                     )
                 },
@@ -1156,7 +1156,7 @@ class IssuanceSingleRequestTest {
                 config = OpenId4VCIConfiguration.copy(
                     proofs = ProofsConfig(
                         isNoProofSupported = false,
-                        jwtProof = ProofsConfig.SupportedJwtProof(setOf(JWSAlgorithm.ES512)),
+                        jwtProof = ProofsConfig.SupportedJwtProof(setOf(JWSAlgorithm.ES512), true),
                         attestationProof = null,
                     ),
                 ),

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
@@ -23,6 +23,7 @@ import com.nimbusds.jwt.SignedJWT
 import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.ResponseUnparsable
 import eu.europa.ec.eudi.openid4vci.CryptoGenerator.attestationProofSpec
 import eu.europa.ec.eudi.openid4vci.CryptoGenerator.jwtProofWithKeyAttestationSpec
+import eu.europa.ec.eudi.openid4vci.CryptoGenerator.jwtProofsWithoutKeyAttestation
 import eu.europa.ec.eudi.openid4vci.IssuerMetadataVersion.NO_NONCE_ENDPOINT
 import eu.europa.ec.eudi.openid4vci.examples.selfSignedClient
 import eu.europa.ec.eudi.openid4vci.examples.verifySelfSignedClientAttestation
@@ -148,33 +149,35 @@ class IssuanceSingleRequestTest {
             assertFailsWith<CredentialIssuanceError.IssuerBatchSizeLimitExceeded> {
                 with(issuer) {
                     val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-                    authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256, 4)).getOrThrow()
+                    authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256, 4))
+                        .getOrThrow()
                 }
             }
         }
 
     @Test
-    fun `when attestation proof contains more attested keys than the batch limit IssuerBatchSizeLimitExceeded is thrown`() = runTest {
-        val mockedKtorHttpClientFactory = mockedHttpClient(
-            credentialIssuerMetadataWellKnownMocker(IssuerMetadataVersion.ATTESTATION_PROOF_SUPPORTED),
-            authServerWellKnownMocker(),
-            parPostMocker(),
-            tokenPostMocker(),
-            nonceEndpointMocker(),
-        )
-        val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
-            httpClient = mockedKtorHttpClientFactory,
-        )
+    fun `when attestation proof contains more attested keys than the batch limit IssuerBatchSizeLimitExceeded is thrown`() =
+        runTest {
+            val mockedKtorHttpClientFactory = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(IssuerMetadataVersion.ATTESTATION_PROOF_SUPPORTED),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                tokenPostMocker(),
+                nonceEndpointMocker(),
+            )
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
+                httpClient = mockedKtorHttpClientFactory,
+            )
 
-        val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
-        assertFailsWith<CredentialIssuanceError.IssuerBatchSizeLimitExceeded> {
-            with(issuer) {
-                val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-                authorizedRequest.request(requestPayload, attestationProofSpec(keysNo = 4)).getOrThrow()
+            val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
+            assertFailsWith<CredentialIssuanceError.IssuerBatchSizeLimitExceeded> {
+                with(issuer) {
+                    val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
+                    authorizedRequest.request(requestPayload, attestationProofSpec(keysNo = 4)).getOrThrow()
+                }
             }
         }
-    }
 
     @Test
     fun `when credential configuration config does not demand proofs, no proof is included in the request`() = runTest {
@@ -210,42 +213,43 @@ class IssuanceSingleRequestTest {
     }
 
     @Test
-    fun `when credential configuration config demands proofs and issuer has no nonce endpoint, expect proofs without nonce`() = runTest {
-        val mockedKtorHttpClientFactory = mockedHttpClient(
-            credentialIssuerMetadataWellKnownMocker(NO_NONCE_ENDPOINT),
-            authServerWellKnownMocker(),
-            parPostMocker(),
-            tokenPostMocker(),
-            singleIssuanceRequestMocker(
-                requestValidator = {
-                    val textContent = it.body as TextContent
-                    val issuanceRequest = Json.decodeFromString<CredentialRequestTO>(textContent.text)
-                    assertNotNull(
-                        issuanceRequest.proofs,
-                        "Proof expected to be sent but was not sent.",
-                    )
-                    val jwtProofs = assertNotNull(issuanceRequest.proofs.jwtProofs)
-                    val distinctNonces = jwtProofs
-                        .map { SignedJWT.parse(it) }
-                        .mapNotNull { it.jwtClaimsSet.getStringClaim("nonce") }
-                        .distinct()
+    fun `when credential configuration config demands proofs and issuer has no nonce endpoint, expect proofs without nonce`() =
+        runTest {
+            val mockedKtorHttpClientFactory = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(NO_NONCE_ENDPOINT),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                tokenPostMocker(),
+                singleIssuanceRequestMocker(
+                    requestValidator = {
+                        val textContent = it.body as TextContent
+                        val issuanceRequest = Json.decodeFromString<CredentialRequestTO>(textContent.text)
+                        assertNotNull(
+                            issuanceRequest.proofs,
+                            "Proof expected to be sent but was not sent.",
+                        )
+                        val jwtProofs = assertNotNull(issuanceRequest.proofs.jwtProofs)
+                        val distinctNonces = jwtProofs
+                            .map { SignedJWT.parse(it) }
+                            .mapNotNull { it.jwtClaimsSet.getStringClaim("nonce") }
+                            .distinct()
 
-                    assertTrue(distinctNonces.isEmpty(), "No c_nonce expected in proof but found one")
-                },
-            ),
-        )
+                        assertTrue(distinctNonces.isEmpty(), "No c_nonce expected in proof but found one")
+                    },
+                ),
+            )
 
-        val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
-            httpClient = mockedKtorHttpClientFactory,
-        )
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
+                httpClient = mockedKtorHttpClientFactory,
+            )
 
-        val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
-        with(issuer) {
-            val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-            authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
+            val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
+            with(issuer) {
+                val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
+                authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
+            }
         }
-    }
 
     @Test
     fun `successful issuance of credential requested by credential configuration id`() = runTest {
@@ -307,117 +311,121 @@ class IssuanceSingleRequestTest {
     }
 
     @Test
-    fun `when token endpoint returns credential identifiers, issuance request must be IdentifierBasedIssuanceRequestTO`() = runTest {
-        val mockedKtorHttpClientFactory = mockedHttpClient(
-            credentialIssuerMetadataWellKnownMocker(),
-            authServerWellKnownMocker(),
-            parPostMocker(),
-            nonceEndpointMocker(),
-            tokenPostMockerWithAuthDetails(
-                listOf(CredentialConfigurationIdentifier("eu.europa.ec.eudiw.pid_vc_sd_jwt")),
-            ),
-            singleIssuanceRequestMocker(
-                credential = "credential",
-                requestValidator = {
-                    val textContent = it.body as TextContent
-                    val issuanceRequestTO = Json.decodeFromString<CredentialRequestTO>(textContent.text)
-                    assertNotNull(
-                        issuanceRequestTO.credentialIdentifier,
-                        "Expected identifier based issuance request but credential_identifier is null",
-                    )
-                },
-            ),
-        )
-        val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
-            httpClient = mockedKtorHttpClientFactory,
-        )
-
-        val requestPayload = authorizedRequest.credentialIdentifiers?.let {
-            IssuanceRequestPayload.IdentifierBased(
-                it.entries.first().key,
-                it.entries.first().value[0],
+    fun `when token endpoint returns credential identifiers, issuance request must be IdentifierBasedIssuanceRequestTO`() =
+        runTest {
+            val mockedKtorHttpClientFactory = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                nonceEndpointMocker(),
+                tokenPostMockerWithAuthDetails(
+                    listOf(CredentialConfigurationIdentifier("eu.europa.ec.eudiw.pid_vc_sd_jwt")),
+                ),
+                singleIssuanceRequestMocker(
+                    credential = "credential",
+                    requestValidator = {
+                        val textContent = it.body as TextContent
+                        val issuanceRequestTO = Json.decodeFromString<CredentialRequestTO>(textContent.text)
+                        assertNotNull(
+                            issuanceRequestTO.credentialIdentifier,
+                            "Expected identifier based issuance request but credential_identifier is null",
+                        )
+                    },
+                ),
             )
-        } ?: error("No credential identifier")
-        with(issuer) {
-            authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256, 1)).getOrThrow()
-        }
-    }
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
+                httpClient = mockedKtorHttpClientFactory,
+            )
 
-    @Test
-    fun `when request is by credential id, this id must be in the list of identifiers returned from token endpoint`() = runTest {
-        val mockedKtorHttpClientFactory = mockedHttpClient(
-            credentialIssuerMetadataWellKnownMocker(),
-            authServerWellKnownMocker(),
-            parPostMocker(),
-            nonceEndpointMocker(),
-            tokenPostMockerWithAuthDetails(
-                listOf(CredentialConfigurationIdentifier("eu.europa.ec.eudiw.pid_vc_sd_jwt")),
-            ),
-            singleIssuanceRequestMocker(
-                credential = "credential",
-                requestValidator = {
-                    val textContent = it.body as TextContent
-                    val issuanceRequestTO = Json.decodeFromString<CredentialRequestTO>(textContent.text)
-                    assertNotNull(
-                        issuanceRequestTO.credentialResponseEncryption,
-                        "Expected identifier based issuance request but credential_identifier is null",
-                    )
-                },
-            ),
-        )
-        val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
-            httpClient = mockedKtorHttpClientFactory,
-        )
-
-        val requestPayload = IssuanceRequestPayload.IdentifierBased(
-            CredentialConfigurationIdentifier("eu.europa.ec.eudiw.pid_vc_sd_jwt"),
-            CredentialIdentifier("DUMMY"),
-        )
-        assertThrows<IllegalArgumentException> {
+            val requestPayload = authorizedRequest.credentialIdentifiers?.let {
+                IssuanceRequestPayload.IdentifierBased(
+                    it.entries.first().key,
+                    it.entries.first().value[0],
+                )
+            } ?: error("No credential identifier")
             with(issuer) {
                 authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256, 1)).getOrThrow()
             }
         }
-    }
 
     @Test
-    fun `issuance request by credential id, is allowed only when token endpoint has returned credential identifiers`() = runTest {
-        val mockedKtorHttpClientFactory = mockedHttpClient(
-            credentialIssuerMetadataWellKnownMocker(),
-            authServerWellKnownMocker(),
-            parPostMocker(),
-            tokenPostMocker(),
-            nonceEndpointMocker(),
-            singleIssuanceRequestMocker(
-                credential = "credential",
-                requestValidator = {
-                    val textContent = it.body as TextContent
-                    val issuanceRequestTO = Json.decodeFromString<CredentialRequestTO>(textContent.text)
-                    assertNotNull(
-                        issuanceRequestTO.credentialIdentifier,
-                        "Expected identifier based issuance request but credential_identifier is null",
+    fun `when request is by credential id, this id must be in the list of identifiers returned from token endpoint`() =
+        runTest {
+            val mockedKtorHttpClientFactory = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                nonceEndpointMocker(),
+                tokenPostMockerWithAuthDetails(
+                    listOf(CredentialConfigurationIdentifier("eu.europa.ec.eudiw.pid_vc_sd_jwt")),
+                ),
+                singleIssuanceRequestMocker(
+                    credential = "credential",
+                    requestValidator = {
+                        val textContent = it.body as TextContent
+                        val issuanceRequestTO = Json.decodeFromString<CredentialRequestTO>(textContent.text)
+                        assertNotNull(
+                            issuanceRequestTO.credentialResponseEncryption,
+                            "Expected identifier based issuance request but credential_identifier is null",
+                        )
+                    },
+                ),
+            )
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
+                httpClient = mockedKtorHttpClientFactory,
+            )
 
-                    )
-                },
-            ),
-        )
-        val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
-            httpClient = mockedKtorHttpClientFactory,
-        )
-
-        val requestPayload = IssuanceRequestPayload.IdentifierBased(
-            CredentialConfigurationIdentifier("eu.europa.ec.eudiw.pid_vc_sd_jwt"),
-            CredentialIdentifier("id"),
-        )
-        assertThrows<IllegalArgumentException> {
-            with(issuer) {
-                authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
+            val requestPayload = IssuanceRequestPayload.IdentifierBased(
+                CredentialConfigurationIdentifier("eu.europa.ec.eudiw.pid_vc_sd_jwt"),
+                CredentialIdentifier("DUMMY"),
+            )
+            assertThrows<IllegalArgumentException> {
+                with(issuer) {
+                    authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256, 1))
+                        .getOrThrow()
+                }
             }
         }
-    }
+
+    @Test
+    fun `issuance request by credential id, is allowed only when token endpoint has returned credential identifiers`() =
+        runTest {
+            val mockedKtorHttpClientFactory = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                tokenPostMocker(),
+                nonceEndpointMocker(),
+                singleIssuanceRequestMocker(
+                    credential = "credential",
+                    requestValidator = {
+                        val textContent = it.body as TextContent
+                        val issuanceRequestTO = Json.decodeFromString<CredentialRequestTO>(textContent.text)
+                        assertNotNull(
+                            issuanceRequestTO.credentialIdentifier,
+                            "Expected identifier based issuance request but credential_identifier is null",
+
+                        )
+                    },
+                ),
+            )
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
+                httpClient = mockedKtorHttpClientFactory,
+            )
+
+            val requestPayload = IssuanceRequestPayload.IdentifierBased(
+                CredentialConfigurationIdentifier("eu.europa.ec.eudiw.pid_vc_sd_jwt"),
+                CredentialIdentifier("id"),
+            )
+            assertThrows<IllegalArgumentException> {
+                with(issuer) {
+                    authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
+                }
+            }
+        }
 
     @Test
     fun `when token endpoint returns authorization_details they are parsed properly`() = runTest {
@@ -452,17 +460,18 @@ class IssuanceSingleRequestTest {
     }
 
     @Test
-    fun `when successful issuance response contains additional info, it is reflected in SubmissionOutcome_Success`() = runTest {
-        val mockedKtorHttpClientFactory = mockedHttpClient(
-            credentialIssuerMetadataWellKnownMocker(),
-            authServerWellKnownMocker(),
-            parPostMocker(),
-            tokenPostMocker(),
-            nonceEndpointMocker(),
-            singleIssuanceRequestMocker(
-                responseBuilder = {
-                    respond(
-                        content = """
+    fun `when successful issuance response contains additional info, it is reflected in SubmissionOutcome_Success`() =
+        runTest {
+            val mockedKtorHttpClientFactory = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                tokenPostMocker(),
+                nonceEndpointMocker(),
+                singleIssuanceRequestMocker(
+                    responseBuilder = {
+                        respond(
+                            content = """
                                 {                                  
                                   "credentials": [{
                                        "credential": "credential_content",
@@ -475,284 +484,290 @@ class IssuanceSingleRequestTest {
                                    }],
                                   "notification_id": "valbQc6p55LS"
                                 }
-                        """.trimIndent(),
-                        status = HttpStatusCode.OK,
-                        headers = headersOf(
-                            HttpHeaders.ContentType to listOf("application/json"),
-                        ),
-                    )
-                },
-            ),
-        )
-        val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
-            httpClient = mockedKtorHttpClientFactory,
-        )
+                            """.trimIndent(),
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(
+                                HttpHeaders.ContentType to listOf("application/json"),
+                            ),
+                        )
+                    },
+                ),
+            )
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
+                httpClient = mockedKtorHttpClientFactory,
+            )
 
-        with(issuer) {
-            val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
-            val (_, outcome) = assertDoesNotThrow {
-                val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-                authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
+            with(issuer) {
+                val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
+                val (_, outcome) = assertDoesNotThrow {
+                    val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
+                    authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
+                }
+                assertIs<SubmissionOutcome.Success>(outcome)
+                assertTrue { outcome.credentials.size == 1 }
+                assertIs<Credential.Str>(outcome.credentials[0].credential)
+
+                val credAdditionalInfo = outcome.credentials[0].additionalInfo
+                assertNotNull(credAdditionalInfo)
+                assertNull(credAdditionalInfo["credential"])
+                assertIs<JsonObject>(credAdditionalInfo["infoObj"])
+                assertIs<JsonPrimitive>(credAdditionalInfo["infoStr"])
+                assertIs<JsonArray>(credAdditionalInfo["infoArr"])
             }
-            assertIs<SubmissionOutcome.Success>(outcome)
-            assertTrue { outcome.credentials.size == 1 }
-            assertIs<Credential.Str>(outcome.credentials[0].credential)
-
-            val credAdditionalInfo = outcome.credentials[0].additionalInfo
-            assertNotNull(credAdditionalInfo)
-            assertNull(credAdditionalInfo["credential"])
-            assertIs<JsonObject>(credAdditionalInfo["infoObj"])
-            assertIs<JsonPrimitive>(credAdditionalInfo["infoStr"])
-            assertIs<JsonArray>(credAdditionalInfo["infoArr"])
         }
-    }
 
     @Test
-    fun `when successful issuance response does not contain 'credential' attribute fails with ResponseUnparsable exception`() = runTest {
-        val mockedKtorHttpClientFactory = mockedHttpClient(
-            credentialIssuerMetadataWellKnownMocker(),
-            authServerWellKnownMocker(),
-            parPostMocker(),
-            tokenPostMocker(),
-            nonceEndpointMocker(),
-            singleIssuanceRequestMocker(
-                responseBuilder = {
-                    respond(
-                        content = """
+    fun `when successful issuance response does not contain 'credential' attribute fails with ResponseUnparsable exception`() =
+        runTest {
+            val mockedKtorHttpClientFactory = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                tokenPostMocker(),
+                nonceEndpointMocker(),
+                singleIssuanceRequestMocker(
+                    responseBuilder = {
+                        respond(
+                            content = """
                                 {                                  
                                   "credentials": [{
                                        "crdntial": "credential_content"                                                                          
                                    }],
                                   "notification_id": "valbQc6p55LS"
                                 }
-                        """.trimIndent(),
-                        status = HttpStatusCode.OK,
-                        headers = headersOf(
-                            HttpHeaders.ContentType to listOf("application/json"),
-                        ),
-                    )
-                },
-            ),
-        )
-        val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
-            httpClient = mockedKtorHttpClientFactory,
-        )
+                            """.trimIndent(),
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(
+                                HttpHeaders.ContentType to listOf("application/json"),
+                            ),
+                        )
+                    },
+                ),
+            )
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
+                httpClient = mockedKtorHttpClientFactory,
+            )
 
-        with(issuer) {
+            with(issuer) {
+                val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
+                val ex = assertFailsWith<JsonConvertException> {
+                    val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
+                    authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
+                }
+                assertIs<ResponseUnparsable>(ex.cause)
+            }
+        }
+
+    @Test
+    fun `when authorized with pre-authorization code grand and client is public, 'iss' attribute is not included in proof`() =
+        runTest {
+            val mockedKtorHttpClientFactory = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(),
+                authServerWellKnownMocker(),
+                tokenPostMocker { request ->
+                    with(request) { tokenPostApplyPreAuthFlowAssertionsAndGetFormData() }
+                },
+                nonceEndpointMocker(),
+                singleIssuanceRequestMocker(
+                    requestValidator = {
+                        val textContent = it.body as TextContent
+                        val issuanceRequest = Json.decodeFromString<CredentialRequestTO>(textContent.text)
+                        assertNotNull(
+                            issuanceRequest.proofs,
+                            "Proof expected to be sent but was not sent.",
+                        )
+                        assertNotNull(issuanceRequest.proofs.jwtProofs)
+                        val jwtProofStr = issuanceRequest.proofs.jwtProofs[0]
+                        val jwtProof = SignedJWT.parse(jwtProofStr)
+
+                        val iss = jwtProof.jwtClaimsSet.getStringClaim("iss")
+                        assertNull(iss, "No 'iss' claim expected in proof but found one")
+                    },
+                ),
+            )
+
+            val (authorizedRequest, issuer) = preAuthorizeRequestForCredentialOffer(
+                credentialOfferStr = CredentialOfferMixedDocTypes_PRE_AUTH_GRANT,
+                httpClient = mockedKtorHttpClientFactory,
+                txCode = "1234",
+            )
+
             val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
-            val ex = assertFailsWith<JsonConvertException> {
+            with(issuer) {
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
                 authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
             }
-            assertIs<ResponseUnparsable>(ex.cause)
         }
-    }
 
     @Test
-    fun `when authorized with pre-authorization code grand and client is public, 'iss' attribute is not included in proof`() = runTest {
-        val mockedKtorHttpClientFactory = mockedHttpClient(
-            credentialIssuerMetadataWellKnownMocker(),
-            authServerWellKnownMocker(),
-            tokenPostMocker { request ->
-                with(request) { tokenPostApplyPreAuthFlowAssertionsAndGetFormData() }
-            },
-            nonceEndpointMocker(),
-            singleIssuanceRequestMocker(
-                requestValidator = {
-                    val textContent = it.body as TextContent
-                    val issuanceRequest = Json.decodeFromString<CredentialRequestTO>(textContent.text)
-                    assertNotNull(
-                        issuanceRequest.proofs,
-                        "Proof expected to be sent but was not sent.",
-                    )
-                    assertNotNull(issuanceRequest.proofs.jwtProofs)
-                    val jwtProofStr = issuanceRequest.proofs.jwtProofs[0]
-                    val jwtProof = SignedJWT.parse(jwtProofStr)
+    fun `when dpop is supported from auth server, access token is of dpop type and dpop jwt is sent the issuance request `() =
+        runTest {
+            val mockedKtorHttpClientFactory = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                nonceEndpointMocker(),
+                tokenPostMocker(dpopAccessToken = true),
+                singleIssuanceRequestMocker(
+                    requestValidator = {
+                        val headers = it.headers
 
-                    val iss = jwtProof.jwtClaimsSet.getStringClaim("iss")
-                    assertNull(iss, "No 'iss' claim expected in proof but found one")
-                },
-            ),
-        )
+                        val authorizationHeader = headers.get("Authorization")
+                        assertNotNull(authorizationHeader, "No Authorization header found.")
+                        assertTrue(authorizationHeader.contains("DPoP"), "Expected DPoP access token but was not.")
 
-        val (authorizedRequest, issuer) = preAuthorizeRequestForCredentialOffer(
-            credentialOfferStr = CredentialOfferMixedDocTypes_PRE_AUTH_GRANT,
-            httpClient = mockedKtorHttpClientFactory,
-            txCode = "1234",
-        )
+                        val dpopHeader = headers.get("DPoP")
+                        assertNotNull(
+                            dpopHeader,
+                            "No DPoP found.",
+                        )
+                        val dpopJwt = SignedJWT.parse(dpopHeader)
+                        assertTrue(
+                            dpopJwt.state == JWSObject.State.SIGNED,
+                            "Expected a signed dpop jwt but was not",
+                        )
+                        assertTrue(
+                            dpopJwt.header.type.toString() == "dpop+jwt",
+                            "Wrong DPoP JWT. Type expected to be dpop+jwt but was not",
+                        )
+                        assertNotNull(
+                            dpopJwt.jwtClaimsSet.claims.get("htm"),
+                            "Expected htm claim but didn't find one.",
+                        )
+                        assertNotNull(
+                            dpopJwt.jwtClaimsSet.claims.get("htu"),
+                            "Expected htu claim but didn't find one.",
+                        )
+                    },
+                ),
+            )
 
-        val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
-        with(issuer) {
-            val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-            authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
-        }
-    }
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                config = OpenId4VCIConfigurationWithDpopSigner,
+                credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
+                httpClient = mockedKtorHttpClientFactory,
+            )
 
-    @Test
-    fun `when dpop is supported from auth server, access token is of dpop type and dpop jwt is sent the issuance request `() = runTest {
-        val mockedKtorHttpClientFactory = mockedHttpClient(
-            credentialIssuerMetadataWellKnownMocker(),
-            authServerWellKnownMocker(),
-            parPostMocker(),
-            nonceEndpointMocker(),
-            tokenPostMocker(dpopAccessToken = true),
-            singleIssuanceRequestMocker(
-                requestValidator = {
-                    val headers = it.headers
-
-                    val authorizationHeader = headers.get("Authorization")
-                    assertNotNull(authorizationHeader, "No Authorization header found.")
-                    assertTrue(authorizationHeader.contains("DPoP"), "Expected DPoP access token but was not.")
-
-                    val dpopHeader = headers.get("DPoP")
-                    assertNotNull(
-                        dpopHeader,
-                        "No DPoP found.",
-                    )
-                    val dpopJwt = SignedJWT.parse(dpopHeader)
-                    assertTrue(
-                        dpopJwt.state == JWSObject.State.SIGNED,
-                        "Expected a signed dpop jwt but was not",
-                    )
-                    assertTrue(
-                        dpopJwt.header.type.toString() == "dpop+jwt",
-                        "Wrong DPoP JWT. Type expected to be dpop+jwt but was not",
-                    )
-                    assertNotNull(
-                        dpopJwt.jwtClaimsSet.claims.get("htm"),
-                        "Expected htm claim but didn't find one.",
-                    )
-                    assertNotNull(
-                        dpopJwt.jwtClaimsSet.claims.get("htu"),
-                        "Expected htu claim but didn't find one.",
-                    )
-                },
-            ),
-        )
-
-        val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            config = OpenId4VCIConfigurationWithDpopSigner,
-            credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
-            httpClient = mockedKtorHttpClientFactory,
-        )
-
-        val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
-        with(issuer) {
-            val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-            authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
-        }
-    }
-
-    @Test
-    fun `when dpop supported from auth server and issuer nonce endpoint provides dpop nonces, they are included in dpop jwt`() = runTest {
-        val mockedKtorHttpClientFactory = mockedHttpClient(
-            credentialIssuerMetadataWellKnownMocker(),
-            authServerWellKnownMocker(),
-            parPostMocker(),
-            nonceEndpointMocker(dPopNonceValue = "nonce_endpoint_dpop_nonce"),
-            tokenPostMocker(dpopAccessToken = true),
-            singleIssuanceRequestMocker(
-                requestValidator = {
-                    val headers = it.headers
-
-                    val authorizationHeader = headers.get("Authorization")
-                    assertNotNull(authorizationHeader, "No Authorization header found.")
-                    assertTrue(authorizationHeader.contains("DPoP"), "Expected DPoP access token but was not.")
-
-                    val dpopHeader = headers.get("DPoP")
-                    assertNotNull(
-                        dpopHeader,
-                        "No DPoP found.",
-                    )
-                    val dpopJwt = SignedJWT.parse(dpopHeader)
-                    assertNotNull(
-                        dpopJwt.jwtClaimsSet.claims.get("nonce"),
-                        "Expected nonce but didn't find one.",
-                    )
-                    assertTrue("Expected dpop nonce from issuer's nonce endpoint but wasn't.") {
-                        "nonce_endpoint_dpop_nonce" == dpopJwt.jwtClaimsSet.claims.get("nonce")
-                    }
-                },
-            ),
-        )
-
-        val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            config = OpenId4VCIConfigurationWithDpopSigner,
-            credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
-            httpClient = mockedKtorHttpClientFactory,
-        )
-
-        val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
-        with(issuer) {
-            val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-            authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
-        }
-    }
-
-    @Test
-    fun `when dpop is not supported from auth server, access token is of Bearer type and no dpop jwt is sent`() = runTest {
-        val mockedKtorHttpClientFactory = mockedHttpClient(
-            credentialIssuerMetadataWellKnownMocker(),
-            authServerWellKnownMocker(AuthServerMetadataVersion.NO_DPOP),
-            parPostMocker {
-                assertNull(it.headers["DPoP"])
-            },
-            nonceEndpointMocker(),
-            tokenPostMocker(dpopAccessToken = false) {
-                assertNull(it.headers["DPoP"])
-            },
-            singleIssuanceRequestMocker(
-                requestValidator = {
-                    val headers = it.headers
-
-                    val authorizationHeader = headers.get("Authorization")
-                    assertNotNull(authorizationHeader, "No Authorization header found.")
-                    assertTrue(authorizationHeader.contains("Bearer"), "Expected Bearer access token but was not.")
-
-                    val dpopHeader = headers.get("DPoP")
-                    assertNull(dpopHeader, "No DPoP expected but one found.")
-                },
-            ),
-        )
-
-        val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            config = OpenId4VCIConfigurationWithDpopSigner,
-            credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
-            httpClient = mockedKtorHttpClientFactory,
-        )
-
-        val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
-        with(issuer) {
-            val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-            authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
-        }
-    }
-
-    @Test
-    fun `issuance fails if jwt proof with key attestation is signed with algorithm not in jwt proof's supported algorithms`() = runTest {
-        val mockedHttpClient = mockedHttpClient(
-            credentialIssuerMetadataWellKnownMocker(),
-            authServerWellKnownMocker(),
-            parPostMocker(),
-            tokenPostMocker(),
-            nonceEndpointMocker(),
-            singleIssuanceRequestMocker(),
-        )
-        val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
-            httpClient = mockedHttpClient,
-        )
-
-        val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
-        assertFailsWith<CredentialIssuanceError.ProofGenerationError.ProofTypeSigningAlgorithmNotSupported> {
+            val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
             with(issuer) {
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-                authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_384)).getOrThrow()
+                authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
             }
         }
-    }
+
+    @Test
+    fun `when dpop supported from auth server and issuer nonce endpoint provides dpop nonces, they are included in dpop jwt`() =
+        runTest {
+            val mockedKtorHttpClientFactory = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                nonceEndpointMocker(dPopNonceValue = "nonce_endpoint_dpop_nonce"),
+                tokenPostMocker(dpopAccessToken = true),
+                singleIssuanceRequestMocker(
+                    requestValidator = {
+                        val headers = it.headers
+
+                        val authorizationHeader = headers.get("Authorization")
+                        assertNotNull(authorizationHeader, "No Authorization header found.")
+                        assertTrue(authorizationHeader.contains("DPoP"), "Expected DPoP access token but was not.")
+
+                        val dpopHeader = headers.get("DPoP")
+                        assertNotNull(
+                            dpopHeader,
+                            "No DPoP found.",
+                        )
+                        val dpopJwt = SignedJWT.parse(dpopHeader)
+                        assertNotNull(
+                            dpopJwt.jwtClaimsSet.claims.get("nonce"),
+                            "Expected nonce but didn't find one.",
+                        )
+                        assertTrue("Expected dpop nonce from issuer's nonce endpoint but wasn't.") {
+                            "nonce_endpoint_dpop_nonce" == dpopJwt.jwtClaimsSet.claims.get("nonce")
+                        }
+                    },
+                ),
+            )
+
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                config = OpenId4VCIConfigurationWithDpopSigner,
+                credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
+                httpClient = mockedKtorHttpClientFactory,
+            )
+
+            val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
+            with(issuer) {
+                val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
+                authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
+            }
+        }
+
+    @Test
+    fun `when dpop is not supported from auth server, access token is of Bearer type and no dpop jwt is sent`() =
+        runTest {
+            val mockedKtorHttpClientFactory = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(),
+                authServerWellKnownMocker(AuthServerMetadataVersion.NO_DPOP),
+                parPostMocker {
+                    assertNull(it.headers["DPoP"])
+                },
+                nonceEndpointMocker(),
+                tokenPostMocker(dpopAccessToken = false) {
+                    assertNull(it.headers["DPoP"])
+                },
+                singleIssuanceRequestMocker(
+                    requestValidator = {
+                        val headers = it.headers
+
+                        val authorizationHeader = headers.get("Authorization")
+                        assertNotNull(authorizationHeader, "No Authorization header found.")
+                        assertTrue(authorizationHeader.contains("Bearer"), "Expected Bearer access token but was not.")
+
+                        val dpopHeader = headers.get("DPoP")
+                        assertNull(dpopHeader, "No DPoP expected but one found.")
+                    },
+                ),
+            )
+
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                config = OpenId4VCIConfigurationWithDpopSigner,
+                credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
+                httpClient = mockedKtorHttpClientFactory,
+            )
+
+            val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
+            with(issuer) {
+                val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
+                authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
+            }
+        }
+
+    @Test
+    fun `issuance fails if jwt proof with key attestation is signed with algorithm not in jwt proof's supported algorithms`() =
+        runTest {
+            val mockedHttpClient = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                tokenPostMocker(),
+                nonceEndpointMocker(),
+                singleIssuanceRequestMocker(),
+            )
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
+                httpClient = mockedHttpClient,
+            )
+
+            val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
+            assertFailsWith<CredentialIssuanceError.ProofGenerationError.ProofTypeSigningAlgorithmNotSupported> {
+                with(issuer) {
+                    val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
+                    authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_384)).getOrThrow()
+                }
+            }
+        }
 
     @Test
     fun `issuance with attestation proof is successful when the issuer supports it `() = runTest {
@@ -780,80 +795,83 @@ class IssuanceSingleRequestTest {
     }
 
     @Test
-    fun `issuance fails if attestation proof's signing alg is not in issuer's supported algorithms for this proof type`() = runTest {
-        val mockedHttpClient = mockedHttpClient(
-            credentialIssuerMetadataWellKnownMocker(IssuerMetadataVersion.ATTESTATION_PROOF_SUPPORTED),
-            authServerWellKnownMocker(),
-            parPostMocker(),
-            tokenPostMocker(),
-            nonceEndpointMocker(),
-            singleIssuanceRequestMocker(),
-        )
-        val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
-            httpClient = mockedHttpClient,
-        )
+    fun `issuance fails if attestation proof's signing alg is not in issuer's supported algorithms for this proof type`() =
+        runTest {
+            val mockedHttpClient = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(IssuerMetadataVersion.ATTESTATION_PROOF_SUPPORTED),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                tokenPostMocker(),
+                nonceEndpointMocker(),
+                singleIssuanceRequestMocker(),
+            )
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
+                httpClient = mockedHttpClient,
+            )
 
-        val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
-        with(issuer) {
-            val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-            val proofSpec = attestationProofSpec(curve = Curve.P_384) { _, preferredKeyStorageStatusPeriod ->
-                assertEquals(1.days.toJavaDuration(), preferredKeyStorageStatusPeriod?.value)
+            val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
+            with(issuer) {
+                val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
+                val proofSpec = attestationProofSpec(curve = Curve.P_384) { _, preferredKeyStorageStatusPeriod ->
+                    assertEquals(1.days.toJavaDuration(), preferredKeyStorageStatusPeriod?.value)
+                }
+                authorizedRequest.request(requestPayload, proofSpec).getOrThrow()
             }
-            authorizedRequest.request(requestPayload, proofSpec).getOrThrow()
         }
-    }
 
     @Test
-    fun `issuance fails with attested client when authorization server does not support attest_jwt_client_auth`() = runTest {
-        val walletInstanceKey = ECKeyGenerator(Curve.P_521).keyID(UUID.randomUUID().toString()).generate()
-        val client = selfSignedClient(
-            walletInstanceKey = walletInstanceKey,
-            clientId = "MyWallet_ClientId",
-        )
-        val config = OpenId4VCIConfiguration.copy(clientAuthentication = client)
-
-        val mockedHttpClient = mockedHttpClient(
-            credentialIssuerMetadataWellKnownMocker(IssuerMetadataVersion.ATTESTATION_PROOF_SUPPORTED),
-            authServerWellKnownMocker(AuthServerMetadataVersion.NO_CLIENT_ATTESTATION),
-        )
-
-        val error = assertFailsWith<IllegalArgumentException> {
-            authorizeRequestForCredentialOffer(
-                config = config,
-                credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
-                httpClient = mockedHttpClient,
+    fun `issuance fails with attested client when authorization server does not support attest_jwt_client_auth`() =
+        runTest {
+            val walletInstanceKey = ECKeyGenerator(Curve.P_521).keyID(UUID.randomUUID().toString()).generate()
+            val client = selfSignedClient(
+                walletInstanceKey = walletInstanceKey,
+                clientId = "MyWallet_ClientId",
             )
+            val config = OpenId4VCIConfiguration.copy(clientAuthentication = client)
+
+            val mockedHttpClient = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(IssuerMetadataVersion.ATTESTATION_PROOF_SUPPORTED),
+                authServerWellKnownMocker(AuthServerMetadataVersion.NO_CLIENT_ATTESTATION),
+            )
+
+            val error = assertFailsWith<IllegalArgumentException> {
+                authorizeRequestForCredentialOffer(
+                    config = config,
+                    credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
+                    httpClient = mockedHttpClient,
+                )
+            }
+            assertTrue { "Authentication Method not supported by Authorization Server" in error.message.orEmpty() }
         }
-        assertTrue { "Authentication Method not supported by Authorization Server" in error.message.orEmpty() }
-    }
 
     @Test
-    fun `issuance fails with attest client with unsupported attestation jwt or attestation pop jwt signing algorithm`() = runTest {
-        val walletInstanceKey = ECKeyGenerator(Curve.P_256).keyID(UUID.randomUUID().toString()).generate()
-        val client = selfSignedClient(
-            walletInstanceKey = walletInstanceKey,
-            clientId = "MyWallet_ClientId",
-        )
-        val config = OpenId4VCIConfiguration.copy(clientAuthentication = client)
-
-        val mockedHttpClient = mockedHttpClient(
-            credentialIssuerMetadataWellKnownMocker(IssuerMetadataVersion.ATTESTATION_PROOF_SUPPORTED),
-            authServerWellKnownMocker(AuthServerMetadataVersion.FULL),
-        )
-
-        val error = assertFailsWith<IllegalArgumentException> {
-            authorizeRequestForCredentialOffer(
-                config = config,
-                credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
-                httpClient = mockedHttpClient,
+    fun `issuance fails with attest client with unsupported attestation jwt or attestation pop jwt signing algorithm`() =
+        runTest {
+            val walletInstanceKey = ECKeyGenerator(Curve.P_256).keyID(UUID.randomUUID().toString()).generate()
+            val client = selfSignedClient(
+                walletInstanceKey = walletInstanceKey,
+                clientId = "MyWallet_ClientId",
             )
+            val config = OpenId4VCIConfiguration.copy(clientAuthentication = client)
+
+            val mockedHttpClient = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(IssuerMetadataVersion.ATTESTATION_PROOF_SUPPORTED),
+                authServerWellKnownMocker(AuthServerMetadataVersion.FULL),
+            )
+
+            val error = assertFailsWith<IllegalArgumentException> {
+                authorizeRequestForCredentialOffer(
+                    config = config,
+                    credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
+                    httpClient = mockedHttpClient,
+                )
+            }
+            assertTrue {
+                "Client Attestation JWS Algorithm not supported by Authorization Server" in error.message.orEmpty() ||
+                    "Client Attestation POP JWS Algorithm not supported by Authorization Server" in error.message.orEmpty()
+            }
         }
-        assertTrue {
-            "Client Attestation JWS Algorithm not supported by Authorization Server" in error.message.orEmpty() ||
-                "Client Attestation POP JWS Algorithm not supported by Authorization Server" in error.message.orEmpty()
-        }
-    }
 
     @Test
     fun `issuance success with attested client`() = runTest {
@@ -957,54 +975,58 @@ class IssuanceSingleRequestTest {
     }
 
     @Test
-    fun `preferred_client_status_period is provided to wallet during client attestation provisioning if present`() = runTest {
-        suspend fun test(issuerMetadataVersion: IssuerMetadataVersion, expectedPreferredClientStatusPeriod: PositiveDuration?) {
-            val walletInstanceKey = ECKeyGenerator(Curve.P_521).keyID(UUID.randomUUID().toString()).generate()
-            val client = selfSignedClient(
-                walletInstanceKey = walletInstanceKey,
-                clientId = "MyWallet_ClientId",
-            ) { _, preferredClientStatusPeriod ->
-                when (expectedPreferredClientStatusPeriod) {
-                    null -> assertNull(preferredClientStatusPeriod)
-                    else -> assertEquals(expectedPreferredClientStatusPeriod, preferredClientStatusPeriod)
+    fun `preferred_client_status_period is provided to wallet during client attestation provisioning if present`() =
+        runTest {
+            suspend fun test(
+                issuerMetadataVersion: IssuerMetadataVersion,
+                expectedPreferredClientStatusPeriod: PositiveDuration?,
+            ) {
+                val walletInstanceKey = ECKeyGenerator(Curve.P_521).keyID(UUID.randomUUID().toString()).generate()
+                val client = selfSignedClient(
+                    walletInstanceKey = walletInstanceKey,
+                    clientId = "MyWallet_ClientId",
+                ) { _, preferredClientStatusPeriod ->
+                    when (expectedPreferredClientStatusPeriod) {
+                        null -> assertNull(preferredClientStatusPeriod)
+                        else -> assertEquals(expectedPreferredClientStatusPeriod, preferredClientStatusPeriod)
+                    }
+                }
+                val abcaChallenge = Nonce(UUID.randomUUID().toString())
+                val updatedAbcaChallenge = Nonce(UUID.randomUUID().toString())
+
+                val mockedHttpClient = mockedHttpClient(
+                    credentialIssuerMetadataWellKnownMocker(issuerMetadataVersion),
+                    authServerWellKnownMocker(AuthServerMetadataVersion.FULL),
+                    challengePostMocker(abcaChallenge),
+                    parPostMocker {
+                        it.verifySelfSignedClientAttestation(walletInstanceKey, abcaChallenge)
+                    },
+                    challengePostMocker(updatedAbcaChallenge),
+                    tokenPostMocker {
+                        it.verifySelfSignedClientAttestation(walletInstanceKey, updatedAbcaChallenge)
+                    },
+                    nonceEndpointMocker(),
+                    singleIssuanceRequestMocker(),
+                )
+
+                val config = OpenId4VCIConfiguration.copy(clientAuthentication = client)
+
+                val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                    config = config,
+                    credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
+                    httpClient = mockedHttpClient,
+                )
+
+                val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
+                with(issuer) {
+                    val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
+                    authorizedRequest.request(requestPayload, attestationProofSpec()).getOrThrow()
                 }
             }
-            val abcaChallenge = Nonce(UUID.randomUUID().toString())
-            val updatedAbcaChallenge = Nonce(UUID.randomUUID().toString())
 
-            val mockedHttpClient = mockedHttpClient(
-                credentialIssuerMetadataWellKnownMocker(issuerMetadataVersion),
-                authServerWellKnownMocker(AuthServerMetadataVersion.FULL),
-                challengePostMocker(abcaChallenge),
-                parPostMocker {
-                    it.verifySelfSignedClientAttestation(walletInstanceKey, abcaChallenge)
-                },
-                challengePostMocker(updatedAbcaChallenge),
-                tokenPostMocker {
-                    it.verifySelfSignedClientAttestation(walletInstanceKey, updatedAbcaChallenge)
-                },
-                nonceEndpointMocker(),
-                singleIssuanceRequestMocker(),
-            )
-
-            val config = OpenId4VCIConfiguration.copy(clientAuthentication = client)
-
-            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-                config = config,
-                credentialOfferStr = CredentialOfferMixedDocTypes_NO_GRANTS,
-                httpClient = mockedHttpClient,
-            )
-
-            val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
-            with(issuer) {
-                val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-                authorizedRequest.request(requestPayload, attestationProofSpec()).getOrThrow()
-            }
+            test(IssuerMetadataVersion.ATTESTATION_PROOF_SUPPORTED, null)
+            test(IssuerMetadataVersion.WITH_PREFERRED_CLIENT_STATUS_PERIOD, PositiveDuration(Duration.ofDays(30L)))
         }
-
-        test(IssuerMetadataVersion.ATTESTATION_PROOF_SUPPORTED, null)
-        test(IssuerMetadataVersion.WITH_PREFERRED_CLIENT_STATUS_PERIOD, PositiveDuration(Duration.ofDays(30L)))
-    }
 
     @Test
     fun `issuance fails for attested client when authorization server returns use_attestation_challenge and no challenge`() =
@@ -1202,29 +1224,30 @@ class IssuanceSingleRequestTest {
     }
 
     @Test
-    fun `when issuer supports only jwt proofs and wallet sends jwt proof with unsupported algorithm issuance fails`() = runTest {
-        val mockedHttpClient = mockedHttpClient(
-            credentialIssuerMetadataWellKnownMocker(IssuerMetadataVersion.ONLY_JWT_PROOFS_SUPPORTED),
-            authServerWellKnownMocker(),
-            parPostMocker(),
-            tokenPostMocker(),
-            nonceEndpointMocker(),
-            singleIssuanceRequestMocker(),
-        )
-        val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            credentialOfferStr = CredentialOfferWithSdJwtVc_NO_GRANTS,
-            httpClient = mockedHttpClient,
-        )
+    fun `when issuer supports only jwt proofs and wallet sends jwt proof with unsupported algorithm issuance fails`() =
+        runTest {
+            val mockedHttpClient = mockedHttpClient(
+                credentialIssuerMetadataWellKnownMocker(IssuerMetadataVersion.ONLY_JWT_PROOFS_SUPPORTED),
+                authServerWellKnownMocker(),
+                parPostMocker(),
+                tokenPostMocker(),
+                nonceEndpointMocker(),
+                singleIssuanceRequestMocker(),
+            )
+            val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
+                credentialOfferStr = CredentialOfferWithSdJwtVc_NO_GRANTS,
+                httpClient = mockedHttpClient,
+            )
 
-        val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
-        with(issuer) {
-            val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-            val proofSpec = jwtProofWithKeyAttestationSpec(Curve.P_521)
-            assertFailsWith<CredentialIssuanceError.ProofGenerationError.ProofTypeSigningAlgorithmNotSupported> {
-                authorizedRequest.request(requestPayload, proofSpec).getOrThrow()
+            val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
+            with(issuer) {
+                val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
+                val proofSpec = jwtProofWithKeyAttestationSpec(Curve.P_521)
+                assertFailsWith<CredentialIssuanceError.ProofGenerationError.ProofTypeSigningAlgorithmNotSupported> {
+                    authorizedRequest.request(requestPayload, proofSpec).getOrThrow()
+                }
             }
         }
-    }
 
     @Test
     fun `when issuer supports only jwt proofs and wallet sends no proof`() = runTest {
@@ -1328,5 +1351,36 @@ class IssuanceSingleRequestTest {
             }
         }
         assertEquals("Credential configuration requires proofs.", exception.message)
+    }
+
+    @Test
+    fun `succeeds when issuer does not support batch issuance and wallets sends a single plain jwt proof`() = runTest {
+        val issuerMetadataVersion = IssuerMetadataVersion.NO_BATCH
+        val mockedKtorHttpClientFactory = mockedHttpClient(
+            credentialIssuerMetadataWellKnownMocker(issuerMetadataVersion = issuerMetadataVersion),
+            authServerWellKnownMocker(),
+            parPostMocker(),
+            tokenPostMocker(),
+            nonceEndpointMocker(),
+            singleIssuanceRequestMocker(
+                responseBuilder = encryptionAwareSuccessCredentialResponseResponseDataBuilder(issuerMetadataVersion, 1),
+                requestValidator = encryptionAwareJwtProofsWithoutKeyAttestationRequestValidator(issuerMetadataVersion, 1),
+            ),
+        )
+        val (authorizedRequest, issuer) =
+            authorizeRequestForCredentialOffer(
+                config = OpenId4VCIConfigurationOnlyPlainJwtProofs,
+                credentialOfferStr = CredentialOfferWithSdJwtVc_NO_GRANTS,
+                httpClient = mockedKtorHttpClientFactory,
+            )
+
+        val request = IssuanceRequestPayload.ConfigurationBased(
+            CredentialConfigurationIdentifier(PID_SdJwtVC),
+        )
+        val (_, outcome) = with(issuer) {
+            authorizedRequest.request(request, jwtProofsWithoutKeyAttestation(keysNo = 1)).getOrThrow()
+        }
+        val issuedCredentials = assertIs<SubmissionOutcome.Success>(outcome).credentials
+        assertEquals(1, issuedCredentials.size, "Expected 3 Credentials to be issued")
     }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
@@ -1096,7 +1096,7 @@ class IssuanceSingleRequestTest {
         }
 
     @Test
-    fun `when wallet does not support atestations that require not proofs, issuance fails`() = runTest {
+    fun `when wallet does not support attestations that require not proofs, issuance fails`() = runTest {
         val mockedHttpClient = mockedHttpClient(
             credentialIssuerMetadataWellKnownMocker(),
             authServerWellKnownMocker(),
@@ -1104,7 +1104,7 @@ class IssuanceSingleRequestTest {
             tokenPostMocker(),
         )
         val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            config = OpenId4VCIConfiguration.copy(proofs = ProofsConfig(false, null, null)),
+            config = OpenId4VCIConfiguration.copy(proofs = ProofsConfig(false, null, null, null)),
             credentialOfferStr = CredentialOfferWithMDLMdoc_NO_GRANTS,
             httpClient = mockedHttpClient,
         )
@@ -1128,7 +1128,7 @@ class IssuanceSingleRequestTest {
             tokenPostMocker(),
         )
         val (authorizedRequest, issuer) = authorizeRequestForCredentialOffer(
-            config = OpenId4VCIConfiguration.copy(proofs = ProofsConfig(false, null, null)),
+            config = OpenId4VCIConfiguration.copy(proofs = ProofsConfig(false, null, null, null)),
             credentialOfferStr = CredentialOfferWithSdJwtVc_NO_GRANTS,
             httpClient = mockedHttpClient,
         )
@@ -1156,8 +1156,9 @@ class IssuanceSingleRequestTest {
                 config = OpenId4VCIConfiguration.copy(
                     proofs = ProofsConfig(
                         isNoProofSupported = false,
-                        jwtProof = ProofsConfig.SupportedJwtProof(setOf(JWSAlgorithm.ES512), true),
+                        jwtProofWithKeyAttestation = ProofsConfig.SupportedJwtProof(setOf(JWSAlgorithm.ES512)),
                         attestationProof = null,
+                        jwtProofsWithoutKeyAttestation = null,
                     ),
                 ),
                 credentialOfferStr = CredentialOfferWithSdJwtVc_NO_GRANTS,

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/IssuanceSingleRequestTest.kt
@@ -22,7 +22,7 @@ import com.nimbusds.jose.jwk.gen.ECKeyGenerator
 import com.nimbusds.jwt.SignedJWT
 import eu.europa.ec.eudi.openid4vci.CredentialIssuanceError.ResponseUnparsable
 import eu.europa.ec.eudi.openid4vci.CryptoGenerator.attestationProofSpec
-import eu.europa.ec.eudi.openid4vci.CryptoGenerator.jwtProofSpec
+import eu.europa.ec.eudi.openid4vci.CryptoGenerator.jwtProofWithKeyAttestationSpec
 import eu.europa.ec.eudi.openid4vci.IssuerMetadataVersion.NO_NONCE_ENDPOINT
 import eu.europa.ec.eudi.openid4vci.examples.selfSignedClient
 import eu.europa.ec.eudi.openid4vci.examples.verifySelfSignedClientAttestation
@@ -99,7 +99,7 @@ class IssuanceSingleRequestTest {
             val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
             val (_, outcome) = assertDoesNotThrow {
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-                authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256, 3)).getOrThrow()
+                authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256, 3)).getOrThrow()
             }
             assertIs<SubmissionOutcome.Failed>(outcome)
             assertIs<CredentialIssuanceError.InvalidProof>(outcome.error)
@@ -148,7 +148,7 @@ class IssuanceSingleRequestTest {
             assertFailsWith<CredentialIssuanceError.IssuerBatchSizeLimitExceeded> {
                 with(issuer) {
                     val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-                    authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256, 4)).getOrThrow()
+                    authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256, 4)).getOrThrow()
                 }
             }
         }
@@ -243,7 +243,7 @@ class IssuanceSingleRequestTest {
         val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
         with(issuer) {
             val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-            authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+            authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
         }
     }
 
@@ -300,7 +300,7 @@ class IssuanceSingleRequestTest {
         val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
         val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
         val (_, outcome) = with(issuer) {
-            authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+            authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
         }
         val success = assertIs<SubmissionOutcome.Success>(outcome)
         assertNull(success.selectedCredentialReusePolicy)
@@ -340,7 +340,7 @@ class IssuanceSingleRequestTest {
             )
         } ?: error("No credential identifier")
         with(issuer) {
-            authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256, 1)).getOrThrow()
+            authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256, 1)).getOrThrow()
         }
     }
 
@@ -377,7 +377,7 @@ class IssuanceSingleRequestTest {
         )
         assertThrows<IllegalArgumentException> {
             with(issuer) {
-                authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256, 1)).getOrThrow()
+                authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256, 1)).getOrThrow()
             }
         }
     }
@@ -414,7 +414,7 @@ class IssuanceSingleRequestTest {
         )
         assertThrows<IllegalArgumentException> {
             with(issuer) {
-                authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+                authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
             }
         }
     }
@@ -493,7 +493,7 @@ class IssuanceSingleRequestTest {
             val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
             val (_, outcome) = assertDoesNotThrow {
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-                authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+                authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
             }
             assertIs<SubmissionOutcome.Success>(outcome)
             assertTrue { outcome.credentials.size == 1 }
@@ -544,7 +544,7 @@ class IssuanceSingleRequestTest {
             val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
             val ex = assertFailsWith<JsonConvertException> {
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-                authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+                authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
             }
             assertIs<ResponseUnparsable>(ex.cause)
         }
@@ -586,7 +586,7 @@ class IssuanceSingleRequestTest {
         val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
         with(issuer) {
             val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-            authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+            authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
         }
     }
 
@@ -641,7 +641,7 @@ class IssuanceSingleRequestTest {
         val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
         with(issuer) {
             val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-            authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+            authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
         }
     }
 
@@ -687,7 +687,7 @@ class IssuanceSingleRequestTest {
         val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
         with(issuer) {
             val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-            authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+            authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
         }
     }
 
@@ -726,7 +726,7 @@ class IssuanceSingleRequestTest {
         val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
         with(issuer) {
             val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-            authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+            authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
         }
     }
 
@@ -749,7 +749,7 @@ class IssuanceSingleRequestTest {
         assertFailsWith<CredentialIssuanceError.ProofGenerationError.ProofTypeSigningAlgorithmNotSupported> {
             with(issuer) {
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-                authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_384)).getOrThrow()
+                authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_384)).getOrThrow()
             }
         }
     }
@@ -1137,7 +1137,7 @@ class IssuanceSingleRequestTest {
         with(issuer) {
             val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
             val exception = assertFailsWith<IllegalArgumentException> {
-                authorizedRequest.request(requestPayload, jwtProofSpec()).getOrThrow()
+                authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec()).getOrThrow()
             }
             assertEquals("Wallet doesn't support any of the advertised Proofs", exception.message)
         }
@@ -1168,7 +1168,7 @@ class IssuanceSingleRequestTest {
             with(issuer) {
                 val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
                 val exception = assertFailsWith<IllegalArgumentException> {
-                    authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_521)).getOrThrow()
+                    authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_521)).getOrThrow()
                 }
                 assertEquals("Wallet doesn't support any of the advertised Proofs", exception.message)
             }
@@ -1218,7 +1218,7 @@ class IssuanceSingleRequestTest {
         val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
         with(issuer) {
             val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-            val proofSpec = jwtProofSpec(Curve.P_521)
+            val proofSpec = jwtProofWithKeyAttestationSpec(Curve.P_521)
             assertFailsWith<CredentialIssuanceError.ProofGenerationError.ProofTypeSigningAlgorithmNotSupported> {
                 authorizedRequest.request(requestPayload, proofSpec).getOrThrow()
             }
@@ -1269,7 +1269,7 @@ class IssuanceSingleRequestTest {
         val credentialConfigurationId = issuer.credentialOffer.credentialConfigurationIdentifiers[0]
         val exception = with(issuer) {
             val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
-            val proofSpec = jwtProofSpec()
+            val proofSpec = jwtProofWithKeyAttestationSpec()
             assertFailsWith<IllegalArgumentException> {
                 authorizedRequest.request(requestPayload, proofSpec).getOrThrow()
             }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/RequestMockers.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/RequestMockers.kt
@@ -20,6 +20,7 @@ import com.nimbusds.jose.JWEAlgorithm
 import com.nimbusds.jose.JWEHeader
 import com.nimbusds.jose.crypto.ECDHEncrypter
 import com.nimbusds.jose.crypto.RSAEncrypter
+import com.nimbusds.jose.crypto.factories.DefaultJWSVerifierFactory
 import com.nimbusds.jose.jwk.ECKey
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.JWKSet
@@ -30,8 +31,10 @@ import com.nimbusds.jose.proc.SecurityContext
 import com.nimbusds.jose.util.JSONObjectUtils
 import com.nimbusds.jwt.EncryptedJWT
 import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
 import com.nimbusds.jwt.proc.DefaultJWTProcessor
 import eu.europa.ec.eudi.openid4vci.IssuerMetadataVersion.*
+import eu.europa.ec.eudi.openid4vci.examples.publicKey
 import eu.europa.ec.eudi.openid4vci.internal.JsonSupport
 import eu.europa.ec.eudi.openid4vci.internal.http.*
 import eu.europa.ec.eudi.openid4vci.internal.issuanceEncryptionSpecs
@@ -41,8 +44,12 @@ import io.ktor.http.*
 import io.ktor.http.content.*
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 import java.util.*
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
@@ -104,8 +111,10 @@ enum class IssuerMetadataVersion {
     ATTESTATION_PROOF_SUPPORTED,
     WITH_PREFERRED_CLIENT_STATUS_PERIOD,
     ONLY_JWT_PROOFS_SUPPORTED,
+    ONLY_JWT_PROOFS_WITHOUT_KEY_ATTESTATION_SUPPORTED,
     ONLY_ATTESTATION_PROOFS_SUPPORTED,
     SIGNED_FULL,
+    NO_BATCH,
 }
 
 internal fun issuerMetadataJsonContent(issuerMetadataVersion: IssuerMetadataVersion): String = when (issuerMetadataVersion) {
@@ -119,8 +128,12 @@ internal fun issuerMetadataJsonContent(issuerMetadataVersion: IssuerMetadataVers
     ATTESTATION_PROOF_SUPPORTED -> getResourceAsText("well-known/openid-credential-issuer_attestation_proof_supported.json")
     WITH_PREFERRED_CLIENT_STATUS_PERIOD -> getResourceAsText("well-known/openid-credential-issuer_with_preferred_client_status_period.json")
     ONLY_JWT_PROOFS_SUPPORTED -> getResourceAsText("well-known/openid-credential-issuer_only_jwt_proof.json")
+    ONLY_JWT_PROOFS_WITHOUT_KEY_ATTESTATION_SUPPORTED -> getResourceAsText(
+        "well-known/openid-credential-issuer_only_jwt_proofs_without_key_attestation.json",
+    )
     ONLY_ATTESTATION_PROOFS_SUPPORTED -> getResourceAsText("well-known/openid-credential-issuer_only_attestation_proof.json")
     SIGNED_FULL -> getResourceAsText("well-known/openid-credential-issuer_full_signed.txt")
+    NO_BATCH -> getResourceAsText("well-known/openid-credential-issuer_no_batch.json")
 }
 
 enum class AuthServerMetadataVersion {
@@ -463,6 +476,26 @@ fun MockRequestHandleScope.encryptionAwareResponseDataBuilder(
     }
 }
 
+internal fun encryptionAwareSuccessCredentialResponseResponseDataBuilder(
+    issuerMetadataVersion: IssuerMetadataVersion,
+    credentialsNo: Int,
+): HttpResponseDataBuilder {
+    require(credentialsNo > 0)
+    return { request ->
+        encryptionAwareResponseDataBuilder(request, issuerMetadataVersion) {
+            Json.encodeToString(
+                CredentialResponseSuccessTO(
+                    credentials = List(credentialsNo) { index ->
+                        buildJsonObject {
+                            put("credential", JsonPrimitive("issued_credential_content_mso_mdoc$index"))
+                        }
+                    },
+                ),
+            )
+        }
+    }
+}
+
 private fun extractResponseEncryptionSpec(
     request: HttpRequestData?,
     issuerMetadataVersion: IssuerMetadataVersion,
@@ -527,6 +560,50 @@ internal inline fun <reified RequestTO> encryptionAwareRequestValidator(
     val requestDecrypter = RequestDecrypter(issuerMetadataVersion, walletConfig)
     val decrypted = requestDecrypter.decrypt<RequestTO>(request)
     validateRequest(decrypted)
+}
+
+internal fun encryptionAwareJwtProofWithKeyAttestationRequestValidator(
+    issuerMetadataVersion: IssuerMetadataVersion,
+    attestedKeys: Int,
+): (request: HttpRequestData) -> Unit {
+    require(attestedKeys > 0)
+    return { request ->
+        encryptionAwareRequestValidator<CredentialRequestTO>(request, issuerMetadataVersion) {
+            assertNotNull(
+                it.proofs,
+                "Proofs expected but received none",
+            )
+            val jwtProofs = it.proofs.jwtProofs
+            assertNotNull(jwtProofs, "Jwt Proofs expected")
+            assertEquals(1, jwtProofs.size, "Exactly one Jwt Proof expected")
+            val keyAttestation =
+                KeyAttestationJWT(SignedJWT.parse(jwtProofs.first()).header.getCustomParam("key_attestation") as String)
+            assertEquals(attestedKeys, keyAttestation.attestedKeys.size, "Exactly $attestedKeys attested keys expected")
+        }
+    }
+}
+
+internal fun encryptionAwareJwtProofsWithoutKeyAttestationRequestValidator(
+    issuerMetadataVersion: IssuerMetadataVersion,
+    proofsNo: Int,
+): (request: HttpRequestData) -> Unit {
+    require(proofsNo >= 0)
+    return { request ->
+        encryptionAwareRequestValidator<CredentialRequestTO>(request, issuerMetadataVersion) {
+            val jwtProofs = assertNotNull(it.proofs?.jwtProofs, "JWT Proofs expected but received none")
+            assertEquals(proofsNo, jwtProofs.size, "Expected $proofsNo JWT Proofs to be sent")
+            jwtProofs.forEach { serialized ->
+                val deserialized = SignedJWT.parse(serialized)
+                val jwk = assertNotNull(deserialized.header.jwk)
+                assertTrue("JWT Proof signature cannot be verified") {
+                    deserialized.verify(
+                        DefaultJWSVerifierFactory().createJWSVerifier(deserialized.header, jwk.publicKey),
+                    )
+                }
+                assertNull(deserialized.header.getCustomParam("key_attestation"), "JWT Proof must not contain Key Attestation")
+            }
+        }
+    }
 }
 
 internal fun decrypt(encrypted: String, alg: JWEAlgorithm, enc: EncryptionMethod, jwkSet: JWKSet): Result<JWTClaimsSet> =

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/SignersTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/SignersTest.kt
@@ -78,7 +78,7 @@ class SignersTest {
                 provider = null,
             )
 
-            val jwtProofSigner = JwtProofSigner(
+            val jwtProofSigner = KeyAttestationJwtProofSigner(
                 algorithm = Curve.P_256.toJavaSigningAlg().toJoseAlg(),
                 signOperation = signer.acquire(),
                 keyIndex = 0,

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/TestUtils.kt
@@ -114,6 +114,15 @@ val OpenId4VCIConfigurationWithDpopSigner = OpenId4VCIConfig(
     proofs = ProofsConfig.Default,
 )
 
+val OpenId4VCIConfigurationOnlyPlainJwtProofs = OpenId4VCIConfiguration.copy(
+    proofs = ProofsConfig(
+        isNoProofSupported = false,
+        jwtProofWithKeyAttestation = null,
+        jwtProofsWithoutKeyAttestation = ProofsConfig.SupportedJwtProof(setOf(JWSAlgorithm.ES256)),
+        attestationProof = null,
+    ),
+)
+
 suspend fun authorizeRequestForCredentialOffer(
     config: OpenId4VCIConfig? = OpenId4VCIConfiguration,
     credentialOfferStr: String,

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/Commons.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/Commons.kt
@@ -18,7 +18,7 @@ package eu.europa.ec.eudi.openid4vci.examples
 import com.nimbusds.jose.jwk.Curve
 import eu.europa.ec.eudi.openid4vci.*
 import eu.europa.ec.eudi.openid4vci.CryptoGenerator.attestationProofSpec
-import eu.europa.ec.eudi.openid4vci.CryptoGenerator.jwtProofSpec
+import eu.europa.ec.eudi.openid4vci.CryptoGenerator.jwtProofWithKeyAttestationSpec
 import io.ktor.client.*
 import io.ktor.client.engine.apache.*
 import io.ktor.client.plugins.contentnegotiation.*
@@ -112,7 +112,7 @@ suspend fun <ENV> Issuer.submitCredentialRequest(
         }
 
     val proofSpec: ProofSpecification = when (proofsType) {
-        is ProofsType.JwtProof -> jwtProofSpec(
+        is ProofsType.JwtProof -> jwtProofWithKeyAttestationSpec(
             Curve.P_256,
             proofsNo,
             keyAttestationJwt = {

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingAuthorizationFlow.kt
@@ -17,7 +17,7 @@ package eu.europa.ec.eudi.openid4vci.examples
 
 import com.nimbusds.jose.jwk.Curve
 import eu.europa.ec.eudi.openid4vci.*
-import eu.europa.ec.eudi.openid4vci.CryptoGenerator.jwtProofSpec
+import eu.europa.ec.eudi.openid4vci.CryptoGenerator.jwtProofWithKeyAttestationSpec
 import eu.europa.ec.eudi.openid4vci.internal.ensure
 import kotlinx.coroutines.runBlocking
 import java.net.URLEncoder
@@ -99,7 +99,7 @@ private suspend fun submit(
     with(issuer) {
         val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
         val (newAuthorized, outcome) =
-            authorized.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+            authorized.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
         return when (outcome) {
             is SubmissionOutcome.Success -> newAuthorized to outcome.credentials
             is SubmissionOutcome.Deferred -> newAuthorized to handleDeferred(issuer, authorized, outcome.transactionId)

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingPreAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/OfferBasedIssuanceUsingPreAuthorizationFlow.kt
@@ -17,7 +17,7 @@ package eu.europa.ec.eudi.openid4vci.examples
 
 import com.nimbusds.jose.jwk.Curve
 import eu.europa.ec.eudi.openid4vci.*
-import eu.europa.ec.eudi.openid4vci.CryptoGenerator.jwtProofSpec
+import eu.europa.ec.eudi.openid4vci.CryptoGenerator.jwtProofWithKeyAttestationSpec
 import eu.europa.ec.eudi.openid4vci.internal.ensure
 import kotlinx.coroutines.runBlocking
 import java.net.URI
@@ -75,7 +75,7 @@ private suspend fun submit(
     with(issuer) {
         val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
         val (newAuthorized, outcome) =
-            authorized.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+            authorized.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
 
         return when (outcome) {
             is SubmissionOutcome.Success -> newAuthorized to outcome.credentials

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/WalletInitiatedIssuanceUsingAuthorizationFlow.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/examples/WalletInitiatedIssuanceUsingAuthorizationFlow.kt
@@ -17,7 +17,7 @@ package eu.europa.ec.eudi.openid4vci.examples
 
 import com.nimbusds.jose.jwk.Curve
 import eu.europa.ec.eudi.openid4vci.*
-import eu.europa.ec.eudi.openid4vci.CryptoGenerator.jwtProofSpec
+import eu.europa.ec.eudi.openid4vci.CryptoGenerator.jwtProofWithKeyAttestationSpec
 import io.ktor.client.*
 import kotlinx.coroutines.runBlocking
 
@@ -94,7 +94,7 @@ private suspend fun Issuer.submitCredentialRequest(
     issuanceLog("Requesting issuance of '$credentialConfigurationId'")
     val requestPayload = IssuanceRequestPayload.ConfigurationBased(credentialConfigurationId)
     val (newAuthorized, outcome) =
-        authorizedRequest.request(requestPayload, jwtProofSpec(Curve.P_256)).getOrThrow()
+        authorizedRequest.request(requestPayload, jwtProofWithKeyAttestationSpec(Curve.P_256)).getOrThrow()
 
     return when (outcome) {
         is SubmissionOutcome.Success -> newAuthorized to outcome.credentials

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialIssuerMetadataJsonParserTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialIssuerMetadataJsonParserTest.kt
@@ -64,7 +64,7 @@ class CredentialIssuerMetadataJsonParserTest {
     }
 
     @Test
-    fun `does fails when jwt proof does not require key attestation`() {
+    fun `fails when jwt proof does not require key attestation`() {
         val json = getResourceAsText("well-known/openid-credential-issuer_jwt_proof_no_keyattestation.json")
         val metadata = CredentialIssuerMetadataJsonParser.parseMetaData(json, SampleIssuer.Id)
         val credentialConfiguration = assertNotNull(

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialIssuerMetadataJsonParserTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialIssuerMetadataJsonParserTest.kt
@@ -64,7 +64,7 @@ class CredentialIssuerMetadataJsonParserTest {
     }
 
     @Test
-    fun `fails when jwt proof does not require key attestation`() {
+    fun `succeeds when jwt proof does not require key attestation`() {
         val json = getResourceAsText("well-known/openid-credential-issuer_jwt_proof_no_keyattestation.json")
         val metadata = CredentialIssuerMetadataJsonParser.parseMetaData(json, SampleIssuer.Id)
         val credentialConfiguration = assertNotNull(

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialIssuerMetadataJsonParserTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vci/internal/CredentialIssuerMetadataJsonParserTest.kt
@@ -45,7 +45,8 @@ class CredentialIssuerMetadataJsonParserTest {
 
         val jwtProof = assertNotNull(credentialConfiguration.proofTypesSupported[ProofType.JWT])
         check(jwtProof is ProofTypeMeta.Jwt)
-        assertEquals(1.days.toJavaDuration(), jwtProof.keyAttestationRequirement.preferredKeyStorageStatusPeriod?.value)
+        val keyAttestationRequirement = assertNotNull(jwtProof.keyAttestationRequirement)
+        assertEquals(1.days.toJavaDuration(), keyAttestationRequirement.preferredKeyStorageStatusPeriod?.value)
 
         val attestationProof = assertNotNull(credentialConfiguration.proofTypesSupported[ProofType.ATTESTATION])
         check(attestationProof is ProofTypeMeta.Attestation)
@@ -63,13 +64,16 @@ class CredentialIssuerMetadataJsonParserTest {
     }
 
     @Test
-    fun `fails when jwt proof does not require key attestation`() {
+    fun `does fails when jwt proof does not require key attestation`() {
         val json = getResourceAsText("well-known/openid-credential-issuer_jwt_proof_no_keyattestation.json")
-        val exception = assertFailsWith<CredentialIssuerMetadataValidationError.InvalidCredentialsSupported> {
-            CredentialIssuerMetadataJsonParser.parseMetaData(json, SampleIssuer.Id)
-        }
-        val cause = assertIs<IllegalArgumentException>(exception.cause)
-        assertEquals("jwt proof must contain 'key_attestations_required'", cause.message)
+        val metadata = CredentialIssuerMetadataJsonParser.parseMetaData(json, SampleIssuer.Id)
+        val credentialConfiguration = assertNotNull(
+            metadata.credentialConfigurationsSupported[CredentialConfigurationIdentifier("eu.europa.ec.eudiw.pid_vc_sd_jwt")],
+        )
+        assertEquals(1, credentialConfiguration.proofTypesSupported.values.size)
+
+        val jwtProof = assertIs<ProofTypeMeta.Jwt>(credentialConfiguration.proofTypesSupported[ProofType.JWT])
+        assertNull(jwtProof.keyAttestationRequirement)
     }
 
     @Test

--- a/src/test/resources/well-known/openid-credential-issuer_no_batch.json
+++ b/src/test/resources/well-known/openid-credential-issuer_no_batch.json
@@ -1,0 +1,81 @@
+{
+  "credential_issuer": "https://credential-issuer.example.com",
+  "authorization_servers": [
+    "https://auth-server.example.com"
+  ],
+  "credential_endpoint": "https://credential-issuer.example.com/credentials",
+  "nonce_endpoint": "https://credential-issuer.example.com/nonce",
+  "deferred_credential_endpoint": "https://credential-issuer.example.com/credentials/deferred",
+  "notification_endpoint": "https://credential-issuer.example.com/notification",
+  "credential_identifiers_supported": true,
+  "credential_configurations_supported": {
+    "eu.europa.ec.eudiw.pid_vc_sd_jwt": {
+      "format": "dc+sd-jwt",
+      "scope": "eu.europa.ec.eudiw.pid_vc_sd_jwt",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "RS256"
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ]
+        }
+      },
+      "vct": "eu.europa.ec.eudiw.pid.1",
+      "credential_metadata": {
+        "claims": [
+          {
+            "path": [
+              "given_name"
+            ],
+            "display": [
+              {
+                "name": "Given Name",
+                "locale": "en-US"
+              }
+            ]
+          },
+          {
+            "path": [
+              "family_name"
+            ],
+            "display": [
+              {
+                "name": "Surname",
+                "locale": "en-US"
+              }
+            ]
+          },
+          {
+            "path": [
+              "birth_date"
+            ]
+          }
+        ],
+        "display": [
+          {
+            "name": "Personal Identification Data ",
+            "locale": "en-US",
+            "logo": {
+              "uri": "https://examplestate.com/public/pid.png",
+              "alt_text": "a square logo of a university"
+            },
+            "background_color": "#12107c",
+            "text_color": "#FFFFFF"
+          }
+        ]
+      }
+    }
+  },
+  "display": [
+    {
+      "name": "credential-issuer.example.com",
+      "locale": "en-US"
+    }
+  ]
+}

--- a/src/test/resources/well-known/openid-credential-issuer_only_jwt_proofs_without_key_attestation.json
+++ b/src/test/resources/well-known/openid-credential-issuer_only_jwt_proofs_without_key_attestation.json
@@ -1,0 +1,84 @@
+{
+  "credential_issuer": "https://credential-issuer.example.com",
+  "authorization_servers": [
+    "https://auth-server.example.com"
+  ],
+  "credential_endpoint": "https://credential-issuer.example.com/credentials",
+  "nonce_endpoint": "https://credential-issuer.example.com/nonce",
+  "deferred_credential_endpoint": "https://credential-issuer.example.com/credentials/deferred",
+  "notification_endpoint": "https://credential-issuer.example.com/notification",
+  "batch_credential_issuance": {
+    "batch_size": 3
+  },
+  "credential_identifiers_supported": true,
+  "credential_configurations_supported": {
+    "eu.europa.ec.eudiw.pid_vc_sd_jwt": {
+      "format": "dc+sd-jwt",
+      "scope": "eu.europa.ec.eudiw.pid_vc_sd_jwt",
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "credential_signing_alg_values_supported": [
+        "RS256"
+      ],
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": [
+            "RS256",
+            "ES256"
+          ]
+        }
+      },
+      "vct": "eu.europa.ec.eudiw.pid.1",
+      "credential_metadata": {
+        "claims": [
+          {
+            "path": [
+              "given_name"
+            ],
+            "display": [
+              {
+                "name": "Given Name",
+                "locale": "en-US"
+              }
+            ]
+          },
+          {
+            "path": [
+              "family_name"
+            ],
+            "display": [
+              {
+                "name": "Surname",
+                "locale": "en-US"
+              }
+            ]
+          },
+          {
+            "path": [
+              "birth_date"
+            ]
+          }
+        ],
+        "display": [
+          {
+            "name": "Personal Identification Data ",
+            "locale": "en-US",
+            "logo": {
+              "uri": "https://examplestate.com/public/pid.png",
+              "alt_text": "a square logo of a university"
+            },
+            "background_color": "#12107c",
+            "text_color": "#FFFFFF"
+          }
+        ]
+      }
+    }
+  },
+  "display": [
+    {
+      "name": "credential-issuer.example.com",
+      "locale": "en-US"
+    }
+  ]
+}


### PR DESCRIPTION
This PR re-introduces support for JWT Proofs without Key Attestation.

`ProofsConfig` has been updated as follows:

```kotlin
ProofsConfig(
        isNoProofSupported = true, // whether attestations that require no proofs are supported
        jwtProofWithKeyAttestation = ProofsConfig.SupportedJwtProof(setOf(JWSAlgorithm.ES256, JWSAlgorithm.ES384, JWSAlgorithm.ES512)), // whether jwt proofs with key attestation are supported
        attestationProof = ProofsConfig.SupportedAttestationProof(setOf(JWSAlgorithm.ES256, JWSAlgorithm.ES384, JWSAlgorithm.ES512)), // whether attestation proofs are supported,
        jwtProofsWithoutKeyAttestation = ProofsConfig.SupportedJwtProof(setOf(JWSAlgorithm.ES256, JWSAlgorithm.ES384, JWSAlgorithm.ES512)), // whether jwt proofs without key attestation are supported
    )
```

By default we enable support for:

* JWT Proof with Key Attestation
* Attestation Proof

i.e.:

```kotlin
val ProofsConfig.Companion.Default: ProofsConfig
            get() {
                val supportedAlgorithms = setOf(JWSAlgorithm.ES256, JWSAlgorithm.ES384, JWSAlgorithm.ES512)
                return ProofsConfig(
                    isNoProofSupported = true,
                    jwtProofWithKeyAttestation = SupportedJwtProof(supportedAlgorithms),
                    attestationProof = SupportedAttestationProof(supportedAlgorithms),
                    jwtProofsWithoutKeyAttestation = null,
                )
            }
```


`ProofSpecification` has been updated as follows:

```kotlin
sealed interface ProofSpecification {

    data object NoProof : ProofSpecification

    data class JwtProofWithKeyAttestation(
        val proofSignerProvider: suspend (Nonce?, PositiveDuration?) -> Signer<KeyAttestationJWT>,
    ) : ProofSpecification

    data class JwtProofsWithoutKeyAttestation(
        val proofSigner: BatchSigner<JwtBindingKey>,
    ) : ProofSpecification

    data class AttestationProof(
        val attestationProvider: suspend (Nonce?, PositiveDuration?) -> KeyAttestationJWT,
    ) : ProofSpecification
}
```


The entry point for requesting the issuance of a Verifiable Credential given an `AuthorizedRequest` remains `RequestIssuance` and is unchanged:

```kotlin
/**
 * An interface for submitting a credential issuance request.
 */
fun interface RequestIssuance {

    /**
     * Places a request to the credential issuance endpoint.
     *
     * If the [AuthorizedRequest] contains authorization details for the requested
     * [IssuanceRequestPayload.credentialConfigurationIdentifier], then the [requestPayload] must be
     * [IssuanceRequestPayload.IdentifierBased] and the credential identifier must be one of the authorized identifiers.
     *
     * @param requestPayload the payload of the request
     * @param proofSpecification the specification of proofs to be included in the request
     * @return the possibly updated [AuthorizedRequest] (if updated, it will contain a fresh updated Resource-Server DPoP Nonce)
     * and the [SubmissionOutcome]
     */
    suspend fun AuthorizedRequest.request(
        requestPayload: IssuanceRequestPayload,
        proofSpecification: ProofSpecification,
    ): Result<AuthorizedRequestAnd<SubmissionOutcome>>
```


Closes #589